### PR TITLE
Allow null emails remove index 10

### DIFF
--- a/db/migrate/20201123172207_remove_email_index_from_users.rb
+++ b/db/migrate/20201123172207_remove_email_index_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveEmailIndexFromUsers < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :users, :email
+  end
+end

--- a/db/migrate/20201123172331_allow_null_email_in_users.rb
+++ b/db/migrate/20201123172331_allow_null_email_in_users.rb
@@ -1,0 +1,5 @@
+class AllowNullEmailInUsers < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :users, :email, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20201123172331) do
     t.index ["name"], name: "index_property_bag_on_name", unique: true
   end
 
-  create_table "searches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
+  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201109164154) do
+ActiveRecord::Schema.define(version: 20201123172331) do
 
-  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
+  create_table "bookmarks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -24,13 +24,13 @@ ActiveRecord::Schema.define(version: 20201109164154) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "property_bag", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
+  create_table "property_bag", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
     t.string "name"
     t.string "value"
     t.index ["name"], name: "index_property_bag_on_name", unique: true
   end
 
-  create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
+  create_table "searches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -39,8 +39,8 @@ ActiveRecord::Schema.define(version: 20201109164154) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
-    t.string "email", default: "", null: false
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
+    t.string "email", default: ""
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
@@ -51,7 +51,6 @@ ActiveRecord::Schema.define(version: 20201109164154) do
     t.string "provider"
     t.string "uid"
     t.string "display_name"
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid"], name: "index_users_on_uid"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20201123172331) do
 
-  create_table "bookmarks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
+  create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -24,13 +24,13 @@ ActiveRecord::Schema.define(version: 20201123172331) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "property_bag", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
+  create_table "property_bag", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.string "name"
     t.string "value"
     t.index ["name"], name: "index_property_bag_on_name", unique: true
   end
 
-  create_table "searches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
+  create_table "searches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 20201123172331) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.string "email", default: ""
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
- db/migrate/20201123172207_remove_email_index_from_users.rb: removes email index causing error.
- db/migrate/20201123172331_allow_null_email_in_users.rb: allows emails to be null.
- db/schema.rb: updates schema with requested changes.