### PR TITLE
Adds trim_punctuation to author_ssim and collection_ssim (#357).

### DIFF
--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -158,7 +158,7 @@ to_field 'author_addl_ssim', extract_marc("700abcdgqt:710abcdgn:711acdegnqe", al
 to_field 'author_display_ssim', extract_marc("100abcdgqe:110abcdgne:111acdegjnqj", alternate_script: false), trim_punctuation
 # JSTOR isn't an author. Try to not use it as one
 to_field 'author_si', marc_sortable_author
-to_field 'author_ssim', extract_marc("100abcdq:110abd:111acd:700abcdq:710abd:711acd")
+to_field 'author_ssim', extract_marc("100abcdq:110abd:111acd:700abcdq:710abd:711acd"), trim_punctuation
 to_field 'author_ssm', extract_marc("100abcdq:110#{ATOZ}:111#{ATOZ}", alternate_script: false)
 to_field 'author_tesim', extract_marc("100abcegqu:110abcdegnu:111acdegjnqu")
 to_field 'author_vern_ssim', extract_marc("100abcdgqe:110abcdgne:111acdegjnqj", alternate_script: :only), trim_punctuation

--- a/lib/traject/extract_collection.rb
+++ b/lib/traject/extract_collection.rb
@@ -9,7 +9,7 @@ module ExtractCollection
 
       needed_subf_values(rec).each { |v| ret_values << v } unless needed_subf_values(rec).empty?
       pulled_490a_values(rec).each { |v| ret_values << v } if ret_values.empty?
-      ret_values.each { |v| acc << v }
+      ret_values.each { |v| acc << marc21.trim_punctuation(v) }
     end
   end
 

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'Indexing fields with custom logic' do
     end
 
     it 'maps 490a when exact 710(s) are not found' do
-      expect(solr_doc_2['collection_ssim']).to eq(['Open-file report ;'])
+      expect(solr_doc_2['collection_ssim']).to eq(['Open-file report'])
     end
 
     it 'maps 490a when it is the only field available' do


### PR DESCRIPTION
- lib/marc_indexer.rb: tacks on `trim_punctuation` to `author_ssim`.
- lib/traject/extract_collection.rb: calls same method the custom collection method.
- spec/models/marc_indexing_spec.rb: changes the expectation for the custom method response.