### PR TITLE
Provides option for fully indexing the desired OAI set (#258).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,7 @@ Metrics/BlockLength:
         - spec/models/property_bag_spec.rb
         - spec/models/user_spec.rb
         - spec/services/oai_processing_service_spec.rb
+        - spec/services/oai_query_string_service_spec.rb
         - spec/spec_helper.rb
         - spec/system/facet_by_year_spec.rb
         - spec/system/targeted_field_search_spec.rb
@@ -56,6 +57,7 @@ Lint/EmptyWhen:
 Rails/Output:
     Exclude:
         - 'app/services/oai_processing_service.rb'
+        - 'app/services/oai_query_string_service.rb'
 
 RSpec/DescribeClass:
     Exclude:

--- a/HARVESTING_ALMA_DATA.md
+++ b/HARVESTING_ALMA_DATA.md
@@ -11,15 +11,16 @@ alma="na03"
 institution="01GALI_EMORY"
 # provide SOLR_URL for solr connections
 SOLR_URL="http://localhost:8983/solr/blacklight-core"
-# provides name for oai set being fetched
-oai_set_name="blacklighttest"
 ```
 3. Connect to `vpnproxy.emory.edu` using Big-IP Edge Client.
 4. Run the rake task:
-  - If the default set is desired, run `RAILS_ENV=development bundle exec rails oai_harvest` in your terminal.
-  - If there is a specific OAI set that is preferred over `blacklighttest`, add the `oai_set_name` variable assignment to the command:
-    `RAILS_ENV=development bundle exec rails oai_harvest oai_set_name=<name of preferred set>`
-  - Either command may take several minutes to process.
-5. In your local [Solr instance](http://localhost:8983/solr/#/blacklight-core/query), perform a global search query. The default subset collection contains roughly 4500 items.
+  - If the production set (4.9~ million) is desired, run 
+    `RAILS_ENV=development bundle exec rails marc_index_ingest oai_set_name=blacklight full_index=true` 
+    in your terminal. This will take over twelve hours to process, so be cautious using this set locally.
+  - If you'd like a more manageable set (4.6~ thousand) for testing purposes, run the command below:
+    `RAILS_ENV=development bundle exec rails marc_index_ingest oai_set_name=blacklighttest full_index=true`
+  - Note: The commands above can be used to re-index (update) your local Solr instance. To re-index only the 
+    items that have changed since the last harvest, remove the argument `full_index=true` completely.
+5. In your local [Solr instance](http://localhost:8983/solr/#/blacklight-core/query), perform a global search query. You will start to see records accumulate when refreshing the page multiple times.
 
 This tutorial can also be found at this [link](https://wiki.emory.edu/display/BDL/Using+SolrMarc+to+harvest+data+from+Alma+into+Solr+Index) (Emory login required).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 1. Install the required gems: `bundle install`
 1. Migrate the database: `rails db:migrate`
 1. Launch development instance of solr in the same folder but a separate terminal window/tab: `bundle exec solr_wrapper`
-1. First time running this application locally? Give yourself some test objects: `rake solr:marc:index_test_data`
+1. First time running this application locally? Give yourself some test objects by following the directions [here](https://github.com/emory-libraries/blacklight-catalog/blob/main/HARVESTING_ALMA_DATA.md)
 1. Start the application: `rails server`
 1. You should now be able to go to `http://localhost:3000/catalog` and see the application
 

--- a/app/services/oai_query_string_service.rb
+++ b/app/services/oai_query_string_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class OaiQueryStringService
+  def self.process_query_string(oai_set, full_index, to_time)
+    from_time = process_from_time(full_index)
+    # check where to resume harvesting from
+    saved_resumption_token = PropertyBag.get('marc_ingest_resumption_token')
+
+    process_string(saved_resumption_token, oai_set, from_time, to_time)
+  end
+
+  def self.process_from_time(full_index)
+    from_time = full_index ? nil : PropertyBag.get('marc_ingest_time')
+    log "Setting 'from' time: #{from_time}"
+    from_time = "&from=#{from_time}" if from_time
+    from_time
+  end
+
+  def self.process_string(saved_resumption_token, oai_set, from_time, to_time)
+    # resume from last harvested
+    return "?verb=ListRecords&resumptionToken=#{saved_resumption_token}" unless saved_resumption_token.empty?
+    # start fresh harvest
+    "?verb=ListRecords&set=#{oai_set}&metadataPrefix=marc21&until=#{to_time}#{from_time}"
+  end
+
+  def self.log(msg)
+    time = Time.new.utc.strftime("%Y-%m-%d %H:%M:%S")
+    puts "#{time} - #{msg}"
+    true
+  end
+end

--- a/lib/tasks/marc_index_ingester.rake
+++ b/lib/tasks/marc_index_ingester.rake
@@ -3,27 +3,14 @@
 desc "Harvest OAI XML denoted in ENV oai_set_name and index in Solr via Traject"
 task marc_index_ingest: [:environment] do
   oai_set = ENV['oai_set_name']
+  full_index = ENV['full_index'].present?
+  to_time = Time.new.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
   abort 'The ENV variable oai_set_name has not been set.' if oai_set.blank?
 
   log "Starting..."
 
-  from_time = PropertyBag.get('marc_ingest_time')
-  log "Setting 'from' time: #{from_time}"
-  from_time = "&from=#{from_time}" if from_time
-
-  to_time = Time.new.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+  qs = OaiQueryStringService.process_query_string(oai_set, full_index, to_time)
   log "Set 'to' time: #{to_time}"
-
-  # check where to resume harvesting from
-  saved_resumption_token = PropertyBag.get('marc_ingest_resumption_token')
-
-  qs = if !saved_resumption_token.to_s == ''
-         # resume from last harvested
-         "?verb=ListRecords&resumptionToken=#{saved_resumption_token}"
-       else
-         # start fresh harvest
-         "?verb=ListRecords&set=#{oai_set}&metadataPrefix=marc21&until=#{to_time}#{from_time}"
-       end
 
   loop do
     # expect resumption token to be returned from process_oai method, else
@@ -42,8 +29,7 @@ task marc_index_ingest: [:environment] do
 end
 
 def log(msg)
-  time = Time.new.utc
-  time = time.strftime("%Y-%m-%d %H:%M:%S")
+  time = Time.new.utc.strftime("%Y-%m-%d %H:%M:%S")
   puts "#{time} - #{msg}"
   true
 end

--- a/spec/models/property_bag_spec.rb
+++ b/spec/models/property_bag_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe PropertyBag, :clean do
   let(:time_ingester_format) { Time.new.utc.strftime("%Y-%m-%dT%H:%M:%SZ") }
   let(:item_name) { 'test_marc_ingest_time' }
 
-  before { described_class.set(item_name, time_ingester_format) }
+  before do
+    described_class.delete_all
+    described_class.set(item_name, time_ingester_format)
+  end
 
   context '#set' do
     it 'calls the set method' do

--- a/spec/services/oai_query_string_service_spec.rb
+++ b/spec/services/oai_query_string_service_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe OaiQueryStringService, :clean do
+  let(:oai_set) { 'blacklighttest' }
+  let(:full_index) { false }
+  let(:to_time) { Time.new.utc.strftime("%Y-%m-%dT%H:%M:%SZ") }
+  let(:ingest_time) { '2021-02-23T21:32:25Z' }
+  PropertyBag.set('marc_ingest_resumption_token', '')
+
+  before { PropertyBag.set('marc_ingest_time', ingest_time) }
+  after { PropertyBag.delete_all }
+
+  context '#process_query_string' do
+    it 'returns the right string when full_index false and resumption token not present' do
+      qs = described_class.process_query_string(oai_set, full_index, to_time)
+
+      check_other_methods_called
+      expect(qs).to eq(
+        "?verb=ListRecords&set=#{oai_set}&metadataPrefix=marc21&until=#{to_time}&from=#{ingest_time}"
+      )
+    end
+
+    it 'returns the right string when full_index true and resumption token not present' do
+      qs = described_class.process_query_string(oai_set, true, to_time)
+
+      check_other_methods_called
+      expect(qs).to eq(
+        "?verb=ListRecords&set=#{oai_set}&metadataPrefix=marc21&until=#{to_time}"
+      )
+    end
+
+    it 'returns the right string when resumption token present' do
+      PropertyBag.set('marc_ingest_resumption_token', 'Hello!')
+      qs = described_class.process_query_string(oai_set, full_index, to_time)
+
+      check_other_methods_called
+      expect(qs).to eq("?verb=ListRecords&resumptionToken=Hello!")
+    end
+  end
+
+  context '#process_from_time' do
+    it 'returns ingest_time inside a substring when full_index is false' do
+      expect(described_class.process_from_time(full_index)).to eq("&from=#{ingest_time}")
+    end
+
+    it 'returns nothing when full_index is true' do
+      expect(described_class.process_from_time(true)).to be_nil
+    end
+  end
+
+  def check_other_methods_called
+    expect(described_class).to respond_to(:process_from_time).with(1).argument
+    expect(described_class).to respond_to(:process_string).with(4).argument
+  end
+end


### PR DESCRIPTION
- .rubocop.yml: excludes testing and services from rubocop testing.
- HARVESTING_ALMA_DATA.md and README.md: updates instructions on how to index data locally.
- app/services/oai_query_string_service.rb: institutes a service to extract more processing away from the rake task itself.
- lib/tasks/marc_index_ingester.rake: removes logic from rake task and replaces it with a call to the service above.
- spec/*: tests for the correct processing of the query string.