### PR TITLE
Configures targeted search for Author

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -161,7 +161,7 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('author') do |field|
+    config.add_search_field('author', label: 'Author/Creator') do |field|
       field.solr_parameters = {
         'spellcheck.dictionary': 'author',
         qf: author_fields.join(' '),

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -135,6 +135,7 @@ class CatalogController < ApplicationController
       'publisher_number_sim', 'nonformat_table_contents_tsim', 'summary_tsim',
       'participant_performer_note_tsim', 'creation_production_credits_tsim', 'local_note_tsim'
     ]
+    author_fields = ['author_t', 'author_display', 'author_vern_display', 'author_sort', 'author_addl_t']
 
     # This one uses all the defaults set by the solr request handler. Which
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
@@ -163,8 +164,8 @@ class CatalogController < ApplicationController
     config.add_search_field('author') do |field|
       field.solr_parameters = {
         'spellcheck.dictionary': 'author',
-        qf: '${author_qf}',
-        pf: '${author_pf}'
+        qf: author_fields.join(' '),
+        pf: ''
       }
     end
 

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -56,6 +56,7 @@
     <field name="participant_performer_note_tsim" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="creation_production_credits_tsim" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="local_note_tsim" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_vern_display" type="text" indexed="true" stored="true" multiValued="true"/>
 
     <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     [
       'isbn_t', 'issn_sim', 'lccn_sim', 'oclc_sim', 'other_standard_ids_sim',
       'publisher_number_sim', 'nonformat_table_contents_tsim', 'summary_tsim',
-      'participant_performer_note_tsim', 'creation_production_credits_tsim', 'local_note_tsim'
+      'participant_performer_note_tsim', 'creation_production_credits_tsim', 'local_note_tsim',
+      'author_t', 'author_display', 'author_vern_display', 'author_sort', 'author_addl_t'
     ]
   end
 
@@ -28,7 +29,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     solr.commit
   end
 
-  it 'searches the right fields for Common Fields target' do
+  it 'searches the right fields for Keyword target' do
     visit root_path
     page.select('Keyword', from: 'search_field')
     fill_in 'q', with: 'iMCnR6E8'
@@ -57,5 +58,24 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       'Target in local_note_tsim',
       'Target in id'
     )
+  end
+
+  it 'searches the right fields for Author target' do
+    visit root_path
+    page.select('Author', from: 'search_field')
+    fill_in 'q', with: 'iMCnR6E8'
+    click_on 'search'
+    result_titles = []
+
+    within '#documents' do
+      result_titles += page.all(:css, 'h3.document-title-heading/a').to_a.map(&:text)
+      expect(result_titles).to contain_exactly(
+        'Target in author_t',
+        'Target in author_display',
+        'Target in author_vern_display',
+        'Target in author_sort',
+        'Target in author_addl_t'
+      )
+    end
   end
 end


### PR DESCRIPTION
* We are adding fields that are required to be searched through using the author target.
* Also updating tests to show results.
* Adding a field to solr schema that was previously missing during mapping.

Temp draft PR against the keyword branch, since this PR branch is off of that branch. Will change base with main once the keyword branch is merged and rerun CI.