### PR TITLE
Adjusts column widths on metadata fields for the show page (#377)

### DIFF
--- a/app/views/catalog/_metadata_block.html.erb
+++ b/app/views/catalog/_metadata_block.html.erb
@@ -5,8 +5,8 @@
   <br>
   <dl class="row dl-invert document-metadata">
     <% fields.each do |field_name, field| %>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-9<%= " truncate" if blacklight_config.truncate_field_values.include? field_name %>"><%= doc_presenter.field_value field %></dd>
+      <dt class="blacklight-<%= field_name.parameterize %> col-md-4"><%= render_document_show_field_label document, field: field_name %></dt>
+      <dd class="blacklight-<%= field_name.parameterize %> col-md-8<%= " truncate" if blacklight_config.truncate_field_values.include? field_name %>"><%= doc_presenter.field_value field %></dd>
     <% end %>
   </dl>
 <% end %>

--- a/app/views/catalog/_metadata_line.html.erb
+++ b/app/views/catalog/_metadata_line.html.erb
@@ -1,2 +1,2 @@
-<dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>
-<dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
+<dt class="blacklight-<%= field_name.parameterize %> col-md-4"><%= render_document_show_field_label document, field: field_name %></dt>
+<dd class="blacklight-<%= field_name.parameterize %> col-md-8"><%= doc_presenter.field_value field %></dd>

--- a/app/views/catalog/_url_display.html.erb
+++ b/app/views/catalog/_url_display.html.erb
@@ -3,8 +3,8 @@
   <dl class="row dl-invert document-metadata">
     <% fields.each do |field| %>
       <% parsed_field = JSON.parse(field) %>
-      <dt class='blacklight-<%= "#{t('catalog.show.url_fulltext_field')}".parameterize %> col-md-3'><%= render_document_show_field_label document, field: t('catalog.show.url_fulltext_field') %></dt>
-      <dd class='blacklight-<%= "#{t('catalog.show.url_fulltext_field')}".parameterize %> col-md-9'><%= link_to "#{parsed_field.values.first || parsed_field.keys.first}", "#{parsed_field.keys.first}" %></dd>
+      <dt class='blacklight-<%= "#{t('catalog.show.url_fulltext_field')}".parameterize %> col-md-4'><%= render_document_show_field_label document, field: t('catalog.show.url_fulltext_field') %></dt>
+      <dd class='blacklight-<%= "#{t('catalog.show.url_fulltext_field')}".parameterize %> col-md-8'><%= link_to "#{parsed_field.values.first || parsed_field.keys.first}", "#{parsed_field.keys.first}" %></dd>
     <% end %>
   </dl>
 <% end %>


### PR DESCRIPTION
This adjusts the column widths on the metadata field labels and content from ".col-3/.col-9" to ".col-4/.col-8"

- app/views/catalog/_metadata_block.html.erb
- app/views/catalog/_metadata_line.html.erb
- app/views/catalog/_url_display.html.erb