### PR TITLE
Adds the fields for facets away from the homepage (#84). [MERGE AFTER PR #114 IN MAIN]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/BlockLength:
         - app/controllers/catalog_controller.rb
         - spec/controllers/catalog_controller_spec.rb
         - spec/models/user_spec.rb
+        - spec/system/view_search_results_spec.rb
 
 Metrics/CyclomaticComplexity:
     Exclude:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -56,6 +56,11 @@ class CatalogController < ApplicationController
     # config.show.display_type_field = 'format'
     # config.show.thumbnail_field = 'thumbnail_path_ss'
 
+    # solr fields that will be used for homepage facets
+    # When users venture away from the homepage, the full list of facets will
+    # be available to them. Any field listed below will appear on the homepage facets.
+    config.homepage_facet_fields = ['format', 'language_facet']
+
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
     #
@@ -80,21 +85,16 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'format', label: 'Format'
-    config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
-    config.add_facet_field 'subject_ssim', label: 'Topic', limit: 20, index_range: 'A'..'Z'
-    config.add_facet_field 'language_ssim', label: 'Language', limit: true
-    config.add_facet_field 'lc_1letter_ssim', label: 'Call Number'
-    config.add_facet_field 'subject_geo_ssim', label: 'Region'
-    config.add_facet_field 'subject_era_ssim', label: 'Era'
+    config.add_facet_field 'format', label: 'Resource Type', limit: 5
+    config.add_facet_field 'language_facet', label: 'Language', limit: 5
 
-    config.add_facet_field 'example_pivot_field', label: 'Pivot Field', pivot: ['format', 'language_ssim']
+    # config.add_facet_field 'example_pivot_field', label: 'Pivot Field', pivot: ['format', 'language_ssim']
 
-    config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
-      years_5: { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5} TO *]" },
-      years_10: { label: 'within 10 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 10} TO *]" },
-      years_25: { label: 'within 25 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 25} TO *]" }
-    }
+    # config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
+    #   years_5: { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5} TO *]" },
+    #   years_10: { label: 'within 10 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 10} TO *]" },
+    #   years_25: { label: 'within 25 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 25} TO *]" }
+    # }
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -88,14 +88,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'format', label: 'Resource Type', limit: 5
     config.add_facet_field 'language_facet', label: 'Language', limit: 5
 
-    # config.add_facet_field 'example_pivot_field', label: 'Pivot Field', pivot: ['format', 'language_ssim']
-
-    # config.add_facet_field 'example_query_facet_field', label: 'Publish Date', query: {
-    #   years_5: { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5} TO *]" },
-    #   years_10: { label: 'within 10 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 10} TO *]" },
-    #   years_25: { label: 'within 25 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 25} TO *]" }
-    # }
-
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
     # handler defaults, or have no facets.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,8 +85,14 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
+    config.add_facet_field 'marc_resource', label: 'Access', limit: 5
     config.add_facet_field 'format', label: 'Resource Type', limit: 5
     config.add_facet_field 'language_facet', label: 'Language', limit: 5
+    config.add_facet_field 'author_display', label: 'Author/Creator', limit: 5
+    config.add_facet_field 'subject_topic_facet', label: 'Subject', limit: 5
+    config.add_facet_field 'title_series_t', label: 'Collection', limit: 5
+    config.add_facet_field 'subject_geo_facet', label: 'Region', limit: 5
+    config.add_facet_field 'subject_era_facet', label: 'Era', limit: 5
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -1,0 +1,21 @@
+<% # Override of BlacklLight 7.4.1 -%>
+<% # main container for facets/limits menu -%>
+<% page_specific_field_names = request.fullpath == '/' ? blacklight_config.homepage_facet_fields : facet_field_names(groupname) %>
+<% if has_facet_values? facet_field_names(groupname), @response %>
+<div id="facets<%= "-#{groupname}" unless groupname.nil? %>" class="facets sidenav facets-toggleable-md">
+
+  <div class="navbar">
+    <h2 class="facets-heading">
+      <%= groupname.blank? ? t('blacklight.search.facets.title') : t("blacklight.search.facets-#{groupname}.title") %>
+    </h2>
+
+    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" aria-controls="facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" aria-expanded="false" aria-label="Toggle facets">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+  </div>
+
+  <div id="facet-panel<%= "-#{groupname}" unless groupname.nil? %>-collapse" class="facets-collapse collapse">
+    <%= render_facet_partials page_specific_field_names, response: @response %>
+  </div>
+</div>
+<% end %>

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,0 +1,21 @@
+<!-- This is a Blacklight 7.4.3 overwrite that is required to remove a string of "</span>" occuring after the disabled "Previous" links
+     in the pagination bar -->
+<div class="prev_next_links btn-group float-md-left">
+  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { blacklight_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn' %>
+  <% end %>
+
+  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { blacklight_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn' %>
+  <% end %>
+</div>
+
+<div class="sort-options btn-group float-md-right">
+  <% if @pagination.sort == 'index' -%>
+    <span class="active az btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.index') %></span>
+    <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h), class: "sort_change numeric btn btn-outline-secondary", data: { blacklight_modal: "preserve" }) %>
+  <% elsif @pagination.sort == 'count' -%>
+    <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', search_state.to_h), class: "sort_change az btn btn-outline-secondary",  data: { blacklight_modal: "preserve" }) %>
+    <span class="active numeric btn btn-outline-secondary"><%= t('blacklight.search.facets.sort.count') %></span>
+  <% end -%>
+</div>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -41,7 +41,11 @@ RSpec.describe CatalogController, type: :controller do
         .facet_fields.keys
         .map { |field| field.gsub(/\_s+im$/, '') }
     end
-    let(:expected_facet_fields) { ['format', 'language_facet'] }
+    let(:expected_facet_fields) do
+      ["author_display", "format", "language_facet", "marc_resource",
+       "subject_era_facet", "subject_geo_facet", "subject_topic_facet",
+       "title_series_t"]
+    end
     let(:homepage_facet_fields) { controller.blacklight_config.homepage_facet_fields }
 
     context 'homepage facet fields' do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -33,4 +33,21 @@ RSpec.describe CatalogController, type: :controller do
 
     it { expect(show_fields).to contain_exactly(*expected_show_fields) }
   end
+
+  describe 'facet fields' do
+    let(:facet_fields) do
+      controller
+        .blacklight_config
+        .facet_fields.keys
+        .map { |field| field.gsub(/\_s+im$/, '') }
+    end
+    let(:expected_facet_fields) { ['format', 'language_facet'] }
+    let(:homepage_facet_fields) { controller.blacklight_config.homepage_facet_fields }
+
+    context 'homepage facet fields' do
+      it { expect(homepage_facet_fields).to eq(['format', 'language_facet']) }
+    end
+
+    it { expect(facet_fields).to contain_exactly(*expected_facet_fields) }
+  end
 end

--- a/spec/support/solr_documents/item.rb
+++ b/spec/support/solr_documents/item.rb
@@ -8,5 +8,9 @@ TEST_ITEM = {
   lc_callnum_display: 'ANOTHER MAGICAL NUM .78F',
   marc_resource: ['Electronic Resource'],
   pub_date: '2015',
-  title_display: ['The Title of my Work']
+  subject_era_facet: ['1990-'],
+  subject_geo_facet: ['Texas'],
+  subject_topic_facet: ['Frontier and pioneer life', 'Electronic books'],
+  title_display: ['The Title of my Work'],
+  title_series_t: ['American county histories']
 }.freeze

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -3,8 +3,28 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'front page', type: :system do
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.add(TEST_ITEM)
+    solr.commit
+    visit root_path
+  end
+
   it 'has expected text' do
-    visit "/"
     expect(page).to have_css('h1.jumbotron-heading', text: 'Welcome!')
+  end
+
+  context 'facets' do
+    let(:facet_buttons) { find_all('h3.card-header.p-0.facet-field-heading button') }
+    let(:facet_headers) { facet_buttons.map(&:text) }
+
+    it 'has the right number of facets' do
+      expect(facet_buttons.size).to eq 2
+    end
+
+    it 'has the right headers' do
+      expect(facet_headers).to match_array(['Resource Type', 'Language'])
+    end
   end
 end

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.feature "View Search Results", type: :system, js: false do
+RSpec.feature 'View Search Results', type: :system, js: false do
   before do
     delete_all_documents_from_solr
     solr = Blacklight.default_index.connection
@@ -22,6 +22,22 @@ RSpec.feature "View Search Results", type: :system, js: false do
 
     it 'has the right values' do
       ['George Jenkins', 'Book', 'Electronic Resource'].each { |value| expect(page).to have_content(value) }
+    end
+  end
+
+  context 'facets' do
+    let(:facet_buttons) { find_all('h3.card-header.p-0.facet-field-heading button') }
+    let(:facet_headers) { facet_buttons.map(&:text) }
+
+    it 'has the right number of facets' do
+      expect(facet_buttons.size).to eq 8
+    end
+
+    it 'has the right headers' do
+      expect(facet_headers).to match_array(
+        ['Access', 'Author/Creator', 'Collection', 'Era', 'Language', 'Region',
+         'Resource Type', 'Subject']
+      )
     end
   end
 end


### PR DESCRIPTION
- .rubocop.yml: adds `view_search_results_spec.rb` to BlockLength exclusion.
- app/controllers/catalog_controller.rb: inserts the fields that will be faceted on index pages.
- spec/controllers/catalog_controller_spec.rb: expands the list of expected facet fields.
- spec/support/solr_documents/item.rb: widens the test item fields.
- spec/system/view_search_results_spec.rb: tests for the facets exclusive to the index page.