### PR TITLE
Fixes the redirects after login (#318).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ Metrics/BlockLength:
         - app/controllers/catalog_controller.rb
         - config/routes.rb
         - spec/controllers/catalog_controller_spec.rb
+        - spec/controllers/omniauth_callbacks_controller_spec.rb
         - spec/models/marc_indexing_spec.rb
         - spec/models/property_bag_spec.rb
         - spec/models/user_spec.rb

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -7,7 +7,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if @user.persisted?
       set_flash_message :notice, :success, kind: "Shibboleth"
       sign_in @user
-      redirect_to session[:requested_page] || request.env["omniauth.origin"] || root_path
+      redirect_to request.env["omniauth.origin"] || root_path
     else
       redirect_to root_path
       set_flash_message(:notice, :failure, kind: "Shibboleth", reason: "you aren't authorized to use this application.")

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,9 +5,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user.persisted?
+      set_flash_message :notice, :success, kind: "Shibboleth"
       sign_in @user
       redirect_to session[:requested_page] || request.env["omniauth.origin"] || root_path
-      set_flash_message :notice, :success, kind: "Shibboleth"
     else
       redirect_to root_path
       set_flash_message(:notice, :failure, kind: "Shibboleth", reason: "you aren't authorized to use this application.")

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,7 +5,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user.persisted?
-      sign_in_and_redirect @user
+      sign_in @user
+      redirect_to session[:requested_page] || request.env["omniauth.origin"] || root_path
       set_flash_message :notice, :success, kind: "Shibboleth"
     else
       redirect_to root_path

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def shibboleth
-    Rails.logger.debug "OmniauthCallbacksController#shibboleth: request.env['omniauth.auth']: #{request.env['omniauth.auth']}"
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user.persisted?

--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -3,6 +3,7 @@ class OmniauthController < Devise::SessionsController
   def new
     # Rails.logger.debug "SessionsController#new: request.referer = #{request.referer}"
     if Rails.env.production?
+      session[:requested_page] = request.url
       redirect_to user_shibboleth_omniauth_authorize_path
     else
       super

--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class OmniauthController < Devise::SessionsController
   def new
-    # Rails.logger.debug "SessionsController#new: request.referer = #{request.referer}"
     if Rails.env.production?
       session[:requested_page] = request.url
       redirect_to user_shibboleth_omniauth_authorize_path

--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -2,7 +2,6 @@
 class OmniauthController < Devise::SessionsController
   def new
     if Rails.env.production?
-      session[:requested_page] = request.url
       redirect_to user_shibboleth_omniauth_authorize_path
     else
       super

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe OmniauthCallbacksController do
+  before do
+    User.create(
+      provider: 'shibboleth',
+      uid: 'brianbboys1967',
+      display_name: 'Brian Wilson'
+    )
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:shib]
+    post :shibboleth
+  end
+
+  OmniAuth.config.mock_auth[:shib] =
+    OmniAuth::AuthHash.new(
+      provider: 'shibboleth',
+      uid: "P0000001",
+      info: {
+        display_name: "Brian Wilson",
+        uid: 'brianbboys1967'
+      }
+    )
+
+  context "when both origin and requested_page are present" do
+    before do
+      request.env["omniauth.origin"] = '/example'
+      session[:requested_page] = '/example/1'
+      post :shibboleth
+    end
+
+    it "redirects to origin" do
+      expect(response.redirect_url).to eq 'http://test.host/example/1'
+    end
+  end
+
+  context "when requested_page is missing" do
+    before do
+      request.env["omniauth.origin"] = '/example'
+      post :shibboleth
+    end
+
+    it "redirects to origin" do
+      expect(response.redirect_url).to include 'http://test.host/example'
+    end
+  end
+
+  context "when both are missing" do
+    it "redirects to home" do
+      expect(response.redirect_url).to include 'http://test.host/'
+    end
+  end
+end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -23,30 +23,18 @@ RSpec.describe OmniauthCallbacksController do
       }
     )
 
-  context "when both origin and requested_page are present" do
-    before do
-      request.env["omniauth.origin"] = '/example'
-      session[:requested_page] = '/example/1'
-      post :shibboleth
-    end
-
-    it "redirects to origin" do
-      expect(response.redirect_url).to eq 'http://test.host/example/1'
-    end
-  end
-
-  context "when requested_page is missing" do
+  context "when origin is present" do
     before do
       request.env["omniauth.origin"] = '/example'
       post :shibboleth
     end
 
     it "redirects to origin" do
-      expect(response.redirect_url).to include 'http://test.host/example'
+      expect(response.redirect_url).to eq 'http://test.host/example'
     end
   end
 
-  context "when both are missing" do
+  context "when origin is missing" do
     it "redirects to home" do
       expect(response.redirect_url).to include 'http://test.host/'
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Devise::Test::ControllerHelpers, type: :controller
 end


### PR DESCRIPTION
- .rubocop.yml: excludes the spec file from the rubo rules.
- app/controllers/omniauth_callbacks_controller.rb: redirects to page request was made from.
- app/controllers/omniauth_controller.rb: removes logger to increase security.
- spec/controllers/omniauth_callbacks_controller_spec.rb: adds testing for redirects.
- spec/rails_helper.rb: allows mocking of Shibboleth login.