### PR TITLE
Converts Genre field to facet search hyperlink (#369).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -143,7 +143,7 @@ class CatalogController < ApplicationController
       label: 'Additional Author/Creators',
       helper_method: :author_additional_format)
     #   Subjects/Genre Section
-    config.add_show_field 'genre_ssim', label: 'Genre', helper_method: :multiple_values_new_line
+    config.add_show_field 'genre_ssim', label: 'Genre', helper_method: :multilined_links_to_facet
     config.add_show_field 'subject_display_ssim', label: 'Subjects', helper_method: :multilined_links_to_facet
     #   Description/Summary Section
     config.add_show_field 'finding_aid_url_ssim', label: 'Finding Aid', helper_method: :generic_solr_value_to_url

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -195,7 +195,7 @@ to_field 'subject_ssim', extract_marc("600abcdq:610ab:611adc:630aa:650aa:653aa:6
 to_field 'subject_tsim', extract_marc(subject_tsim_str(ATOU))
 
 # Genre Fields
-to_field 'genre_ssim', extract_marc("655a")
+to_field 'genre_ssim', extract_marc("655a"), trim_punctuation
 
 # Publication Fields
 to_field 'note_publication_dates_tesim', extract_marc('362a')

--- a/lib/traject/extract_subject_display.rb
+++ b/lib/traject/extract_subject_display.rb
@@ -12,7 +12,7 @@ module ExtractSubjectDisplay
 
       dfs_to_process.each do |df|
         rec.fields(df.to_i.to_s).find_all do |f|
-          acc << accumulate_values(df, f) unless f.indicator2 == "4" || any_subfield_fast?(f)
+          acc << marc21.trim_punctuation(accumulate_values(df, f)) unless f.indicator2 == "4" || any_subfield_fast?(f)
         end
       end
       acc

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -182,10 +182,10 @@ RSpec.describe 'Indexing fields with custom logic' do
     end
     let(:included_elements) do
       [
-        "Population density--Yemen (Republic)--Maps.", "Ethnic groups--Yemen (Republic)--Maps.",
-        "Tribes--Yemen (Republic)--Maps.", "Ethnology--Yemen (Republic)--Maps.", "Rain and rainfall--Yemen (Republic)--Maps.",
-        "Land use--Yemen (Republic)--Maps.", "Yemen (Republic)--Maps.", "Yemen (Republic)--Population--Maps.",
-        "Yemen (Republic)--Economic conditions--Maps.", "Yemen (Republic)--Religion--Maps."
+        "Population density--Yemen (Republic)--Maps", "Ethnic groups--Yemen (Republic)--Maps",
+        "Tribes--Yemen (Republic)--Maps", "Ethnology--Yemen (Republic)--Maps", "Rain and rainfall--Yemen (Republic)--Maps",
+        "Land use--Yemen (Republic)--Maps", "Yemen (Republic)--Maps", "Yemen (Republic)--Population--Maps",
+        "Yemen (Republic)--Economic conditions--Maps", "Yemen (Republic)--Religion--Maps"
       ]
     end
 


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: swaps out the helper method to the facet search link method.
- lib/marc_indexer.rb and lib/traject/extract_subject_display.rb: trims both string for punctuation.
- spec/models/marc_indexing_spec.rb: resets expectations without punctuation.