### PR TITLE
Generates the correct APA 7th edition citation (#417).

### DIFF
--- a/config/initializers/prepends.rb
+++ b/config/initializers/prepends.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative '../prepends/custom_citation_logic'
+
+Blacklight::Solr::Document::MarcExport.prepend(CustomCitationLogic)

--- a/config/prepends/custom_citation_logic.rb
+++ b/config/prepends/custom_citation_logic.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module CustomCitationLogic
+  # Overrides Blacklight::Solr::Document::MarcExport#apa_citation
+  def apa_citation(record)
+    solr_doc = SolrDocument.find(record.find{|f| f.tag == '001'}.value)
+    build_arr = []
+
+    #setup formatted author list
+    author = get_author_from_solr_apa(solr_doc)
+    build_arr << author if author.present?
+    # Get Pub Date
+    pub_date = get_pub_date_from_solr_apa(solr_doc)
+    build_arr << pub_date if pub_date.present?
+    # setup title/edition/volume info
+    title = get_title_from_solr_apa(solr_doc)
+    build_arr << "<i>" + title + "</i> " if title.present?
+
+    # Edition
+    edition_data = setup_edition(record)
+    text += edition_data + " " unless edition_data.nil?
+
+    # Publisher info
+    text += setup_pub_info(record) unless setup_pub_info(record).nil?
+    unless text.blank?
+      if text[-1,1] != "."
+        text += "."
+      end
+    end
+    text
+  end
+
+  def get_author_from_solr_apa(solr_doc)
+    author = solr_doc['author_ssim']&.first&.strip
+    auth_splits = clean_end_punctuation(author).split(', ').flatten if author.present?
+
+    author = if auth_splits.size == 2
+               auth_last, auth_firsts = auth_splits
+               auth_inits = auth_firsts.split(' ').map { |s| "#{s.first}." }
+               ([auth_last] + auth_inits).join(', ')
+             elsif auth_splits.present?
+               "#{author}."
+             end
+
+    return author if authors.present?
+    ''
+  end
+
+  def get_pub_date_from_solr_apa(solr_doc)
+    pub_date = solr_doc['pub_date_isim']&.last
+
+    return "(#{pub_date})." if pub_date.present?
+    ''
+  end
+
+  def get_title_from_solr_apa(solr_doc)
+    build_str = ''
+    primary_title = solr_doc['title_tesim']&.first&.strip
+    subtitle = solr_doc['subtitle_display_tesim']&.first&.strip
+     =
+
+    if primary_title.present? && subtitle.present?
+      build_str += primary_title.last(2) == ' :' ? primary_title : "#{clean_end_punctuation(primary_title)} :"
+      build_str += " #{clean_end_punctuation(subtitle).capitalize}."
+    elsif primary_title.present? && !subtitle.present?
+      build_str += "#{clean_end_punctuation(primary_title)}."
+    end
+    build_str
+  end
+
+  def get_vol_ed_from_solr_apa(solr_doc)
+end

--- a/config/prepends/custom_citation_logic.rb
+++ b/config/prepends/custom_citation_logic.rb
@@ -3,70 +3,91 @@
 module CustomCitationLogic
   # Overrides Blacklight::Solr::Document::MarcExport#apa_citation
   def apa_citation(record)
-    solr_doc = SolrDocument.find(record.find{|f| f.tag == '001'}.value)
+    solr_doc = SolrDocument.find(record.find { |f| f.tag == '001' }.value)
     build_arr = []
 
-    #setup formatted author list
-    author = get_author_from_solr_apa(solr_doc)
-    build_arr << author if author.present?
+    # Get Author
+    get_author_from_solr_apa(solr_doc, build_arr)
     # Get Pub Date
-    pub_date = get_pub_date_from_solr_apa(solr_doc)
-    build_arr << pub_date if pub_date.present?
-    # setup title/edition/volume info
-    title = get_title_from_solr_apa(solr_doc)
-    build_arr << "<i>" + title + "</i> " if title.present?
+    get_pub_date_from_solr_apa(solr_doc, build_arr)
+    # Get title/edition/volume info
+    build_title_vol_ed_sections_apa(solr_doc, build_arr)
+    # Get Publisher info
+    get_publisher_from_solr_apa(solr_doc, build_arr)
+    # Get DOI info
+    get_doi_from_solr_apa(solr_doc, build_arr)
 
-    # Edition
-    edition_data = setup_edition(record)
-    text += edition_data + " " unless edition_data.nil?
-
-    # Publisher info
-    text += setup_pub_info(record) unless setup_pub_info(record).nil?
-    unless text.blank?
-      if text[-1,1] != "."
-        text += "."
-      end
-    end
-    text
+    build_arr.compact.join(' ')
   end
 
-  def get_author_from_solr_apa(solr_doc)
+  def get_author_from_solr_apa(solr_doc, build_arr)
     author = solr_doc['author_ssim']&.first&.strip
     auth_splits = clean_end_punctuation(author).split(', ').flatten if author.present?
+    author = format_author_string(author, auth_splits)
 
-    author = if auth_splits.size == 2
-               auth_last, auth_firsts = auth_splits
-               auth_inits = auth_firsts.split(' ').map { |s| "#{s.first}." }
-               ([auth_last] + auth_inits).join(', ')
-             elsif auth_splits.present?
-               "#{author}."
-             end
-
-    return author if authors.present?
-    ''
+    build_arr << author if author.present?
   end
 
-  def get_pub_date_from_solr_apa(solr_doc)
+  def format_author_string(author, auth_splits)
+    if auth_splits.present? && auth_splits.size >= 2
+      auth_last = auth_splits[0]
+      auth_firsts = auth_splits - [auth_last]
+      auth_firsts.each { |f| auth_firsts.delete(f) unless f.first.match?(/[[:alpha:]]/) }
+      auth_inits = auth_firsts&.map { |s| s.split(' ').map { |ss| "#{ss.first}." } }&.flatten&.join(' ')
+      [auth_last, auth_inits].join(', ')
+    elsif auth_splits.present?
+      "#{author}."
+    end
+  end
+
+  def get_pub_date_from_solr_apa(solr_doc, build_arr)
     pub_date = solr_doc['pub_date_isim']&.last
 
-    return "(#{pub_date})." if pub_date.present?
-    ''
+    build_arr << "(#{pub_date})." if pub_date.present?
   end
 
   def get_title_from_solr_apa(solr_doc)
     build_str = ''
     primary_title = solr_doc['title_tesim']&.first&.strip
     subtitle = solr_doc['subtitle_display_tesim']&.first&.strip
-     =
 
     if primary_title.present? && subtitle.present?
-      build_str += primary_title.last(2) == ' :' ? primary_title : "#{clean_end_punctuation(primary_title)} :"
-      build_str += " #{clean_end_punctuation(subtitle).capitalize}."
-    elsif primary_title.present? && !subtitle.present?
-      build_str += "#{clean_end_punctuation(primary_title)}."
+      build_str += "#{clean_end_punctuation(primary_title).strip}:"
+      build_str += " #{clean_end_punctuation(subtitle).capitalize}"
+    elsif primary_title.present? && subtitle.blank?
+      build_str += clean_end_punctuation(primary_title).strip
     end
     build_str
   end
 
   def get_vol_ed_from_solr_apa(solr_doc)
+    vol1 = solr_doc['title_display_partnumber_tesim']&.first&.strip
+    vol2 = solr_doc['title_display_partname_tesim']&.first&.strip
+    edition = solr_doc['edition_tsim']&.first&.strip
+    joined_str = [vol1, vol2, edition].compact.join(', ')
+    return "(#{joined_str})" if joined_str.present?
+    joined_str
+  end
+
+  def get_publisher_from_solr_apa(solr_doc, build_arr)
+    publisher = solr_doc['published_ssm']&.first&.strip
+
+    build_arr << "#{clean_end_punctuation(publisher)}." if publisher.present?
+  end
+
+  def get_doi_from_solr_apa(solr_doc, build_arr)
+    doi = solr_doc['other_standard_ids_ssim']&.first&.strip
+
+    build_arr << "(#{clean_end_punctuation(doi)})" if doi.present?
+  end
+
+  def build_title_vol_ed_sections_apa(solr_doc, build_arr)
+    title = get_title_from_solr_apa(solr_doc)
+    vol_ed = get_vol_ed_from_solr_apa(solr_doc)
+    build_arr << if title.present? && vol_ed.present?
+                   "<i>" + title + "</i>" + " #{vol_ed}."
+                 elsif title.present? && vol_ed.blank?
+                   "<i>" + title + "</i>."
+                 end
+  end
 end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
       it 'has the right title header' do
         # For some reason, the 3 styles load locally, but not here.
         # I looked in blacklight gem's spec for a way to work around this, but
-        # all they tested for was the Cite modal tatile as well.
+        # all they tested for was the Cite modal title as well.
         execute_script("document.querySelector('#citationLink').click()")
         within 'div.modal-body' do
           expect(page).to have_css('h1', class: 'modal-title', text: TEST_ITEM[:title_main_display_tesim].first)

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe "View a item's show page", type: :system, js: true do
       # test presence of fulltext hyperlink with link text
       expect(page).to have_link('Link Text for Book', href: 'http://www.example2.com')
     end
+
+    context 'citations' do
+      it 'has the right title header' do
+        # For some reason, the 3 styles load locally, but not here.
+        # I looked in blacklight gem's spec for a way to work around this, but
+        # all they tested for was the Cite modal tatile as well.
+        execute_script("document.querySelector('#citationLink').click()")
+        within 'div.modal-body' do
+          expect(page).to have_css('h1', class: 'modal-title', text: TEST_ITEM[:title_main_display_tesim].first)
+        end
+      end
+    end
   end
 
   context 'displaying vernacular title' do


### PR DESCRIPTION
- config/initializers/prepends.rb: prepends the new logic to the existing module that serves the citations.
- config/prepends/custom_citation_logic.rb: overrides blacklight 7.4.1 citation method for APA.
- spec/*: tests expectations for the citation title.