### PR TITLE
Swaps out sqlite for MySQL2 (#43).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,32 @@ jobs:
             bundler_version:
                 type: string
                 default: '2.1.4'
-        executor:
-            name: samvera/ruby_fcrepo_solr_redis
-            ruby_version: << parameters.ruby_version >>
+            solr_port:
+                type: string
+                default: '8985'
+            redis_version:
+                type: string
+                default: '4'
+            mysql_version:
+                type: string
+                default: '5.7.22'
+        environment:
+            BUNDLE_PATH: vendor/bundle
+            BUNDLE_JOBS: 4
+            BUNDLE_RETRY: 3
+            RAILS_ENV: test
+            RACK_ENV: test
+            SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+            DATABASE_NAME: circle_test
+            DATABASE_HOST: 127.0.0.1
+            DATABASE_PORT: 3306
+            DATABASE_USERNAME: root
+        docker:
+            - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers-legacy
+            - image: solr:7-alpine
+              command: bin/solr -cloud -noprompt -f -p <<parameters.solr_port>>
+            - image: circleci/redis:<<parameters.redis_version>>
+            - image: circleci/mysql:<<parameters.mysql_version>>
         working_directory: ~/project
         parallelism: 4
         steps:
@@ -50,6 +73,11 @@ jobs:
                     chmod +x ./cc-test-reporter
                     ./cc-test-reporter before-build
             
+            # Dockerize is installed in CircleCI docker images by default.
+            - run:
+                name: Wait for MySQL, if necessary.
+                command: dockerize -wait tcp://${DATABASE_HOST}:${DATABASE_PORT} -timeout 1m
+
             - samvera/parallel_rspec
             
             - run:

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@
 /coverage/
 *solrmarc.log*
 *.DS_Store*
-.env.development
+.env*

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,25 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  adapter: mysql2
+  encoding: utf8mb4
   timeout: 5000
+  database: <%= ENV.fetch('DATABASE_NAME') %>
+  host: <%= ENV.fetch('DATABASE_HOST', 'localhost') %>
+  port: <%= ENV.fetch('DATABASE_PORT', '3306') %>
+  username: <%= ENV.fetch('DATABASE_USERNAME') %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  pool: <%= ENV['DATABASE_POOL'] || ENV['RAILS_MAX_THREADS'] || 5 %>
 
 development:
   <<: *default
-  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  # If host is 'localhost', MySQL will attempt to use a socket to talk to the DB, but if it is '127.0.0.1',
+  # it will use TCP. While a socket may be a preferable default, it will not work for CI.
+  host: <%= ENV.fetch('DATABASE_HOST', '127.0.0.1') %>
 
 production:
   <<: *default
-  database: db/production.sqlite3

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20201109164154) do
 
-  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
+  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -24,13 +24,13 @@ ActiveRecord::Schema.define(version: 20201109164154) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "property_bag", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
+  create_table "property_bag", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.string "name"
     t.string "value"
     t.index ["name"], name: "index_property_bag_on_name", unique: true
   end
 
-  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
+  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 20201109164154) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20201109164154) do
 
-  create_table "bookmarks", force: :cascade do |t|
+  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -24,13 +24,13 @@ ActiveRecord::Schema.define(version: 20201109164154) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "property_bag", force: :cascade do |t|
+  create_table "property_bag", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
     t.string "name"
     t.string "value"
     t.index ["name"], name: "index_property_bag_on_name", unique: true
   end
 
-  create_table "searches", force: :cascade do |t|
+  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 20201109164154) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
- .circleci/config.yml: resets database configuration to mirror Lux.
- .gitignore: forgets all files that start with `.env`.
- config/database.yml: copies database settings from Lux.
- db/schema.rb: rewrites schema to MySQL specs.