### PR TITLE
Overwrites partials from blacklight-adv-search to match styling requirements

### DIFF
--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -1,0 +1,41 @@
+<%# [Overwrite-Blacklight-Advanced-Search-v7.0.0] removes <hr> before sort and submit buttons %>
+  <% unless (search_context_str = render_search_to_s( advanced_search_context)).blank? %>
+    <div class="constraints well search_history">
+      <h4><%= t 'blacklight_advanced_search.form.search_context' %></h4>
+      <%= search_context_str %>
+    </div>
+  <% end %>
+
+<%= form_tag search_catalog_path, :class => 'advanced form-horizontal', :method => :get do  %>
+
+  <%= render_hash_as_hidden_fields(advanced_search_context) %>
+
+  <div class="input-criteria">
+
+      <div class="query-criteria">
+        <h3 class="query-criteria-heading">
+          <%= t('blacklight_advanced_search.form.query_criteria_heading_html', :select_menu =>  select_menu_for_field_operator ) %> 
+        </h3>
+
+        <div id="advanced_search">
+          <%= render 'advanced/advanced_search_fields' %>
+        </div>
+      </div>
+      
+      <div class="limit-criteria">
+        <h3 class="limit-criteria-heading"><%= t('blacklight_advanced_search.form.limit_criteria_heading_html')%></h3>
+
+        <div id="advanced_search_facets" class="limit_input">
+          <% if blacklight_config.try(:advanced_search).try {|h| h[:form_facet_partial] } %>
+            <%= render blacklight_config.advanced_search[:form_facet_partial] %>
+          <% else %>
+            <%= render 'advanced_search_facets' %>
+          <% end %>
+        </div>
+      </div>
+      <div class="container-fluid col-sm-9">
+        <%= render 'advanced_search_submit_btns' %>
+      </div>
+  </div>
+
+<% end %>

--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -1,0 +1,14 @@
+<%# [Overwrite-Blacklight-Advanced-Search-v7.0.0] moves sort by and submit buttons %>
+<div class="sort-buttons pull-left">
+  <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
+  <%- sort_fields = active_sort_fields.values.map { |field_config| [sort_field_label(field_config.key), field_config.key] } %>
+  <br>
+  <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select") %>
+  <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
+</div>
+<br>
+<div class="submit-buttons pull-right">
+  <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit" %>
+  <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-outline-secondary advanced-search-start-over" %>
+</div>
+<br>

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,0 +1,18 @@
+<%# [Overwrite-Blacklight-Advanced-Search-v7.0.0] removes start over button from page top %>
+<% @page_title = "More Search Options - #{application_name}" %>
+
+<div class="advanced-search-form col-sm-12">
+
+  <h1 class="advanced page-header">
+    <%= t('blacklight_advanced_search.form.title') %>
+  </h1>
+
+  <div class="row">
+    <div class="col-md-8">
+      <%= render 'advanced_search_form' %>
+    </div>
+    <div class="col-md-4">
+      <%= render "advanced_search_help" %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
* Connected to previous PR around adv-search; the files in this PR need to be overwritten for styling changes to take effect.
![image](https://user-images.githubusercontent.com/17075287/114629740-229a7d00-9c87-11eb-8a2b-1afd2168dbe3.png)
