### PR TITLE
Configures LOC Classification facet (#202).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -89,6 +89,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'author_ssim', label: 'Author/Creator', limit: 5
     config.add_facet_field 'subject_ssim', label: 'Subject', limit: 5
     config.add_facet_field 'title_series_ssim', label: 'Collection', limit: 5
+    config.add_facet_field 'lc_1letter_ssim', label: 'LC Classification', limit: 5
     config.add_facet_field 'subject_geo_ssim', label: 'Region', limit: 5
     config.add_facet_field 'subject_era_ssim', label: 'Era', limit: 5
     config.add_facet_field 'genre_ssim', label: 'Genre', limit: 5

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -195,7 +195,7 @@ to_field 'pub_date_isi', marc_publication_date
 to_field 'lc_callnum_ssm', extract_marc('050ab'), first_only
 
 first_letter = ->(_rec, acc) { acc.map! { |x| x[0] } }
-to_field 'lc_1letter_ssim', extract_marc('050ab'), first_only, first_letter, translation_map('callnumber_map')
+to_field 'lc_1letter_ssim', extract_marc('050a:090a'), first_letter, translation_map('callnumber_map')
 
 alpha_pat = /\A([A-Z]{1,3})\d.*\Z/
 alpha_only = lambda do |_rec, acc|

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CatalogController, type: :controller do
     let(:expected_facet_fields) do
       ["author_ssim", "format_ssim", "language_ssim", "marc_resource_ssim",
        "subject_era_ssim", "subject_geo_ssim", "subject_ssim",
-       "title_series_ssim", "genre_ssim", "pub_date_isi"]
+       "title_series_ssim", "genre_ssim", "pub_date_isi", "lc_1letter_ssim"]
     end
     let(:homepage_facet_fields) { controller.blacklight_config.homepage_facet_fields }
 

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -114,4 +114,23 @@ RSpec.describe 'Indexing fields with custom logic' do
       expect(solr_doc['title_main_display_tesim']).to eq(["Physical Map Test"])
     end
   end
+
+  describe 'lc_1letter_ssim field' do
+    let(:solr_doc) { SolrDocument.find('9937264718102486') }
+    let(:solr_doc_2) { SolrDocument.find('9937264717902486') }
+    let(:solr_doc_3) { SolrDocument.find('9937264718202486') }
+    let(:solr_doc_4) { SolrDocument.find('9937264718402486') }
+
+    it 'maps P - Language & Literature' do
+      [solr_doc, solr_doc_2].each do |s|
+        expect(s['lc_1letter_ssim']).to eq(['P - Language & Literature'])
+      end
+    end
+
+    it 'does not map values when 050a and 090a are empty' do
+      [solr_doc_3, solr_doc_4].each do |s|
+        expect(s['lc_1letter_ssim']).to be_nil
+      end
+    end
+  end
 end

--- a/spec/support/solr_documents/item.rb
+++ b/spec/support/solr_documents/item.rb
@@ -25,5 +25,6 @@ TEST_ITEM = {
   note_general_tsim: ['General note'],
   publisher_details_display_ssm: ['Atlanta'],
   summary_tesim: ['Short summary'],
-  genre_ssim: ['Genre example']
+  genre_ssim: ['Genre example'],
+  lc_1letter_ssim: ['T - Technology']
 }.freeze

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -30,13 +30,13 @@ RSpec.feature 'View Search Results', type: :system, js: false do
     let(:facet_headers) { facet_buttons.map(&:text) }
 
     it 'has the right number of facets' do
-      expect(facet_buttons.size).to eq 9
+      expect(facet_buttons.size).to eq 10
     end
 
     it 'has the right headers' do
       expect(facet_headers).to match_array(
         ['Access', 'Author/Creator', 'Collection', 'Era', 'Language', 'Region',
-         'Resource Type', 'Subject', 'Genre']
+         'Resource Type', 'Subject', 'Genre', 'LC Classification']
       )
     end
   end


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: injects `lc_1letter_ssim` into the facet list.
- lib/marc_indexer.rb: pulls multiple values into the needed field.
- spec/*: checks for the correct processing of the facet/field.