### PR TITLE
Modifies adv search form

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -7,3 +7,4 @@
 @import 'blacklight_catalog/main';
 @import 'blacklight_catalog/body_html';
 @import 'blacklight_catalog/more_less';
+@import 'blacklight_catalog/advanced_search_form';

--- a/app/assets/stylesheets/blacklight_catalog/_advanced_search_form.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_advanced_search_form.scss
@@ -1,0 +1,18 @@
+.advanced-search-field, .advanced-search-facet {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+.control-label-date {
+  margin-left: -30px;
+}
+.range_limit {
+  margin-left: -5px;
+}
+.container-fluid {
+  float: right;
+}
+select#sort.form-control.sort-select {
+  width: 100%;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -13,9 +13,7 @@ class CatalogController < ApplicationController
     config.advanced_search[:query_parser] ||= 'dismax'
     config.advanced_search[:form_solr_parameters] ||= {
       'facet.field' => [
-        "marc_resource_ssim", "library_ssim", "format_ssim", "language_ssim", "author_ssim",
-        "subject_ssim", "collection_ssim", "lc_1letter_ssim", "subject_geo_ssim",
-        "subject_era_ssim", "genre_ssim"
+        "marc_resource_ssim", "library_ssim", "format_ssim", "language_ssim", "collection_ssim"
       ]
     }
     config.advanced_search[:form_facet_partial] ||= 'advanced_search_facets_as_select'
@@ -255,12 +253,27 @@ class CatalogController < ApplicationController
       'title_former_tesim', 'title_graphic_tesim', 'title_host_item_tesim', 'title_key_tesi',
       'title_series_ssim', 'title_translation_tesim', 'title_varying_tesim'
     ]
+    title_advanced_fields = [
+      'title_addl_tesim', 'title_added_entry_tesim', 'title_abbr_tesim', 'title_former_tesim',
+      'title_later_ssim', 'title_host_item_tesim', 'title_translation_tesim', 'title_varying_tesim'
+    ]
+    author_advanced_fields = [
+      'author_addl_tesim', 'author_tesim'
+    ]
+    subject_advanced_fields = [
+      'subject_tsim', 'subject_display_ssim'
+    ]
+    identifier_advanced_fields = [
+      'isbn_ssim', 'issn_ssim', 'oclc_ssim', 'other_standard_ids_ssim', 'lccn_ssim', 'id',
+      'publisher_number_ssim'
+    ]
 
     # This one uses all the defaults set by the solr request handler. Which
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
 
     config.add_search_field('keyword', label: 'Keyword') do |field|
+      field.include_in_advanced_search = false
       field.solr_parameters = {
         qf: 'text_tesi id',
         pf: ''
@@ -272,6 +285,7 @@ class CatalogController < ApplicationController
     # of Solr search fields.
 
     config.add_search_field('title', label: 'Title') do |field|
+      field.include_in_advanced_search = false
       # solr_parameters hash are sent to Solr as ordinary url query params.
       field.solr_parameters = {
         'spellcheck.dictionary': 'title',
@@ -281,6 +295,7 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('author', label: 'Author/Creator') do |field|
+      field.include_in_advanced_search = false
       field.solr_parameters = {
         'spellcheck.dictionary': 'author',
         qf: author_fields.join(' '),
@@ -292,8 +307,73 @@ class CatalogController < ApplicationController
     # Uniform Title, Named Event, Chronological Term, Topical Term, Geographic Name,
     # Uncontrolled, Faceted Topical Terms, and Genre/Form into an array.
     config.add_search_field('subject', label: 'Subjects') do |field|
+      field.include_in_advanced_search = false
       field.solr_parameters = {
         qf: 'subject_tsim',
+        pf: ''
+      }
+    end
+
+    config.add_search_field('all_fields_advanced', label: 'All Fields') do |field|
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: 'text_tesi',
+        pf: ''
+      }
+    end
+
+    config.add_search_field('title_advanced', label: 'Title') do |field|
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: title_advanced_fields.join(' '),
+        pf: ''
+      }
+    end
+
+    config.add_search_field('author_advanced', label: 'Author/Creator') do |field|
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: author_advanced_fields.join(' '),
+        pf: ''
+      }
+    end
+
+    config.add_search_field('subject_advanced', label: 'Subject') do |field|
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: subject_advanced_fields.join(' '),
+        pf: ''
+      }
+    end
+
+    config.add_search_field('title_series_advanced', label: 'Series Title') do |field|
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: 'title_series_tesim',
+        pf: ''
+      }
+    end
+
+    config.add_search_field('publisher_advanced', label: 'Publisher') do |field|
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: 'published_ssm',
+        pf: ''
+      }
+    end
+
+    config.add_search_field('identifier_advanced', label: 'Identifiers (ISBN, ISSN, DOI, Other)') do |field|
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: identifier_advanced_fields.join(' '),
+        pf: ''
+      }
+    end
+
+    config.add_search_field('call_number_advanced', label: 'Local Call Number') do |field|
+      field.include_in_simple_select = false
+      field.solr_parameters = {
+        qf: 'local_call_number_tesim',
         pf: ''
       }
     end

--- a/app/views/advanced/_advanced_search_facets_as_select.html.erb
+++ b/app/views/advanced/_advanced_search_facets_as_select.html.erb
@@ -33,7 +33,7 @@
 <%# Publication Date is a range input %>
 <% pub_date = facet_configuration_for_field('pub_date_isim') %>
 <div class="form-group advanced-search-facet row">
-  <%= label_tag pub_date.field.parameterize, class: 'col-sm-4 control-label' do %>
+  <%= label_tag pub_date.field.parameterize, class: 'col-sm-3 control-label-date' do %>
     <%= pub_date.label %>
   <% end %>
   <div class="col-sm-8 range_limit">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,3 +46,9 @@ en:
       url_fulltext_field: "Full Text Access"
       find_more_info: "Find more information about "
       more_options: "More Options"
+  blacklight_advanced_search:
+    form:
+      title: 'Advanced Search'
+      sort_label: 'Sort by'
+      search_btn: 'Advanced Search'
+      start_over: 'Clear Form'

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -34,6 +34,7 @@ require 'traject/extract_finding_aid_url'
 require 'traject/extract_format_string'
 require 'traject/extract_isbn'
 require 'traject/extract_other_standard_ids'
+require 'traject/extract_call_number'
 require 'traject/extract_library'
 require 'traject/extract_marc_resource'
 require 'traject/extract_publication_main_display.rb'
@@ -56,6 +57,7 @@ extend ExtractFindingAidUrl
 extend ExtractFormatString
 extend ExtractIsbn
 extend ExtractOtherStandardIds
+extend ExtractCallNumber
 extend ExtractLibrary
 extend ExtractMarcResource
 extend ExtractPublicationMainDisplay
@@ -146,6 +148,7 @@ to_field 'issn_ssim', extract_marc('022ay:800x:810x:811x:830x')
 to_field 'lccn_ssim', extract_marc('010a')
 to_field 'oclc_ssim', oclcnum('019a:035a')
 to_field 'other_standard_ids_ssim', extract_other_standard_ids
+to_field 'local_call_number_tesim', extract_call_number
 
 # Title Fields
 #    Primary Title
@@ -173,7 +176,8 @@ to_field 'title_host_item_tesim', extract_marc("773#{ATOZ}:774#{ATOZ}")
 to_field 'title_key_tesi', extract_marc('222ab'), first_only
 to_field 'title_later_ssim', extract_marc('785abcdgikmnorstuxyz')
 to_field 'title_main_display_tesim', extract_marc('245abfgknps', alternate_script: false), trim_punctuation
-to_field 'title_series_ssim', extract_marc(title_series_ssim_str(ATOG))
+to_field 'title_series_ssim', extract_marc(title_series_str(ATOG))
+to_field 'title_series_tesim', extract_marc(title_series_str(ATOG))
 to_field 'title_ssort', marc_sortable_title
 to_field 'title_translation_tesim', extract_marc("242#{ATOZ}")
 to_field 'title_uniform_ssim', extract_marc("130adfklmnoprs:240#{ATOG}knps")
@@ -205,7 +209,7 @@ to_field 'genre_ssim', extract_marc("655a"), trim_punctuation
 to_field 'note_publication_dates_tesim', extract_marc('362a')
 to_field 'pub_date_isim', extract_publication_date
 to_field 'publication_main_display_ssim', extract_publication_main_display
-to_field 'published_ssim', extract_marc('260a', alternate_script: false), trim_punctuation
+to_field 'published_ssm', extract_marc('260a:264b', alternate_script: false), trim_punctuation
 to_field 'published_vern_ssim', extract_marc('260a', alternate_script: :only), trim_punctuation
 to_field 'publisher_details_display_ssim', extract_publisher_details_display
 to_field 'publisher_location_ssim', extract_marc("260a:264a:008[15-17]"), trim_punctuation

--- a/lib/traject/extract_call_number.rb
+++ b/lib/traject/extract_call_number.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ExtractCallNumber
+  def extract_call_number
+    lambda do |rec, acc|
+      if rec['HOL852']
+        field = rec['HOL852']
+        ret_array = collect_subfields(field)
+        ret_array.each { |r| acc << field[r] }
+      end
+    end
+  end
+
+  private
+
+  def collect_subfields(field)
+    subfields_map = { '0' => ["h", "i"], '1' => ["h"], '2' => ["h"], '3' => ["h", "i"], '4' => ["c", "j"],
+                      '8' => ["b", "c", "j"] }
+    subfields_map[field.indicator1]
+  end
+end

--- a/lib/traject/extract_publication_main_display.rb
+++ b/lib/traject/extract_publication_main_display.rb
@@ -4,16 +4,18 @@ module ExtractPublicationMainDisplay
   def extract_publication_main_display
     lambda do |rec, acc|
       extra_fields = extract_ordered_fields(rec, '264abc:260abc:245fg:502abcdg')
-      selected_field = extra_fields.first.first
-      process_field = selected_field["245fg"] # get value of 245 field, because this may contain duplicates and will need processing
-      selected_field = if process_field
-                         # process 245 field value to remove duplicates
-                         process_field.include?(',') ? process_field.partition(', ').first : process_field.partition(' ').first
-                       else
-                         # if not 245 field, then use the value of key without processing (i.e. 264, 260, 502)
-                         selected_field.values.first
-                       end
-      acc << selected_field
+      unless extra_fields.flatten.empty?
+        selected_field = extra_fields.first&.first
+        process_field = selected_field["245fg"] # get value of 245 field, because this may contain duplicates and will need processing
+        selected_field = if process_field
+                           # process 245 field value to remove duplicates
+                           process_field.include?(',') ? process_field.partition(', ').first : process_field.partition(' ').first
+                         else
+                           # if not 245 field, then use the value of key without processing (i.e. 264, 260, 502)
+                           selected_field.values.first
+                         end
+        acc << selected_field
+      end
     end
   end
 end

--- a/lib/traject/extraction_tools.rb
+++ b/lib/traject/extraction_tools.rb
@@ -97,7 +97,7 @@ module ExtractionTools
     ].join(':').freeze
   end
 
-  def title_series_ssim_str(atog)
+  def title_series_str(atog)
     %W[
       440anpv:490av
       830#{atog}kv

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -67,7 +67,11 @@ RSpec.describe CatalogController, type: :controller do
   describe 'search fields' do
     let(:search_fields) { controller.blacklight_config.search_fields.keys }
     let(:expected_search_fields) { ['keyword', 'title', 'author', 'subject'] }
+    let(:expected_advanced_search_fields) do
+      ['all_fields_advanced', 'title_advanced', 'author_advanced', 'subject_advanced',
+       'publisher_advanced', 'title_series_advanced', 'identifier_advanced', 'call_number_advanced']
+    end
 
-    it { expect(search_fields).to contain_exactly(*expected_search_fields) }
+    it { expect(search_fields).to contain_exactly(*expected_search_fields + expected_advanced_search_fields) }
   end
 end

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -418,4 +418,12 @@ RSpec.describe 'Indexing fields with custom logic' do
       end
     end
   end
+
+  describe 'local_call_number_tesim field' do
+    let(:solr_doc) { SolrDocument.find('9937264718402486') }
+
+    it 'has correct value for call number' do
+      expect(solr_doc['local_call_number_tesim']).to eq([" RC451.4.G39 ", " N53 2021 "])
+    end
+  end
 end

--- a/spec/system/advanced_search_spec.rb
+++ b/spec/system/advanced_search_spec.rb
@@ -8,20 +8,20 @@ RSpec.feature 'Advanced Search Page', type: :system, js: false do
     visit '/advanced'
   end
 
-  let(:search_fields) { CatalogController.new.blacklight_config.search_fields.keys }
+  let(:search_fields) { CatalogController.new.blacklight_config.search_fields.reject { |_k, v| v.include_in_advanced_search == false }.keys }
   let(:pulled_search_fields) { find_all('div.form-group.advanced-search-field label').map { |e| e['for'] } }
-  let(:select_facet_fields) { CatalogController.new.blacklight_config.facet_fields.keys }
+  let(:select_facet_fields) { CatalogController.new.blacklight_config.advanced_search[:form_solr_parameters]["facet.field"] }
   let(:pulled_search_facets) { find_all('div.form-group.advanced-search-facet label').map { |e| e['for'] } }
-  let(:search_button) { find('input[type=submit][value=Search]') }
+  let(:search_button) { find("input[type=submit][value='Advanced Search']") }
   let(:document_title_heading) { 'h3.index_title.document-title-heading.col-sm-9.col-lg-10' }
 
   context 'expected elements' do
     it 'has the correct header' do
-      expect(page).to have_css('h1', text: 'More Search Options')
+      expect(page).to have_css('h1', text: 'Advanced Search')
     end
 
     it 'has the Start Over button' do
-      expect(page).to have_link('Start over', href: '/advanced')
+      expect(page).to have_link('Clear Form', href: '/advanced')
     end
 
     it 'has same options as the search bar' do
@@ -39,28 +39,28 @@ RSpec.feature 'Advanced Search Page', type: :system, js: false do
 
   context 'performing simple searches' do
     it 'finds the one object with a keyword search of item id' do
-      fill_in 'keyword', with: '123'
+      fill_in 'identifier_advanced', with: '123'
       search_button.click
 
       expect(page).to have_css(document_title_heading)
     end
 
     it 'finds the one object with a author search of additional first name' do
-      fill_in 'author', with: 'George'
+      fill_in 'author_advanced', with: 'George'
       search_button.click
 
       expect(page).to have_css(document_title_heading)
     end
 
     it 'finds the one object with a title search of variant title' do
-      fill_in 'title', with: 'Variant'
+      fill_in 'title_advanced', with: 'Variant'
       search_button.click
 
       expect(page).to have_css(document_title_heading)
     end
 
     it 'finds the one object with a subject search of the solr value' do
-      fill_in 'subject', with: 'sample'
+      fill_in 'subject_advanced', with: 'sample'
       search_button.click
 
       expect(page).to have_css(document_title_heading)


### PR DESCRIPTION
* This PR is related to #419 
* [Wireframe for adv search form](https://www.figma.com/file/ocSo3KytI6GgwjalSVAmE1/Blacklight-Wireframes?node-id=70%3A272)
* This commit modifies the advanced search form and fields that are being mapped to match requirements.

Advanced search form:
![image](https://user-images.githubusercontent.com/17075287/114600628-8f4f5080-9c62-11eb-8d5b-b31ce3ab588e.png)
