### PR TITLE
Bug: Makes title_abbr_tesi multivalued to correct ingestion error.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -134,7 +134,7 @@ class CatalogController < ApplicationController
     ]
     author_fields = ['author_tesim', 'author_display_ssim', 'author_vern_ssim', 'author_si', 'author_addl_tesim']
     title_fields = ['title_tesim', 'title_display_tesim', 'title_vern_display_tesi', 'title_ssort',
-                    'title_addl_tesim', 'title_abbr_tesi', 'title_added_entry_tesim', 'title_enhanced_tesim',
+                    'title_addl_tesim', 'title_abbr_tesim', 'title_added_entry_tesim', 'title_enhanced_tesim',
                     'title_former_tesi', 'title_graphic_tesim', 'title_host_item_tesim', 'title_key_tesi',
                     'title_series_ssim', 'title_translation_tesim', 'title_varying_tesim']
 

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -127,7 +127,7 @@ to_field 'subtitle_display_tesim', extract_marc('245b', alternate_script: false)
 to_field 'subtitle_vern_display_tesi', extract_marc('245b', alternate_script: :only), trim_punctuation
 
 #    additional title fields
-to_field 'title_abbr_tesi', extract_marc('210ab')
+to_field 'title_abbr_tesim', extract_marc('210ab')
 to_field 'title_addl_tesim', extract_marc(%W[
   130#{ATOZ}
   210ab

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       'subject_topic_facet_ssim', 'subject_era_ssim', 'subject_geo_ssim', 'lc_callnum_display_ssi',
       'author_tesim', 'author_display_ssim', 'author_vern_ssim', 'author_si', 'author_addl_tesim',
       'subject_tsim', 'title_tesim', 'title_vern_display_tesi', 'title_ssort',
-      'title_addl_tesim', 'title_abbr_tesi', 'title_added_entry_tesim', 'title_enhanced_tesim',
+      'title_addl_tesim', 'title_abbr_tesim', 'title_added_entry_tesim', 'title_enhanced_tesim',
       'title_former_tesi', 'title_graphic_tesim', 'title_host_item_tesim', 'title_key_tesi',
       'title_series_ssim', 'title_translation_tesim', 'title_varying_tesim'
     ]
@@ -111,7 +111,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       'Target in title_vern_display_tesi',
       'Target in title_ssort',
       'Target in title_addl_tesim',
-      'Target in title_abbr_tesi',
+      'Target in title_abbr_tesim',
       'Target in title_added_entry_tesim',
       'Target in title_enhanced_tesim',
       'Target in title_former_tesi',


### PR DESCRIPTION
Changes all occurrences of `title_abbr_tesi` to `title_abbr_tesim` to correct ingestion error:
2021-02-02T12:37:29-05:00 ERROR Error in Solr batch add. Will retry documents individually at performance penalty: Solr response: 400: {
  "responseHeader":{
    "status":400,
    "QTime":280},
  "error":{
    "metadata":[
      "error-class","org.apache.solr.common.SolrException",
      "root-error-class","org.apache.solr.common.SolrException"],
    "msg":"ERROR: [doc=9936493910402486] multiple values encountered for non multiValued field title_abbr_tesi: [KEYBOARD THE WORLDS LEADING MUSIC TECHNOLOGY MAGAZINE, Keyboard (Cupertino Calif.)]",
    "code":400}}

2021-02-02T12:37:29-05:00 ERROR Could not add record <record #851, source_id:9936493910402486 output_id:9936493910402486>: Solr error response: 400: {
  "responseHeader":{
    "status":400,
    "QTime":0},
  "error":{
    "metadata":[
      "error-class","org.apache.solr.common.SolrException",
      "root-error-class","org.apache.solr.common.SolrException"],
    "msg":"ERROR: [doc=9936493910402486] multiple values encountered for non multiValued field title_abbr_tesi: [KEYBOARD THE WORLDS LEADING MUSIC TECHNOLOGY MAGAZINE, Keyboard (Cupertino Calif.)]",
    "code":400}}