### PR TITLE
Updates the AWS region for capistrano

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -50,7 +50,7 @@ set :assets_prefix, "#{shared_path}/public/assets"
 SSHKit.config.command_map[:rake] = 'bundle exec rake'
 
 set :ec2_profile, ENV['AWS_PROFILE'] || ENV['AWS_DEFAULT_PROFILE']
-set :ec2_region, %w[us-east-2]
+set :ec2_region, %w[us-east-1]
 set :ec2_contact_point, :private_ip
 set :ec2_project_tag, 'EmoryApplicationName'
 set :ec2_stages_tag, 'EmoryEnvironment'

--- a/config/deploy/arch.rb
+++ b/config/deploy/arch.rb
@@ -56,6 +56,7 @@
 #   }
 
 set :stage, :ARCH
+set :ec2_region, %w[us-east-2]
 ec2_role %i[web app db],
   user: 'deploy',
   ssh_options: {


### PR DESCRIPTION
us-east-1 by default, but arch is (currently) still in us-east-2