### PR TITLE
Fixes bug of no results when using date slider on homepage (#319).

### DIFF
--- a/app/helpers/render_constraints_helper.rb
+++ b/app/helpers/render_constraints_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module RenderConstraintsHelper
+  def missing_constraint_url(field_name)
+    search_action_url(add_range_missing(field_name))
+  end
+
+  def missing_constraint_url_corrected(field_name)
+    missing_url = missing_constraint_url(field_name)
+    if missing_url.include?("&search_field=keyword")
+      missing_url
+    else
+      "#{missing_url}&search_field=keyword"
+    end
+  end
+end

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -1,0 +1,101 @@
+<% # [Blacklight Range Limit 7.4.0 overwrite] Include dummy search field if only date slider is used #L65-69 %>
+<% # Overwrite adapted from UCLA's Ursus %>
+
+<%- # requires solr_config local passed in
+  field_config = range_config(field_name)
+  label = facet_field_label(field_name)
+
+  input_label_range_begin = field_config[:input_label_range_begin] || t("blacklight.range_limit.range_begin", field_label: label)
+  input_label_range_end   = field_config[:input_label_range_end] || t("blacklight.range_limit.range_end", field_label: label)
+  maxlength = field_config[:maxlength]
+-%>
+
+<div class="limit_content range_limit">
+  <% if has_selected_range_limit?(field_name) %>
+    <ul class="current list-unstyled facet-values">
+      <li class="selected">
+        <span class="facet-label">
+          <span class="selected"><%= range_display(field_name) %></span>
+          <%= link_to search_action_url(remove_range_param(field_name).except(:controller, :action)), :class=>"remove", :title => t('blacklight.range_limit.remove_limit') do %>
+            <span class="remove-icon">✖</span>
+            <span class="sr-only">[<%= t('blacklight.range_limit.remove_limit') %>]</span>
+          <% end %>
+        </span>
+        <span class="selected facet-count"><%= number_with_delimiter(@response.total) %></span>
+      </li>
+    </ul>
+
+  <% end %>
+
+  <!-- no results profile if missing is selected -->
+  <% unless selected_missing_for_range_limit?(field_name) %>
+    <!-- you can hide this if you want, but it has to be on page if you want
+         JS slider and calculated facets to show up, JS sniffs it. -->
+    <div class="profile">
+        <% if stats_for_field?(field_name) %>
+          <!-- No stats information found for field  in search response -->
+        <% end %>
+
+        <% if (min = range_results_endpoint(field_name, :min)) &&
+              (max = range_results_endpoint(field_name, :max)) %>
+
+          <% if field_config[:segments] != false %>
+            <div class="distribution subsection <%= 'chart_js' unless field_config[:chart_js] == false %>">
+              <!-- if  we already fetched segments from solr, display them
+                   here. Otherwise, display a link to fetch them, which JS
+                   will AJAX fetch.  -->
+              <% if solr_range_queries_to_a(field_name).length > 0 %>
+
+                 <%= render(:partial => "blacklight_range_limit/range_segments", :locals => {:solr_field => field_name}) %>
+
+              <% else %>
+                <%= link_to(t('blacklight.range_limit.view_distribution'), range_limit_url(range_field: field_name, range_start: min, range_end: max), :class => "load_distribution") %>
+              <% end %>
+            </div>
+          <% end %>
+          <p class="range subsection <%= "slider_js" unless field_config[:slider_js] == false %>">
+            <%= t('blacklight.range_limit.results_range_html', min: range_results_endpoint(field_name, :min), max: range_results_endpoint(field_name, :max)) %>
+          </p>
+        <% end %>
+    </div>
+
+    <%= form_tag search_action_path, :method => :get, class: [BlacklightRangeLimit.classes[:form], "range_#{field_name} d-flex justify-content-center"].join(' ') do %>
+      <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:page)) %>
+
+      <!-- Include a dummy search_field parameter if none exists to trick blacklight
+           into displaying actual search results instead of home page. -->
+      <% unless params.has_key?(:search_field) %>
+        <%= hidden_field_tag("search_field", "keyword") %>
+      <% end %>
+
+      <%= content_tag :label, t('blacklight.range_limit.date_range_label'), class: 'range_limit_label sr-only' %>
+      <div class="input-group input-group-sm mb-3 flex-nowrap range-limit-input-group">
+        <%= render_range_input(field_name, :begin, input_label_range_begin, maxlength) %>
+        <%= render_range_input(field_name, :end, input_label_range_end, maxlength) %>
+        <div class="input-group-append">
+          <%= submit_tag t('blacklight.range_limit.submit_limit'), class: BlacklightRangeLimit.classes[:submit] %>
+        </div>
+      </div>
+    <% end %>
+
+    <%= link_to t('blacklight.range_limit.view_larger', field_name: label),
+        range_limit_panel_url(id: field_name),
+        class: 'view_larger mt-1',
+        data: { blacklight_modal: 'trigger' } %>
+
+    <% unless request.xhr? %>
+      <% if (stats = stats_for_field(field_name)) && stats["missing"] > 0 %>
+        <ul class="missing list-unstyled facet-values subsection">
+          <li>
+            <span class="facet-label">
+              <%= link_to t('blacklight.range_limit.missing'), missing_constraint_url_corrected(field_name) %>
+            </span>
+            <%# note important there be no whitespace inside facet-count to avoid
+                bug in some versions of Blacklight (including 7.1.0.alpha) %>
+            <span class="facet-count"><%= number_with_delimiter(stats["missing"]) %></span>
+          </li>
+        </ul>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/spec/support/shared_examples_for_facet_by_year.rb
+++ b/spec/support/shared_examples_for_facet_by_year.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'provides_constraint_on_next_page_unknown' do
+  it "provides a constraint on the next page" do
+    expect(page).to have_content('Remove constraint Publication/Creation Date: Unknown')
+    expect(page).not_to have_content('Llama Love')
+    expect(page).not_to have_content('Newt Nutrition')
+    expect(page).to have_content('Eagle Excellence')
+  end
+end
+
+RSpec.shared_examples 'gets_all_possible_documents' do
+  it "gets all available documents" do
+    expect(page).to have_content('Llama Love')
+    expect(page).to have_content('Newt Nutrition')
+    expect(page).to have_content('Eagle Excellence')
+  end
+end

--- a/spec/system/facet_by_year_spec.rb
+++ b/spec/system/facet_by_year_spec.rb
@@ -32,24 +32,55 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
     }
   end
 
-  it 'gets correct search results using year ranges' do
-    visit root_path
-    click_on 'search'
-
-    within '#documents' do
-      expect(page).to have_content('Llama Love')
-      expect(page).to have_content('Newt Nutrition')
-      expect(page).to have_content('Eagle Excellence')
+  context 'from search results page' do
+    before do
+      visit root_path
+      click_on 'search'
     end
 
-    find('input#range_pub_date_isi_begin').set('1920')
-    find('input#range_pub_date_isi_end').set('1925')
-    find("input[value$='Apply']").click
+    include_examples "gets_all_possible_documents"
 
-    within '#documents' do
-      expect(page).to     have_content('Llama Love')
-      expect(page).not_to have_content('Newt Nutrition')
-      expect(page).not_to have_content('Eagle Excellence')
+    it 'returns limited results when faceted' do
+      find('input#range_pub_date_isi_begin').set('1920')
+      find('input#range_pub_date_isi_end').set('1925')
+      find("input[value$='Apply']").click
+
+      within '#documents' do
+        expect(page).to     have_content('Llama Love')
+        expect(page).not_to have_content('Newt Nutrition')
+        expect(page).not_to have_content('Eagle Excellence')
+      end
+    end
+  end
+
+  context 'from homepage' do
+    before do
+      visit root_path
+      # Apply date facet with default parameters and make sure search results appear
+      find('input[value="Apply"]').click
+    end
+
+    include_examples "gets_all_possible_documents"
+  end
+
+  describe 'when "unknown" limiter is clicked' do
+    context 'on homepage' do
+      before do
+        visit root_path
+        click_on "Unknown"
+      end
+
+      include_examples "provides_constraint_on_next_page_unknown"
+    end
+
+    context 'on search results page' do
+      before do
+        visit root_path
+        click_on 'search'
+        click_on "Unknown"
+      end
+
+      include_examples "provides_constraint_on_next_page_unknown"
     end
   end
 end


### PR DESCRIPTION
- app/helpers/render_constraints_helper.rb: imports helpers used to correct bug on Lux.
- app/views/blacklight_range_limit/_range_limit_panel.html.erb: uses override of blacklight_range_limit's view pulled from Lux.
- spec/support/shared_examples_for_facet_by_year.rb: creates shared examples for repeated testing.
- spec/system/facet_by_year_spec.rb: adds tests to make sure that date_slider and `Unknown` work as expected from the homepage.