### PR TITLE
Implements the More Options section of the Show Page (#416).

### DIFF
--- a/app/helpers/more_options_helper.rb
+++ b/app/helpers/more_options_helper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module MoreOptionsHelper
+  MATERIAL_TYPE_PAGE_LINKS = {
+    'Musical Score': { 'Music and Scores': 'music-scores.html' },
+    'Map': { 'General Materials': 'index.html' },
+    'Video/Visual Material': [
+      { 'Films and Videos': 'film-videos/index.html' }, { 'Images': 'images.html' }
+    ],
+    'Sound Recording': { 'Music and Scores': 'music-scores.html' },
+    'Computer File': { 'General Materials': 'index.html' },
+    'Archival Material/Manuscripts': { 'Archives and Special Collections': 'archives-special-collections.html' },
+    'Journal, Newspaper or Serial': [
+      { 'Journals and Newspapers': 'journals-newspapers.html' }, { 'Articles': 'articles.html' }
+    ],
+    'Book': { 'Books': 'books.html' }
+  }.with_indifferent_access.freeze
+
+  def render_more_options_links(document)
+    link_el_hashes = document.more_options.map { |v| MATERIAL_TYPE_PAGE_LINKS[v] }.flatten
+    links = link_el_hashes.map do |h|
+      tag.li(
+        tag.a(t('catalog.show.find_more_info') + h.keys[0],
+          href: "https://libraries.emory.edu/materials/#{h.values[0]}",
+          target: '_blank',
+          rel: 'noopener noreferrer',
+          class: 'nav-link'),
+        class: "list-group-item more-options"
+      )
+    end
+    return safe_join(links, '') if links.present?
+    ''
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -40,4 +40,8 @@ class SolrDocument
   def url_fulltext
     self['url_fulltext_ssm']
   end
+
+  def more_options
+    self['format_ssim']
+  end
 end

--- a/app/views/catalog/_more_options.html.erb
+++ b/app/views/catalog/_more_options.html.erb
@@ -1,0 +1,6 @@
+<div class="card show-tools">
+  <div class="card-header"><h2 class="mb-0 h6"><%= t('catalog.show.more_options') %></h2></div>
+    <ul class="list-group list-group-flush">
+      <%= render_more_options_links(@document) %>
+    </ul>
+</div>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,0 +1,21 @@
+<%# Overrides partial of same name from blacklight (7.4.1) %>
+<%#
+  Inserts a render partial call on line #19 that populates the 
+  More Options sections.
+%>
+<%= render 'show_tools' %>
+
+<% unless document.more_like_this.empty? %>
+  <div class="card">
+    <div class="card-header">More Like This</div>
+    <div class="card-body">
+      <%= render collection: document.more_like_this,
+                 partial: 'show_more_like_this',
+                 as: :document %>
+    </div>
+  </div>
+<% end %>
+
+<% if document.more_options.present? %>
+    <%= render 'more_options' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,3 +44,5 @@ en:
       addl_ids: "Additional Identifiers"
       find_it_header: "Where to find it"
       url_fulltext_field: "Full Text Access"
+      find_more_info: "Find more information about "
+      more_options: "More Options"

--- a/spec/helpers/more_options_helper_spec.rb
+++ b/spec/helpers/more_options_helper_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe MoreOptionsHelper, type: :helper do
+  before do
+    delete_all_documents_from_solr
+    build_solr_docs(
+      [
+        TEST_ITEM,
+        TEST_ITEM.dup.merge(
+          id: '456',
+          format_ssim: ['Musical Score', 'Book']
+        )
+      ]
+    )
+  end
+  let(:links_hash) do
+    {
+      "Musical Score" => { "Music and Scores" => "music-scores.html" },
+      "Map" => { "General Materials" => "index.html" },
+      "Video/Visual Material" => [
+        { "Films and Videos" => "film-videos/index.html" },
+        { "Images" => "images.html" }
+      ],
+      "Sound Recording" => { "Music and Scores" => "music-scores.html" },
+      "Computer File" => { "General Materials" => "index.html" },
+      "Archival Material/Manuscripts" => { "Archives and Special Collections" => "archives-special-collections.html" },
+      "Journal, Newspaper or Serial" => [
+        { "Journals and Newspapers" => "journals-newspapers.html" },
+        { "Articles" => "articles.html" }
+      ],
+      "Book" => { "Books" => "books.html" }
+    }
+  end
+  let(:solr_doc) { SolrDocument.find(TEST_ITEM[:id]) }
+  let(:solr_doc2) { SolrDocument.find('456') }
+  let(:expected_single_valued_string) do
+    "<li class=\"list-group-item more-options\"><a href=\"https://libraries.emory.edu/materials/books.html\" " \
+      "target=\"_blank\" rel=\"noopener noreferrer\" class=\"nav-link\">Find more information about Books</a></li>"
+  end
+  let(:expected_multivalued_string) do
+    "<li class=\"list-group-item more-options\"><a href=\"https://libraries.emory.edu/materials/music-scores.html\" " \
+      "target=\"_blank\" rel=\"noopener noreferrer\" class=\"nav-link\">Find more information about Music and Scores</a>" \
+      "</li><li class=\"list-group-item more-options\"><a href=\"https://libraries.emory.edu/materials/books.html\" " \
+      "target=\"_blank\" rel=\"noopener noreferrer\" class=\"nav-link\">Find more information about Books</a></li>"
+  end
+
+  it 'holds a global hash variable used for mapping' do
+    expect(MoreOptionsHelper::MATERIAL_TYPE_PAGE_LINKS).to eq links_hash
+  end
+
+  context '#render_more_options_links' do
+    it 'returns a single link wrapped in a list item tag when format_ssim has a single value' do
+      expect(helper.render_more_options_links(solr_doc)).to eq(expected_single_valued_string)
+    end
+
+    it 'returns a two links wrapped in their own list item tags when format_ssim has two values' do
+      expect(helper.render_more_options_links(solr_doc2)).to eq(expected_multivalued_string)
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -16,4 +16,10 @@ RSpec.describe SolrDocument do
       expect(solr_doc.combined_author_display_vern).to eq ['George Jenkins', 'G. Jenkins']
     end
   end
+
+  context '#more_options' do
+    it 'pulls the format_ssim value' do
+      expect(solr_doc.more_options).to eq solr_doc['format_ssim']
+    end
+  end
 end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
           )
         )
       )
-      visit solr_document_path('123')
+      visit solr_document_path(id)
 
       expect(page).to have_link('Librarian View')
     end
@@ -133,7 +133,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
             author_addl_display_tesim: ["Tim Jenkins relator: editor."]
           )
         )
-        visit solr_document_path('123')
+        visit solr_document_path(id)
 
         expect(find('dd.blacklight-author_addl_display_tesim').text).to eq("Tim Jenkins, editor.")
         expect(find('dd.blacklight-author_addl_display_tesim a').text).to eq("Tim Jenkins")
@@ -154,7 +154,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
             author_addl_display_tesim: ["Tina", "Lisa", "Courtney", "Tim", "Bob", "Jeff"]
           )
         )
-        visit solr_document_path('123')
+        visit solr_document_path(id)
 
         expect(page).to have_link('', href: '#extended-author-addl')
         expect(page).to have_css('span', id: 'extended-author-addl')
@@ -181,7 +181,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
           build_solr_docs(
             TEST_ITEM.except(:subject_display_ssim)
           )
-          visit solr_document_path('123')
+          visit solr_document_path(id)
         end
 
         it 'does not show subject label when subject display is missing' do
@@ -195,7 +195,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
           build_solr_docs(
             TEST_ITEM.except(:genre_ssim)
           )
-          visit solr_document_path('123')
+          visit solr_document_path(id)
         end
 
         it 'does not show genre label when genre display is missing' do
@@ -209,12 +209,35 @@ RSpec.describe "View a item's show page", type: :system, js: true do
           build_solr_docs(
             TEST_ITEM.except(:genre_ssim, :subject_display_ssim)
           )
-          visit solr_document_path('123')
+          visit solr_document_path(id)
         end
 
         it 'does not show genre/subject or main heading label when genre and subject display are missing' do
           expect(page).not_to have_css('h4', class: 'blacklight-Subjects/Genre')
         end
+      end
+    end
+  end
+
+  context 'More Options card' do
+    it 'shows the section when format_ssim populated' do
+      visit solr_document_path(id)
+
+      expect(page).to have_css('h2', text: 'More Options')
+      expect(page).to have_link('Find more information about Books')
+    end
+
+    context 'format_ssim is missing' do
+      before do
+        build_solr_docs(
+          TEST_ITEM.except(:format_ssim)
+        )
+        visit solr_document_path(id)
+      end
+
+      it 'does not show the section' do
+        expect(page).not_to have_css('h2', text: 'More Options')
+        expect(page).not_to have_link('Find more information about Books')
       end
     end
   end


### PR DESCRIPTION
- app/helpers/more_options_helper.rb: creates a helper to populate the section with the desired links.
- app/models/solr_document.rb: appoints a SolrDocumnet instance method to pull the format_ssim values.
- app/views/catalog/_more_options.html.erb: institutes a partial that stubs the new section.
- app/views/catalog/_show_sidebar.html.erb: overrides the blacklight partial to include the new section.
- config/locales/en.yml: includes the verbiage used in the localizations.
- spec/*: tests and stubs outs expectations for the section.