### PR TITLE
Configures Publication/Creation Date facet (#203).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/BlockLength:
         - spec/models/marc_indexing_spec.rb
         - spec/models/user_spec.rb
         - spec/spec_helper.rb
+        - spec/system/facet_by_year_spec.rb
         - spec/system/targeted_field_search_spec.rb
         - spec/system/view_search_results_spec.rb
         - spec/system/view_show_page_spec.rb
@@ -62,5 +63,6 @@ RSpec/ExampleLength:
     Exclude:
         - spec/requests/not_found_requests_spec.rb
         - spec/routing/alma_availability_routes_spec.rb
+        - spec/system/facet_by_year_spec.rb
         - spec/system/targeted_field_search_spec.rb
         - spec/system/view_show_page_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ ruby '>=2.5.0'
 
 gem 'blacklight', '7.4.1'
 gem 'blacklight-marc', '>= 7.0.0.rc1'
+gem 'blacklight_range_limit'
 gem 'bootstrap', '~> 4.0'
 gem 'coffee-rails', '~> 4.2'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1023,6 +1023,8 @@ GEM
       marc-fastxmlwriter
       rails
       traject (~> 3.0)
+    blacklight_range_limit (7.4.0)
+      blacklight (>= 7.0)
     bootstrap (4.5.2)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
@@ -1407,6 +1409,7 @@ DEPENDENCIES
   bixby
   blacklight (= 7.4.1)
   blacklight-marc (>= 7.0.0.rc1)
+  blacklight_range_limit
   bootstrap (~> 4.0)
   byebug
   cap-ec2-emory!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,3 +22,9 @@
 //= require blacklight/blacklight
 
 //= require_tree .
+
+
+// For blacklight_range_limit built-in JS, if you don't want it you don't need
+// this:
+//= require 'blacklight_range_limit'
+

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,4 +12,9 @@
  *
  *= require_tree .
  *= require_self
- */
+ 
+ *
+ * Used by blacklight_range_limit
+ *= require  'blacklight_range_limit'
+ *
+*/

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class CatalogController < ApplicationController
+  include BlacklightRangeLimit::ControllerOverride
   include Blacklight::Catalog
   include Blacklight::Marc::Catalog
 
@@ -84,6 +85,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'marc_resource_ssim', label: 'Access', limit: 5
     config.add_facet_field 'format_ssim', label: 'Resource Type', limit: 5
     config.add_facet_field 'language_facet_tesim', label: 'Language', limit: 5
+    config.add_facet_field 'pub_date_isi', label: 'Publication/Creation Date', range: true
     config.add_facet_field 'author_display_ssim', label: 'Author/Creator', limit: 5
     config.add_facet_field 'subject_ssim', label: 'Subject', limit: 5
     config.add_facet_field 'title_series_ssim', label: 'Collection', limit: 5
@@ -197,10 +199,10 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, pub_date_si desc, title_si asc', label: 'relevance'
-    config.add_sort_field 'pub_date_si desc, title_si asc', label: 'year'
+    config.add_sort_field 'score desc, pub_date_isi desc, title_si asc', label: 'relevance'
+    config.add_sort_field 'pub_date_isi desc, title_si asc', label: 'year'
     config.add_sort_field 'author_si asc, title_si asc', label: 'author'
-    config.add_sort_field 'title_si asc, pub_date_si desc', label: 'title'
+    config.add_sort_field 'title_si asc, pub_date_isi desc', label: 'title'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class SearchHistoryController < ApplicationController
+  include Blacklight::SearchHistory
+
+  helper BlacklightRangeLimit::ViewHelperOverride
+  helper RangeLimitHelper
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include BlacklightRangeLimit::RangeLimitBuilder
 
   ##
   # @example Adding a new step to the processor chain

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
+  concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   mount Blacklight::Engine => '/'
   concern :marc_viewable, Blacklight::Marc::Routes::MarcViewable.new
 
@@ -8,6 +9,7 @@ Rails.application.routes.draw do
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
+    concerns :range_searchable
   end
 
   devise_for :users, controllers: { omniauth_callbacks: "omniauth_callbacks" }

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -185,8 +185,7 @@ to_field 'genre_ssim', extract_marc("655a")
 to_field 'published_ssm', extract_marc('260a', alternate_script: false), trim_punctuation
 to_field 'published_vern_ssm', extract_marc('260a', alternate_script: :only), trim_punctuation
 to_field 'publisher_location_ssm', extract_marc("260a:264a:008[15-17]"), trim_punctuation
-to_field 'pub_date_si', marc_publication_date
-to_field 'pub_date_ssim', marc_publication_date
+to_field 'pub_date_isi', marc_publication_date
 
 # Call Number fields
 to_field 'lc_callnum_ssm', extract_marc('050ab'), first_only

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CatalogController, type: :controller do
     let(:expected_facet_fields) do
       ["author_display_ssim", "format_ssim", "language_facet_tesim", "marc_resource_ssim",
        "subject_era_ssim", "subject_geo_ssim", "subject_ssim",
-       "title_series_ssim", "genre_ssim"]
+       "title_series_ssim", "genre_ssim", "pub_date_isi"]
     end
     let(:homepage_facet_fields) { controller.blacklight_config.homepage_facet_fields }
 

--- a/spec/system/facet_by_year_spec.rb
+++ b/spec/system/facet_by_year_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Facet the catalog by year', type: :system, js: false do
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.add([llama, newt, eagle])
+    solr.commit
+  end
+
+  let(:llama) do
+    {
+      id: '111',
+      title_main_display_tesim: ['Llama Love'],
+      pub_date_isi: 1920
+    }
+  end
+
+  let(:newt) do
+    {
+      id: '222',
+      title_main_display_tesim: ['Newt Nutrition'],
+      pub_date_isi: 1940
+    }
+  end
+
+  let(:eagle) do
+    {
+      id: '333',
+      title_main_display_tesim: ['Eagle Excellence']
+    }
+  end
+
+  it 'gets correct search results using year ranges' do
+    visit root_path
+    click_on 'search'
+
+    within '#documents' do
+      expect(page).to have_content('Llama Love')
+      expect(page).to have_content('Newt Nutrition')
+      expect(page).to have_content('Eagle Excellence')
+    end
+
+    find('input#range_pub_date_isi_begin').set('1920')
+    find('input#range_pub_date_isi_end').set('1925')
+    find("input[value$='Apply']").click
+
+    within '#documents' do
+      expect(page).to     have_content('Llama Love')
+      expect(page).not_to have_content('Newt Nutrition')
+      expect(page).not_to have_content('Eagle Excellence')
+    end
+  end
+end


### PR DESCRIPTION
- .rubocop.yml: excludes test spec from rubocop rules.
- Gemfile*: adds `blacklight_range_limit` to the application suite.
- app/assets/*, catalog_controller.rb, search_history_controller.rb, search_builder.rb, and routes.rb: integrates `blacklight_range_limit` hooks into the application.
- app/controllers/catalog_controller.rb, lib/marc_indexer.rb, and spec/controllers/catalog_controller_spec.rb: inserts facet and updates sort fields with new field name.
- spec/system/facet_by_year_spec.rb: tests that range limit facet works.