### PR TITLE
Initiates preliminary item level metadata display (#102).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
     Exclude:
         - app/controllers/catalog_controller.rb
+        - spec/controllers/catalog_controller_spec.rb
         - spec/models/user_spec.rb
 
 Metrics/CyclomaticComplexity:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -109,20 +109,14 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field 'title_tsim', label: 'Title'
-    config.add_show_field 'title_vern_ssim', label: 'Title'
-    config.add_show_field 'subtitle_tsim', label: 'Subtitle'
-    config.add_show_field 'subtitle_vern_ssim', label: 'Subtitle'
-    config.add_show_field 'author_tsim', label: 'Author'
-    config.add_show_field 'author_vern_ssim', label: 'Author'
-    config.add_show_field 'format', label: 'Format'
-    config.add_show_field 'url_fulltext_ssim', label: 'URL'
-    config.add_show_field 'url_suppl_ssim', label: 'More Information'
-    config.add_show_field 'language_ssim', label: 'Language'
-    config.add_show_field 'published_ssim', label: 'Published'
-    config.add_show_field 'published_vern_ssim', label: 'Published'
-    config.add_show_field 'lc_callnum_ssim', label: 'Call number'
-    config.add_show_field 'isbn_ssim', label: 'ISBN'
+    config.add_show_field 'title_display', label: 'Title'
+    config.add_show_field 'author_display', label: 'Author/Creator'
+    config.add_show_field 'pub_date', label: 'Creation Date'
+    config.add_show_field 'language_facet', label: 'Language'
+    config.add_show_field 'isbn_t', label: 'ISBN'
+    config.add_show_field 'lc_callnum_display', label: 'Call Number'
+    config.add_show_field 'id', label: 'MMS ID'
+    config.add_show_field 'marc_resource', label: 'Access'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -18,4 +18,19 @@ RSpec.describe CatalogController, type: :controller do
 
     it { expect(index_fields).to contain_exactly(*expected_index_fields) }
   end
+
+  describe 'show fields' do
+    let(:show_fields) do
+      controller
+        .blacklight_config
+        .show_fields.keys
+        .map { |field| field.gsub(/\_s+im$/, '') }
+    end
+    let(:expected_show_fields) do
+      ['title_display', 'author_display', 'pub_date', 'language_facet',
+       'isbn_t', 'lc_callnum_display', 'id', 'marc_resource']
+    end
+
+    it { expect(show_fields).to contain_exactly(*expected_show_fields) }
+  end
 end

--- a/spec/support/solr_documents/item.rb
+++ b/spec/support/solr_documents/item.rb
@@ -3,6 +3,10 @@ TEST_ITEM = {
   id: '123',
   author_display: ['George Jenkins'],
   format: ['Book'],
-  marc_resource: ["Electronic Resource"],
+  isbn_t: ['SOME MAGICAL NUM .66G'],
+  language_facet: ['English'],
+  lc_callnum_display: 'ANOTHER MAGICAL NUM .78F',
+  marc_resource: ['Electronic Resource'],
+  pub_date: '2015',
   title_display: ['The Title of my Work']
 }.freeze

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "View Search Results", type: :system, js: false do
     end
 
     it 'has the right values' do
-      ['George Jenkins', 'Book', 'Electronic Resource'].each { |label| expect(page).to have_content(label) }
+      ['George Jenkins', 'Book', 'Electronic Resource'].each { |value| expect(page).to have_content(value) }
     end
   end
 end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "View a item's show page", type: :system, js: false do
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.add(TEST_ITEM)
+    solr.commit
+    visit solr_document_path(id)
+  end
+
+  let(:id) { '123' }
+
+  context 'displaying metadata' do
+    it 'has the right metadata labels' do
+      ['Title:', 'Author/Creator:', 'Creation Date:', 'Language:', 'ISBN:',
+       'Call Number:', 'MMS ID:', 'Access:'].each do |label|
+        expect(page).to have_content(label)
+      end
+    end
+
+    it 'has the right values' do
+      ['The Title of my Work', 'George Jenkins', '2015', 'English',
+       'SOME MAGICAL NUM .66G', 'ANOTHER MAGICAL NUM .78F', '123',
+       'Electronic Resource'].each do |value|
+        expect(page).to have_content(value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- .rubocop.yml: excludes catalog controller from the Rubocop BlockLength rule.
- app/controllers/catalog_controller.rb: initiates only the requested metadata into the show view.
- spec/controllers/catalog_controller_spec.rb: sets expectations for what show fields are included into the controller.
- spec/support/solr_documents/item.rb: expands the `TEST_ITEM` to include expected fields.
- spec/system/view_search_results_spec.rb: corrects the variable term to reflect what we are testing for.
- spec/system/view_show_page_spec.rb: adds testing for the show page.