### PR TITLE
Adds search result page metadata (#87).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -33,7 +33,7 @@ class CatalogController < ApplicationController
     # config.per_page = [10,20,50,100]
 
     # solr field configuration for search results/index views
-    config.index.title_field = 'title_tsim'
+    config.index.title_field = 'title_display'
     # config.index.display_type_field = 'format'
     # config.index.thumbnail_field = 'thumbnail_path_ss'
 
@@ -103,15 +103,9 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'title_tsim', label: 'Title'
-    config.add_index_field 'title_vern_ssim', label: 'Title'
-    config.add_index_field 'author_tsim', label: 'Author'
-    config.add_index_field 'author_vern_ssim', label: 'Author'
-    config.add_index_field 'format', label: 'Format'
-    config.add_index_field 'language_ssim', label: 'Language'
-    config.add_index_field 'published_ssim', label: 'Published'
-    config.add_index_field 'published_vern_ssim', label: 'Published'
-    config.add_index_field 'lc_callnum_ssim', label: 'Call number'
+    config.add_index_field 'author_display', label: 'Author/Creator'
+    config.add_index_field 'format', label: 'Resource Type'
+    config.add_index_field 'marc_resource', label: 'Access'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :controller do
+  describe 'index fields' do
+    let(:index_fields) do
+      controller
+        .blacklight_config
+        .index_fields.keys
+        .map { |field| field.gsub(/\_s+im$/, '') }
+    end
+    let(:expected_index_fields) { ['author_display', 'format', 'marc_resource'] }
+    let(:field_title) { controller.blacklight_config.index.title_field }
+
+    context 'field titles' do
+      it { expect(field_title).to eq('title_display') }
+    end
+
+    it { expect(index_fields).to contain_exactly(*expected_index_fields) }
+  end
+end

--- a/spec/support/solr_documents/item.rb
+++ b/spec/support/solr_documents/item.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+TEST_ITEM = {
+  id: '123',
+  author_display: ['George Jenkins'],
+  format: ['Book'],
+  marc_resource: ["Electronic Resource"],
+  title_display: ['The Title of my Work']
+}.freeze

--- a/spec/support/solr_helpers.rb
+++ b/spec/support/solr_helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolrHelpers
+  def delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.delete_by_query('*:*')
+    solr.commit
+  end
+
+  RSpec.configure do |config|
+    config.include SolrHelpers
+  end
+end

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "View Search Results", type: :system, js: false do
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.add(TEST_ITEM)
+    solr.commit
+    visit root_path
+    click_on 'Search'
+  end
+
+  context 'displaying metadata' do
+    it 'has a title link' do
+      expect(page).to have_link('The Title of my Work')
+    end
+
+    it 'has the right metadata labels' do
+      ['Author/Creator:', 'Resource Type:', 'Access:'].each { |label| expect(page).to have_content(label) }
+    end
+
+    it 'has the right values' do
+      ['George Jenkins', 'Book', 'Electronic Resource'].each { |label| expect(page).to have_content(label) }
+    end
+  end
+end


### PR DESCRIPTION
- app/controllers/catalog_controller.rb wipes out unnecessary fields and adds the requested ones.
- spec/controllers/catalog_controller_spec.rb: tests for only requested fields to be added to index.
- spec/support/solr_documents/item.rb: creates item for testing.
- spec/support/solr_helpers.rb: provides a method to wipe out Solr container.
- spec/system/view_search_results_spec.rb: checks view expected text and link.