### PR TITLE
Creates a custom 404 page (#143).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,7 @@ Lint/EmptyWhen:
 
 RSpec/ExampleLength:
     Exclude:
+        - spec/requests/not_found_requests_spec.rb
         - spec/routing/alma_availability_routes_spec.rb
         - spec/system/targeted_field_search_spec.rb
         - spec/system/view_show_page_spec.rb

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,10 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  def guest_uid_authentication_key(key)
+    guest_email_authentication_key(key)
+  end
+
   def alma_availability
     availability = AlmaAvailabilityService.new(params[:id])&.current_availability
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,10 +3,6 @@ class CatalogController < ApplicationController
   include Blacklight::Catalog
   include Blacklight::Marc::Catalog
 
-  def guest_uid_authentication_key(key)
-    guest_email_authentication_key(key)
-  end
-
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class StaticController < ApplicationController
+  def not_found
+    render status: 404
+  end
+end

--- a/app/views/static/not_found.html.erb
+++ b/app/views/static/not_found.html.erb
@@ -1,0 +1,5 @@
+<div class="container not-found-container">
+    <div class="row static-heading-row not-found">
+      <h1><%= t('static.not_found.header') %></h1>
+    </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,7 @@ module BlacklightCatalog
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.exceptions_app = routes
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
 
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,11 +20,11 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,6 @@
 
 en:
   hello: "Hello world"
+  static:
+    not_found:
+      header: "404 Error - Page Not Found"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,4 +39,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   get '/alma_availability/:id', to: 'application#alma_availability'
+
+  match '/404', to: 'static#not_found', via: :all
 end

--- a/spec/requests/not_found_requests_spec.rb
+++ b/spec/requests/not_found_requests_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "404 Error Custom Page", type: :request do
+  before { get '/catalog/1' }
+
+  it "loads the page when 404 error detected" do
+    expect(response.status).to eq 404
+    expect(response.body).not_to be_empty
+    expect(response.content_length).to be > 0
+    expect(response.content_type).to eq "text/html"
+    expect(response).to render_template(:not_found)
+  end
+
+  it "contains the requested headers" do
+    expect(response.body).to include '404 Error - Page Not Found'
+  end
+end

--- a/spec/routing/not_found_routes_spec.rb
+++ b/spec/routing/not_found_routes_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Not Found Routes", type: :routing do
+  it "routes requests for 404 to the static controller action not_found" do
+    expect(get("/404")).to route_to(
+      controller: "static",
+      action: "not_found"
+    )
+  end
+end


### PR DESCRIPTION
- .rubocop.yml: excludes my test file from this requirement.
- app/controllers/catalog_controller.rb and app/controllers/application_controller.rb: moves this definition to the application controller so that it's available to all controllers.
- app/controllers/static_controller.rb: creates a new controller for static pages.
- app/views/static/not_found.html.erb: institutes our desired code for the 404 page.
- config/application.rb and config/environments/*: configures the application to make it friendly to customized error pages.
- config/locales/en.yml: diverts text to a localization.
- config/routes.rb: stubs a route for the 404 requested action.
- spec/*: tests for intended behavior.