### PR TITLE
Configures the Keyword option's fields it searches in (#95).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/BlockLength:
         - app/controllers/catalog_controller.rb
         - spec/controllers/catalog_controller_spec.rb
         - spec/models/user_spec.rb
+        - spec/system/targeted_field_search_spec.rb
         - spec/system/view_search_results_spec.rb
 
 Metrics/CyclomaticComplexity:
@@ -42,3 +43,7 @@ Metrics/PerceivedComplexity:
 Lint/EmptyWhen:
     Exclude:
         - app/models/marc_indexer.rb
+
+RSpec/ExampleLength:
+    Exclude:
+        - spec/system/targeted_field_search_spec.rb

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -130,11 +130,22 @@ class CatalogController < ApplicationController
     # urls.  A display label will be automatically calculated from the :key,
     # or can be specified manually to be different.
 
+    keyword_fields = [
+      'isbn_t', 'issn_sim', 'lccn_sim', 'id', 'oclc_sim', 'other_standard_ids_sim',
+      'publisher_number_sim', 'nonformat_table_contents_tsim', 'summary_tsim',
+      'participant_performer_note_tsim', 'creation_production_credits_tsim', 'local_note_tsim'
+    ]
+
     # This one uses all the defaults set by the solr request handler. Which
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
 
-    config.add_search_field 'all_fields', label: 'All Fields'
+    config.add_search_field('keyword') do |field|
+      field.solr_parameters = {
+        qf: keyword_fields.join(' '),
+        pf: ''
+      }
+    end
 
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate

--- a/lib/tasks/solrmarc/index.properties
+++ b/lib/tasks/solrmarc/index.properties
@@ -19,6 +19,11 @@ language_facet = 008[35-37]:041a:041d, language_map.properties
 format = 000[6-7]:000[6], (map.format), first
 marc_resource = 007[0-1]:007[0], (map.format_type), first
 isbn_t = 020a, (pattern_map.isbn_clean)
+issn_sim = 022a
+lccn_sim = 010a
+oclc_sim = 019a:035a
+other_standard_ids_sim = 024a
+publisher_number_sim = 028a
 material_type_display = custom, removeTrailingPunct(300aa)
 
 # Title fields
@@ -66,6 +71,12 @@ lc_b4cutter_facet = 050a, first
 url_fulltext_display = custom, getFullTextUrls
 url_suppl_display = custom, getSupplUrls
 
+# Note Fields
+nonformat_table_contents_tsim = 505a
+summary_tsim = 520a
+participant_performer_note_tsim = 511a
+creation_production_credits_tsim = 508a
+local_note_tsim = 590a
 
 # MAPPINGS
 

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -46,6 +46,16 @@
     <field name="url_suppl_display" type="string" indexed="true" stored="true" multiValued="true"/> 
     <field name="subtitle_vern_display" type="string" indexed="true" stored="true" multiValued="false"/>
     <field name="marc_resource" type="string" stored="true" indexed="true" multiValued="true" />
+    <field name="issn_sim" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="lccn_sim" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="oclc_sim" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="other_standard_ids_sim" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="publisher_number_sim" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="nonformat_table_contents_tsim" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="summary_tsim" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="participant_performer_note_tsim" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="creation_production_credits_tsim" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="local_note_tsim" type="text" indexed="true" stored="true" multiValued="true"/>
 
     <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -54,4 +54,11 @@ RSpec.describe CatalogController, type: :controller do
 
     it { expect(facet_fields).to contain_exactly(*expected_facet_fields) }
   end
+
+  describe 'search fields' do
+    let(:search_fields) { controller.blacklight_config.search_fields.keys }
+    let(:expected_search_fields) { ['keyword', 'title', 'author', 'subject'] }
+
+    it { expect(search_fields).to contain_exactly(*expected_search_fields) }
+  end
 end

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Search the catalog', type: :system, js: false do
+  let(:fields) do
+    [
+      'isbn_t', 'issn_sim', 'lccn_sim', 'oclc_sim', 'other_standard_ids_sim',
+      'publisher_number_sim', 'nonformat_table_contents_tsim', 'summary_tsim',
+      'participant_performer_note_tsim', 'creation_production_credits_tsim', 'local_note_tsim'
+    ]
+  end
+
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    fields.each_with_index do |f, i|
+      solr.add(
+        id: "Junk#{i}",
+        title_display: "Target in #{f}",
+        f.to_sym => ['iMCnR6E8']
+      )
+    end
+
+    solr.add(
+      id: 'iMCnR6E8',
+      title_display: ['Target in id']
+    )
+    solr.commit
+  end
+
+  it 'searches the right fields for Common Fields target' do
+    visit root_path
+    page.select('Keyword', from: 'search_field')
+    fill_in 'q', with: 'iMCnR6E8'
+    click_on 'search'
+    result_titles = []
+
+    loop do
+      within '#documents' do
+        result_titles += page.all(:css, 'h3.document-title-heading/a').to_a.map(&:text)
+      end
+      break if page.has_link?('Next', href: '#')
+      click_link('Next', match: :first)
+    end
+
+    expect(result_titles).to contain_exactly(
+      'Target in isbn_t',
+      'Target in issn_sim',
+      'Target in lccn_sim',
+      'Target in oclc_sim',
+      'Target in other_standard_ids_sim',
+      'Target in publisher_number_sim',
+      'Target in nonformat_table_contents_tsim',
+      'Target in summary_tsim',
+      'Target in participant_performer_note_tsim',
+      'Target in creation_production_credits_tsim',
+      'Target in local_note_tsim',
+      'Target in id'
+    )
+  end
+end


### PR DESCRIPTION
- .rubocop.yml: excludes Rspec files that needed more complexity.
- app/controllers/catalog_controller.rb: provides the fields that this search bar option looks in.
- lib/tasks/solrmarc/index.properties: maps the newly created fields needed for this configuration.
- solr/conf/schema.xml: creates the fields that we needed to perform this search.
- spec/controllers/catalog_controller_spec.rb: tests that all of the options in #86 show in the `search_field` configuration.
- spec/system/targeted_field_search_spec.rb: ensures that all of the fields in this configuration do show up in the search results when provided a common search value.