### PR TITLE
Styles date slider so that dates are visible (#274).

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -2,4 +2,4 @@
 
 @import 'blacklight/blacklight';
 @import 'blacklight_marc';
-
+@import 'blacklight_catalog/date_slider';

--- a/app/assets/stylesheets/blacklight_catalog/_date_slider.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_date_slider.scss
@@ -1,0 +1,3 @@
+.flot-svg > svg {
+  overflow: visible;
+}


### PR DESCRIPTION
- app/assets/stylesheets/blacklight.scss: imports new SCSS partial.
- app/assets/stylesheets/blacklight_catalog/_date_slider.scss: creates a nee SCSS page with styling to make hidden numbers visible.