### PR TITLE
Wires oai_set to an ENV variable so that it can be set in the rake call (#80).

### DIFF
--- a/dotenv.sample
+++ b/dotenv.sample
@@ -13,6 +13,8 @@ DATABASE_AUTH=true
 alma=
 # provide institution for oai base url fetch
 institution=
+# provides name for oai set being fetched
+oai_set_name=blacklighttest
 
 # provide SOLR_URL for solr connections
 SOLR_URL=

--- a/lib/tasks/sample_scheduler.rake
+++ b/lib/tasks/sample_scheduler.rake
@@ -2,9 +2,10 @@
 require 'rest-client'
 require 'nokogiri'
 
-desc "Harvest OAI set 'blacklighttest' and index in Solr"
+desc "Harvest OAI set denoted in ENV oai_set_name and index in Solr"
 task oai_harvest: [:environment] do
-  oai_set = 'blacklighttest'
+  oai_set = ENV['oai_set_name']
+  abort 'The ENV variable oai_set_name has not been set.' unless oai_set.present?
 
   log "Starting..."
 

--- a/lib/tasks/sample_scheduler.rake
+++ b/lib/tasks/sample_scheduler.rake
@@ -5,7 +5,7 @@ require 'nokogiri'
 desc "Harvest OAI set denoted in ENV oai_set_name and index in Solr"
 task oai_harvest: [:environment] do
   oai_set = ENV['oai_set_name']
-  abort 'The ENV variable oai_set_name has not been set.' unless oai_set.present?
+  abort 'The ENV variable oai_set_name has not been set.' if oai_set.blank?
 
   log "Starting..."
 


### PR DESCRIPTION
- dotenv.sample: sets the default value to `blacklighttest`.
- lib/tasks/sample_scheduler.rake: replaces hard set value with ENV variable.