### PR TITLE
Refines the show more Title and Authors collapse behavior (#388).

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -6,3 +6,4 @@
 @import 'blacklight_catalog/footer';
 @import 'blacklight_catalog/main';
 @import 'blacklight_catalog/body_html';
+@import 'blacklight_catalog/more_less';

--- a/app/assets/stylesheets/blacklight_catalog/_more_less.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_more_less.scss
@@ -1,0 +1,19 @@
+a.btn.btn-link.additional-authors-collapse.collapsed:after {
+    content: 'Show more Author/Creators';
+}
+
+a.btn.btn-link.additional-authors-collapse:not(.collapsed):after {
+    content: 'Show less Author/Creators';
+}
+
+a.additional-titles.btn.btn-link.additional-fields.collapsed:after {
+    content: 'Show more Title Information';
+}
+
+a.additional-titles.btn.btn-link.additional-fields:not(.collapsed):after {
+    content: 'Show less Title Information';
+}
+
+a.additional-titles.btn.btn-link.additional-fields {
+    margin-left: 1rem;
+}

--- a/app/helpers/show_page_helper.rb
+++ b/app/helpers/show_page_helper.rb
@@ -51,21 +51,21 @@ module ShowPageHelper
       ret_str = multilined_links_to_facet_author_addl(value[:values])
     else
       build_arr = [multilined_links_to_facet_author_addl(value[:values].first(5))]
-      build_arr.push(author_additional_collapse_link)
       build_arr.push(
         author_additional_collapse_span(
           multilined_links_to_facet_author_addl(value[:values][5..(value[:values].size - 1)])
         )
       )
+      build_arr.push(author_additional_collapse_link)
       ret_str = safe_join(build_arr, tag('br'))
     end
     ret_str
   end
 
   def author_additional_collapse_link
-    link_to(t('catalog.show.collapsible.additional_authors'),
+    link_to('',
           '#extended-author-addl',
-          class: 'btn btn-default additional-authors-collapse',
+          class: 'btn btn-link additional-authors-collapse collapsed',
           data: { toggle: 'collapse' },
           role: "button",
           'aria-expanded' => "false",

--- a/app/views/catalog/_metadata_block_collapsible.html.erb
+++ b/app/views/catalog/_metadata_block_collapsible.html.erb
@@ -11,18 +11,21 @@
       <% end %>
     <% end %>
   </dl>
-    <% if collapsible_fields.length > 0 %>
-      <%= link_to collapse_message,
-                      '#extended-terms',
-                      class: 'btn btn-default additional-fields',
-                      data: { toggle: 'collapse' },
-                      role: "button",
-                      'aria-expanded'=> "false",
-                      'aria-controls'=> "extended-terms" %>
-      <dl id="extended-terms" class='collapse row dl-invert collapsible-document-metadata'>
-        <% collapsible_fields.each do |field_name, field| %>
-          <%= render 'metadata_line', field_name: field_name, document: document, doc_presenter: doc_presenter, field: field %>
-        <% end %>
-      </dl>
-    <% end %>
+  <% if collapsible_fields.length > 0 %>
+    <dl id="extended-terms" class='collapse row dl-invert collapsible-document-metadata'>
+      <% collapsible_fields.each do |field_name, field| %>
+        <%= render 'metadata_line', field_name: field_name, document: document, doc_presenter: doc_presenter, field: field %>
+      <% end %>
+    </dl>
+    <div class="row">
+      <div class="col-md-4"></div>
+      <%= link_to '',
+            '#extended-terms',
+            class: "#{(collapse_link_class + " ") if collapse_link_class.present? }btn btn-link additional-fields collapsed",
+            data: { toggle: 'collapse' },
+            role: "button",
+            'aria-expanded'=> "false",
+            'aria-controls'=> "extended-terms" %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -3,7 +3,11 @@
 <% # New partial for request options %>
 <%= render :partial => 'show_request_options', :locals => {:document => document} %>
 <%= tag.h2 t('catalog.show.more_details_header'), class: "more-details-header" %><br/>
-<%= render 'metadata_block_collapsible', document: document, presenter: AddlTitlesPresenter, title: t('catalog.show.additional_title'), collapse_message: t('catalog.show.collapsible.additional_title') %>
+<%= render 'metadata_block_collapsible', 
+    document: document, 
+    presenter: AddlTitlesPresenter, 
+    title: t('catalog.show.additional_title'), 
+    collapse_link_class: 'additional-titles' %>
 <%= render 'metadata_block', document: document, presenter: RelatedNamesPresenter, title: t('catalog.show.related_names') %>
 <%= render 'metadata_block', document: document, presenter: SubjectsGenrePresenter, title: t('catalog.show.subjects_genre') %>
 <%= render 'metadata_block', document: document, presenter: DescriptionSummaryPresenter, title: t('catalog.show.description_summary') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,3 @@ en:
       addl_ids: "Additional Identifiers"
       find_it_header: "Where to find it"
       url_fulltext_field: "Full Text Access"
-      collapsible:
-        additional_title: "Show more Title Information"
-        additional_authors: "Show more Authors/Creators"

--- a/spec/helpers/show_page_helpers_spec.rb
+++ b/spec/helpers/show_page_helpers_spec.rb
@@ -112,16 +112,15 @@ RSpec.describe ShowPageHelper, type: :helper do
 
     it 'converts a values array with more than 5 items into a new-lined list with a collapsible after 5' do # rubocop:disable RSpec/ExampleLength
       expect(helper.author_additional_format(value_with_6_auth_addl)).to eq(
-        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Jenkins\">Tim Jenkins</a>, editor." \
-        "<br /><a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Sally+Jenkins\">Sally Jenkins</a><br />" \
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Jenkins\">Tim Jenkins</a>, editor.<br />" \
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Sally+Jenkins\">Sally Jenkins</a><br />" \
         "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Betsy+Jenkins\">Betsy Jenkins</a><br />" \
         "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Sal+Weitzman\">Sal Weitzman</a>, ghost writer.<br />" \
         "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Mike+Birbiglia\">Mike Birbiglia</a><br />" \
-        "<a class=\"btn btn-default additional-authors-collapse\" data-toggle=\"collapse\" role=\"button\" " \
-        "aria-expanded=\"false\" aria-controls=\"extended-author-addl\" href=\"#extended-author-addl\">" \
-        "Show more Authors/Creators</a><br /><span id=\"extended-author-addl\"" \
-        " class=\"collapse collapsible-addl-authors\"><a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Conway\">" \
-        "Tim Conway</a>, moral support.</span>"
+        "<span id=\"extended-author-addl\" class=\"collapse collapsible-addl-authors\">" \
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Conway\">Tim Conway</a>, moral support.</span><br />" \
+        "<a class=\"btn btn-link additional-authors-collapse collapsed\" data-toggle=\"collapse\"" \
+        " role=\"button\" aria-expanded=\"false\" aria-controls=\"extended-author-addl\" href=\"#extended-author-addl\"></a>"
       )
     end # rubocop:enable RSpec/ExampleLength
   end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
         )
         visit solr_document_path('123')
 
-        expect(page).to have_link 'Show more Authors/Creators'
+        expect(page).to have_link('', href: '#extended-author-addl')
         expect(page).to have_css('span', id: 'extended-author-addl')
         expect(find_all('span#extended-author-addl a').size).to eq(1)
       end


### PR DESCRIPTION
- app/assets/stylesheets/*: inserts the expected text after each collapse action.
- app/helpers/show_page_helper.rb: rearranges the order of where the collapse and overflow links live.
- app/views/catalog/_metadata_block_collapsible.html.erb: reworks block so that the collapse link sits on the bottom and the collapsed items on top of it.
- app/views/catalog/_show.html.erb: alters the partial call to excise the collapse message and add the ability to insert a class into the collapse link.
- config/locales/en.yml: removes the text now inserted via CSS from localization.
- spec/*: reworks expectations to handle new text locations and CSS-injected link text.