### PR TITLE
Maps subject_display_ssim with customized logic (#306).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,6 @@ Metrics/AbcSize:
     Exclude:
         - 'app/services/oai_processing_service.rb'
         - 'app/services/oai_processing_single_service.rb'
-        - 'lib/tasks/sample_scheduler.rake'
 
 Metrics/BlockLength:
     Exclude:
@@ -44,7 +43,6 @@ Metrics/MethodLength:
     Exclude:
         - 'app/services/oai_processing_service.rb'
         - 'app/services/oai_processing_single_service.rb'
-        - 'lib/tasks/sample_scheduler.rake'
 
 Metrics/PerceivedComplexity:
     Exclude:

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -34,6 +34,7 @@ require 'traject/extract_library'
 require 'traject/extract_marc_resource'
 require 'traject/extract_publication_main_display'
 require 'traject/extract_publisher_details_display'
+require 'traject/extract_subject_display'
 require 'traject/extract_title_details_display'
 require 'traject/extract_title_main_display'
 require 'traject/extract_url_fulltext'
@@ -50,16 +51,18 @@ extend ExtractLibrary
 extend ExtractMarcResource
 extend ExtractPublicationMainDisplay
 extend ExtractPublisherDetailsDisplay
+extend ExtractSubjectDisplay
 extend ExtractTitleDetailsDisplay
 extend ExtractTitleMainDisplay
 extend ExtractUrlFulltext
 extend ExtractUrlSuppl
 
 # Variables used throughout indexing
-ATOZ = ('a'..'z').to_a.join('')
-ATOU = ('a'..'u').to_a.join('')
-ATOG = ('a'..'g').to_a.join('')
-KTOS = ('k'..'s').to_a.join('')
+ATOZ = ('a'..'z').to_a.join('').freeze
+ATOU = ('a'..'u').to_a.join('').freeze
+ATOG = ('a'..'g').to_a.join('').freeze
+KTOS = ('k'..'s').to_a.join('').freeze
+VTOZ = ('v'..'z').to_a.join('').freeze
 
 settings do
   # type may be 'binary', 'xml', or 'json'
@@ -146,6 +149,7 @@ to_field 'author_vern_ssim', extract_marc("100abcdq:110#{ATOZ}:111#{ATOZ}", alte
 
 # Subject Fields
 to_field 'subject_addl_tsim', extract_marc("600vwxyz:610vwxyz:611vwxyz:630vwxyz:650vwxyz:651vwxyz:654vwxyz:655vwxyz")
+to_field 'subject_display_ssim', extract_subject_display(ATOZ, ATOG, VTOZ)
 to_field 'subject_era_ssim',  extract_marc("650y:651y:654y:655y"), trim_punctuation
 to_field 'subject_geo_ssim',  extract_marc("651a:650z"), trim_punctuation
 to_field 'subject_ssim', extract_marc("600abcdq:610ab:611adc:630aa:650aa:653aa:654a"), trim_punctuation

--- a/lib/traject/extract_subject_display.rb
+++ b/lib/traject/extract_subject_display.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'traject/extraction_tools'
+extend ExtractionTools
+
+module ExtractSubjectDisplay
+  def extract_subject_display(atoz, atog, vtoz)
+    lambda do |rec, acc|
+      ret_array = []
+      dfs_to_process = [
+        "600#{atoz}", "610#{atoz}", "611#{atoz}", "630#{atoz}", "650#{atog}#{vtoz}",
+        "651aeg#{vtoz}"
+      ]
+
+      eliminate_datafields(dfs_to_process, rec)
+      dfs_to_process.each { |df| ret_array << marc21.extract_marc_from(rec, df) }
+      ret_array.compact.flatten.each { |v| acc << v }
+    end
+  end
+
+  def rules_for_exclusion?(record, field_number)
+    record.fields(field_number).any? { |f| f.indicator2 == "4" || any_subfield_fast?(f) }
+  end
+
+  def any_subfield_fast?(field)
+    field.subfields.any? { |sf| sf.code == '2' && sf.value == "fast" }
+  end
+
+  def eliminate_datafields(dfs_to_process, record)
+    dfs_to_process.each do |df|
+      field_number = df.to_i.to_s
+
+      dfs_to_process.delete(df) if rules_for_exclusion?(record, field_number)
+    end
+  end
+end

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -167,4 +167,31 @@ RSpec.describe 'Indexing fields with custom logic' do
       expect(solr_doc_4['collection_ssim']).to be_nil
     end
   end
+
+  describe 'subject_display_ssim field' do
+    let(:solr_doc) { SolrDocument.find('9937264718202486') }
+    let(:excluded_elements) do
+      [
+        "Population density Yemen (Republic) Maps", "Ethnic groups Yemen (Republic) Maps",
+        "Tribes Yemen (Republic) Maps", "Ethnology Yemen (Republic) Maps", "Rain and rainfall Yemen (Republic) Maps",
+        "Land use Yemen (Republic) Maps", "Economic history", "Ethnic groups", "Ethnology",
+        "Population", "Population density", "Rain and rainfall", "Religion", "Tribes"
+      ]
+    end
+    let(:included_elements) do
+      [
+        "Yemen (Republic) Maps.", "Yemen (Republic) Population Maps.",
+        "Yemen (Republic) Economic conditions Maps.", "Yemen (Republic) Religion Maps.",
+        "Yemen (Republic)"
+      ]
+    end
+
+    it 'removes datafields with indicator_2 = 4 or subfields with code = 2 and value - fast' do
+      expect(solr_doc['subject_display_ssim']).not_to include(excluded_elements)
+    end
+
+    it 'keeps the rest' do
+      expect(solr_doc['subject_display_ssim']).to match_array(included_elements)
+    end
+  end
 end


### PR DESCRIPTION
- .rubocop.yml: eliminates the solr marc rake task no longer used.
- lib/marc_indexer.rb: inserts new field, plus connections to its mapping logic.
- lib/traject/extract_subject_display.rb: creates the mapping logic.
- spec/models/marc_indexing_spec.rb: tests expectations for new field.