### PR TITLE
Corrects bug created by not fully understanding extract_marc method (#314).

### DIFF
--- a/lib/traject/extract_author_addl_display.rb
+++ b/lib/traject/extract_author_addl_display.rb
@@ -20,11 +20,9 @@ module ExtractAuthorAddlDisplay
 
   def build_ret_strings(record, field_num, text_fields, relator_field, ret_values)
     record.fields(field_num).each do |f|
-      build_str = marc21.trim_punctuation(
-        text_fields.map do |t|
-          f.subfields.map { |sf| sf.value if sf.code == t }.compact.flatten
-        end.compact.flatten.join(' ')
-      )
+      build_arr = []
+      f.subfields.each { |sf| build_arr << sf.value if text_fields.any? { |tf| tf == sf.code } }.join(' ')
+      build_str = marc21.trim_punctuation(build_arr.join(' '))
       build_str += " relator: #{f[relator_field]}" if f[relator_field].present?
       ret_values << build_str
     end

--- a/lib/traject/extract_publisher_details_display.rb
+++ b/lib/traject/extract_publisher_details_display.rb
@@ -7,10 +7,10 @@ module ExtractPublisherDetailsDisplay
     lambda do |rec, acc|
       extra_fields = []
       ['260b', '264b', '260a', '264a'].each do |f|
-        extra_fields << extract_join_remove(rec, f)
+        extra_fields << marc21.extract_marc_from(rec, f)
       end
       extra_fields << marc21.extract_marc_from(rec, '008[15-17]')
-      acc << extra_fields.flatten.join(' ')
+      acc << extra_fields.compact.flatten.join(' ')
     end
   end
 end

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Indexing fields with custom logic' do
     let(:solr_doc) { SolrDocument.find('9937264718202486') }
 
     it 'maps 260, 264, and 008 fields' do
-      expect(solr_doc['publisher_details_display_ssim']).to eq([" Central Intelligence Agency,  Washington, D.C. xx#"])
+      expect(solr_doc['publisher_details_display_ssim']).to eq(["[Central Intelligence Agency], [Washington, D.C.] : xx#"])
     end
   end
 


### PR DESCRIPTION
- lib/traject/extract_author_addl_display.rb: mimics `extract_marc` method behavior, which iterates over the subfields in the order they appear in the MARC. It was assumed that if we passed `710acb` to the method, it would build a string with the value of "c" after "a"--not so. The letters will act as a pool of subfield codes to test against, which means if the order that the subfields appear is "a", then "b", then "c", it will follow that same order in the retuned string. If we want to restrict the values to a certain order, we have to use the structure I had to alter.
- lib/traject/extract_publisher_details_display.rb: eliminates spacing issues in the values.