### PR TITLE
Adds direct-link for record in tools menu

### DIFF
--- a/app/helpers/show_page_helper.rb
+++ b/app/helpers/show_page_helper.rb
@@ -93,4 +93,9 @@ module ShowPageHelper
   def values_of_field(value)
     value[:document][value[:field]]
   end
+
+  def direct_link(document_id)
+    link = solr_document_path(document_id)
+    link_to('Direct Link', link, class: 'nav-link', target: "_blank", rel: 'noopener noreferrer')
+  end
 end

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -1,0 +1,19 @@
+<%# [Overwrite-Blacklight-v7.4.1] Adds direct-link for object L#14 %>
+<% if show_doc_actions? %>
+  <div class="card show-tools">
+    <div class="card-header">
+      <h2 class="mb-0 h6"><%= t('blacklight.tools.title') %></h2>
+    </div>
+
+    <ul class="list-group list-group-flush">
+      <%= render_show_doc_actions @document do |config, inner| %>
+        <li class="list-group-item <%= config.key %>">
+          <%= inner %>
+        </li>
+      <% end %>
+      <li class="list-group-item direct-link">
+        <%= direct_link(@document.id) %>
+      </li>
+    </ul>
+  </div>
+<% end %>

--- a/spec/helpers/show_page_helpers_spec.rb
+++ b/spec/helpers/show_page_helpers_spec.rb
@@ -124,4 +124,10 @@ RSpec.describe ShowPageHelper, type: :helper do
       )
     end # rubocop:enable RSpec/ExampleLength
   end
+
+  context '#direct_link' do
+    it 'returns direct_link with correct link text' do
+      expect(helper.direct_link('123')).to eq("<a class=\"nav-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"/catalog/123\">Direct Link</a>")
+    end
+  end
 end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -253,4 +253,12 @@ RSpec.describe "View a item's show page", type: :system, js: true do
       end
     end
   end
+
+  context 'Tools Menu card' do
+    it 'show direct link for an object' do
+      visit solr_document_path(id)
+
+      expect(page).to have_link("Direct Link")
+    end
+  end
 end


### PR DESCRIPTION
Connected to: #431 
`app/helpers/show_page_helper.rb` : Adds helper method for constructing direct link
`app/views/catalog/_show_tools.html.erb` : overwrites blacklight partial to include direct link as last item in the list
`spec/helpers/show_page_helpers_spec.rb` : spec for helper method
`spec/system/view_show_page_spec.rb` : feature test spec

This change will require adding a new ENV variable that will identify our host. New ENV variable is `BLACKLIGHT_BASE_URL`

![image](https://user-images.githubusercontent.com/17075287/114895313-699a8680-9ddd-11eb-979f-79d84eef8008.png)

