### PR TITLE
Adds trackable required columns to users (#10).

### DIFF
--- a/db/migrate/20201124131933_add_trackable_to_devise.rb
+++ b/db/migrate/20201124131933_add_trackable_to_devise.rb
@@ -1,0 +1,13 @@
+class AddTrackableToDevise < ActiveRecord::Migration[5.1]
+  def up
+    add_column :users, :sign_in_count, :integer, default: 0, null: false
+    add_column :users, :current_sign_in_at, :datetime
+    add_column :users, :last_sign_in_at, :datetime
+    add_column :users, :current_sign_in_ip, :string
+    add_column :users, :last_sign_in_ip, :string
+  end
+
+  def down
+    remove_columns :users, :sign_in_count, :current_sign_in_at, :last_sign_in_at, :current_sign_in_ip, :last_sign_in_ip
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201123172331) do
+ActiveRecord::Schema.define(version: 20201124131933) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.integer "user_id", null: false
@@ -51,6 +51,11 @@ ActiveRecord::Schema.define(version: 20201123172331) do
     t.string "provider"
     t.string "uid"
     t.string "display_name"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid"], name: "index_users_on_uid"
   end


### PR DESCRIPTION
- db/migrate/20201124131933_add_trackable_to_devise.rb: creates columns needed for Devise's trackable feature.
- db/schema.rb: reflects updated schema with new columns.