### PR TITLE
modifies rake task to re-index a single record

### DIFF
--- a/HARVESTING_ALMA_DATA.md
+++ b/HARVESTING_ALMA_DATA.md
@@ -21,6 +21,8 @@ SOLR_URL="http://localhost:8983/solr/blacklight-core"
     `RAILS_ENV=development bundle exec rails marc_index_ingest oai_set_name=blacklighttest full_index=true`
   - Note: The commands above can be used to re-index (update) your local Solr instance. To re-index only the 
     items that have changed since the last harvest, remove the argument `full_index=true` completely.
+  - If you want to re-index a single item, remove `full_index=true`, `oai_set_name` and add `oai_single_id=some_msid`
+    with an id of the record you want to re-index.
 5. In your local [Solr instance](http://localhost:8983/solr/#/blacklight-core/query), perform a global search query. You will start to see records accumulate when refreshing the page multiple times.
 
 This tutorial can also be found at this [link](https://wiki.emory.edu/display/BDL/Using+SolrMarc+to+harvest+data+from+Alma+into+Solr+Index) (Emory login required).

--- a/app/services/oai_query_string_service.rb
+++ b/app/services/oai_query_string_service.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class OaiQueryStringService
-  def self.process_query_string(oai_set, full_index, to_time)
+  def self.process_query_string(oai_set, full_index, to_time, single_record)
     from_time = process_from_time(full_index)
     # check where to resume harvesting from
     saved_resumption_token = PropertyBag.get('marc_ingest_resumption_token')
 
-    process_string(saved_resumption_token, oai_set, from_time, to_time)
+    process_string(saved_resumption_token, oai_set, from_time, to_time, single_record)
   end
 
   def self.process_from_time(full_index)
@@ -16,10 +16,12 @@ class OaiQueryStringService
     from_time
   end
 
-  def self.process_string(saved_resumption_token, oai_set, from_time, to_time)
+  def self.process_string(saved_resumption_token, oai_set, from_time, to_time, single_record)
     # resume from last harvested
     return "?verb=ListRecords&resumptionToken=#{saved_resumption_token}" if saved_resumption_token.present?
-    # start fresh harvest
+    # start a single record harvest
+    return "?verb=GetRecord&identifier=oai:alma.#{ENV['INSTITUTION']}:#{oai_set}&metadataPrefix=marc21&until=#{to_time}#{from_time}" if single_record
+    # start a fresh set harvest
     "?verb=ListRecords&set=#{oai_set}&metadataPrefix=marc21&until=#{to_time}#{from_time}"
   end
 

--- a/lib/tasks/marc_index_ingester.rake
+++ b/lib/tasks/marc_index_ingester.rake
@@ -2,14 +2,15 @@
 
 desc "Harvest OAI XML denoted in ENV oai_set_name and index in Solr via Traject"
 task marc_index_ingest: [:environment] do
-  oai_set = ENV['oai_set_name']
+  oai_set = ENV['oai_set_name'] || ENV['oai_single_id']
   full_index = ENV['full_index'].present?
   to_time = Time.new.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
-  abort 'The ENV variable oai_set_name has not been set.' if oai_set.blank?
+  single_record = ENV.key?('oai_single_id') ? true : false
+  abort 'The ENV variable oai_set_name or oai_single_id has not been set.' if oai_set.blank?
 
   log "Starting..."
 
-  qs = OaiQueryStringService.process_query_string(oai_set, full_index, to_time)
+  qs = OaiQueryStringService.process_query_string(oai_set, full_index, to_time, single_record)
   log "Set 'to' time: #{to_time}"
 
   loop do

--- a/spec/services/oai_query_string_service_spec.rb
+++ b/spec/services/oai_query_string_service_spec.rb
@@ -4,16 +4,27 @@ require 'rails_helper'
 RSpec.describe OaiQueryStringService, :clean do
   let(:oai_set) { 'blacklighttest' }
   let(:full_index) { false }
+  let(:single_record) { true }
   let(:to_time) { Time.new.utc.strftime("%Y-%m-%dT%H:%M:%SZ") }
   let(:ingest_time) { '2021-02-23T21:32:25Z' }
+  let(:institution) { ENV['INSTITUTION'] }
   PropertyBag.set('marc_ingest_resumption_token', '')
 
   before { PropertyBag.set('marc_ingest_time', ingest_time) }
   after { PropertyBag.delete_all }
 
   context '#process_query_string' do
+    it 'returns the right string when full_index false and resumption token not present and single_record true' do
+      qs = described_class.process_query_string(oai_set, full_index, to_time, single_record)
+
+      check_other_methods_called
+      expect(qs).to eq(
+        "?verb=GetRecord&identifier=oai:alma.#{institution}:#{oai_set}&metadataPrefix=marc21&until=#{to_time}&from=#{ingest_time}"
+      )
+    end
+
     it 'returns the right string when full_index false and resumption token not present' do
-      qs = described_class.process_query_string(oai_set, full_index, to_time)
+      qs = described_class.process_query_string(oai_set, full_index, to_time, false)
 
       check_other_methods_called
       expect(qs).to eq(
@@ -22,7 +33,7 @@ RSpec.describe OaiQueryStringService, :clean do
     end
 
     it 'returns the right string when full_index true and resumption token not present' do
-      qs = described_class.process_query_string(oai_set, true, to_time)
+      qs = described_class.process_query_string(oai_set, true, to_time, false)
 
       check_other_methods_called
       expect(qs).to eq(
@@ -32,7 +43,7 @@ RSpec.describe OaiQueryStringService, :clean do
 
     it 'returns the right string when resumption token present' do
       PropertyBag.set('marc_ingest_resumption_token', 'Hello!')
-      qs = described_class.process_query_string(oai_set, full_index, to_time)
+      qs = described_class.process_query_string(oai_set, full_index, to_time, false)
 
       check_other_methods_called
       expect(qs).to eq("?verb=ListRecords&resumptionToken=Hello!")
@@ -51,6 +62,6 @@ RSpec.describe OaiQueryStringService, :clean do
 
   def check_other_methods_called
     expect(described_class).to respond_to(:process_from_time).with(1).argument
-    expect(described_class).to respond_to(:process_string).with(4).argument
+    expect(described_class).to respond_to(:process_string).with(5).argument
   end
 end


### PR DESCRIPTION
- HARVESTING_ALMA_DATA.md: updates instructions on how to index one record locally.
- app/services/oai_query_string_service.rb: updates a service to have the ability to re-index one record .
- lib/tasks/marc_index_ingester.rake: adds new parameters for one record re-indexing.
- spec/*: tests for the correct processing of the query string.