### PR TITLE
Removes Saved Searches Controller.

### DIFF
--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-class SavedSearchesController < ApplicationController
-  include Blacklight::SavedSearches
-
-  helper BlacklightAdvancedSearch::RenderConstraintsOverride
-end


### PR DESCRIPTION
Only added to mimic Penn State's setup, but they eventually removed it anyways.