### PR TITLE
Corrects edit_user_registration_path error by eliminating that link (#10).

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,13 +41,4 @@ class User < ApplicationRecord
   rescue User::NilShibbolethUserError => e
     Rails.logger.error "Nil user detected: Shibboleth didn't pass a uid for #{e.auth.inspect}"
   end
-
-  def self.log_omniauth_error(auth)
-    if auth.info.uid.empty?
-      Rails.logger.error "Nil user detected: Shibboleth didn't pass a uid for #{auth.inspect}"
-    else
-      # Log unauthorized logins to error.
-      Rails.logger.error "Unauthorized user attemped login: #{auth.inspect}"
-    end
-  end
 end

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -1,0 +1,21 @@
+<ul class="navbar-nav">
+  <%= render_nav_actions do |config, action|%>
+    <li class="nav-item"><%= action %></li>
+  <% end %>
+
+  <% if has_user_authentication_provider? %>
+    <% if current_user %>
+      <li class="nav-item">
+        <% if current_user.display_name %>
+          <%= link_to "#{t('blacklight.header_links.logout')} #{current_user.display_name} ", destroy_user_session_path, class: 'nav-link' %>
+        <% else %>
+          <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path, class: 'nav-link' %>
+        <% end %>
+      </li>
+    <% else %>
+      <li class="nav-item">
+        <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: 'nav-link' %>
+      </li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -1,3 +1,4 @@
+<%# Override of Blacklight 7.4.1 view partial %>
 <ul class="navbar-nav">
   <%= render_nav_actions do |config, action|%>
     <li class="nav-item"><%= action %></li>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe User do
         info: {
           display_name: "Jane Quest",
           uid: 'janeq',
-          mail: 'janeq@example.com'
+          mail: 'janeq@emory.edu'
         }
       )
     end


### PR DESCRIPTION
app/models/user.rb, app/views/shared/_user_util_links.html.erb, and spec/models/user_spec.rb: directly mirroring Lux code, this changes the assignment of a user's attributes and provides error protection, as well as eliminating the need for link `edit_user_registration_path` to be in the header, and updating testing expectations.