### PR TITLE
Configures the Subject option in the search bar (#94).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -172,7 +172,7 @@ class CatalogController < ApplicationController
     # Field subject_t combines MARC tags for Personal Name, Corporate Name, Meeting Name,
     # Uniform Title, Named Event, Chronological Term, Topical Term, Geographic Name,
     # Uncontrolled, Faceted Topical Terms, and Genre/Form into an array.
-    config.add_search_field('subject') do |field|
+    config.add_search_field('subject', label: 'Subjects') do |field|
       field.solr_parameters = {
         qf: 'subject_t',
         pf: ''

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -169,15 +169,13 @@ class CatalogController < ApplicationController
       }
     end
 
-    # Specifying a :qt only to show it's possible, and so our internal automated
-    # tests can test it. In this case it's the same as
-    # config[:default_solr_parameters][:qt], so isn't actually neccesary.
+    # Field subject_t combines MARC tags for Personal Name, Corporate Name, Meeting Name,
+    # Uniform Title, Named Event, Chronological Term, Topical Term, Geographic Name,
+    # Uncontrolled, Faceted Topical Terms, and Genre/Form into an array.
     config.add_search_field('subject') do |field|
-      field.qt = 'search'
       field.solr_parameters = {
-        'spellcheck.dictionary': 'subject',
-        qf: '${subject_qf}',
-        pf: '${subject_pf}'
+        qf: 'subject_t',
+        pf: ''
       }
     end
 

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       'isbn_t', 'issn_sim', 'lccn_sim', 'oclc_sim', 'other_standard_ids_sim',
       'publisher_number_sim', 'nonformat_table_contents_tsim', 'summary_tsim',
       'participant_performer_note_tsim', 'creation_production_credits_tsim', 'local_note_tsim',
-      'author_t', 'author_display', 'author_vern_display', 'author_sort', 'author_addl_t'
+      'author_t', 'author_display', 'author_vern_display', 'author_sort', 'author_addl_t', 'subject_t'
     ]
   end
 
@@ -27,10 +27,16 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       title_display: ['Target in id']
     )
     solr.commit
+    visit root_path
+  end
+
+  it 'has the right options' do
+    options = find_all('select.custom-select.search-field > option').map(&:text)
+
+    expect(options).to contain_exactly('Keyword', 'Title', 'Author/Creator', 'Subjects')
   end
 
   it 'searches the right fields for Keyword target' do
-    visit root_path
     page.select('Keyword', from: 'search_field')
     fill_in 'q', with: 'iMCnR6E8'
     click_on 'search'
@@ -61,7 +67,6 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
   end
 
   it 'searches the right fields for Author target' do
-    visit root_path
     page.select('Author', from: 'search_field')
     fill_in 'q', with: 'iMCnR6E8'
     click_on 'search'
@@ -77,5 +82,18 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
         'Target in author_addl_t'
       )
     end
+  end
+
+  it 'searches the right field for Subject target' do
+    page.select('Subject', from: 'search_field')
+    fill_in 'q', with: 'iMCnR6E8'
+    click_on 'search'
+    result_titles = []
+
+    within '#documents' do
+      result_titles += page.all(:css, 'h3.document-title-heading/a').to_a.map(&:text)
+    end
+
+    expect(result_titles).to contain_exactly('Target in subject_t')
   end
 end

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
   end
 
   it 'searches the right field for Subject target' do
-    page.select('Subject', from: 'search_field')
+    page.select('Subjects', from: 'search_field')
     fill_in 'q', with: 'iMCnR6E8'
     click_on 'search'
     result_titles = []


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: changes the Subject field to reflect the needed Solr field `subject_t`.
- spec/system/targeted_field_search_spec.rb: includes testing for the switch of focus for the Subject option.