### PR TITLE
Adds index_range for A-Z navigation options for facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -107,15 +107,15 @@ class CatalogController < ApplicationController
     config.add_facet_field 'marc_resource_ssim', label: 'Access', limit: 5
     config.add_facet_field 'library_ssim', label: 'Library', limit: 25
     config.add_facet_field 'format_ssim', label: 'Resource Type', limit: 25
-    config.add_facet_field 'language_ssim', label: 'Language', limit: 5
+    config.add_facet_field 'language_ssim', label: 'Language', limit: 5, index_range: true
     config.add_facet_field 'pub_date_isim', label: 'Publication/Creation Date', range: true
-    config.add_facet_field 'author_ssim', label: 'Author/Creator', limit: 5
-    config.add_facet_field 'subject_ssim', label: 'Subject', limit: 5
-    config.add_facet_field 'collection_ssim', label: 'Collection', limit: 5
+    config.add_facet_field 'author_ssim', label: 'Author/Creator', limit: 5, index_range: true
+    config.add_facet_field 'subject_ssim', label: 'Subject', limit: 5, index_range: true
+    config.add_facet_field 'collection_ssim', label: 'Collection', limit: 5, index_range: true
     config.add_facet_field 'lc_1letter_ssim', label: 'LC Classification', limit: 5
-    config.add_facet_field 'subject_geo_ssim', label: 'Region', limit: 5
-    config.add_facet_field 'subject_era_ssim', label: 'Era', limit: 5
-    config.add_facet_field 'genre_ssim', label: 'Genre', limit: 5
+    config.add_facet_field 'subject_geo_ssim', label: 'Region', limit: 5, index_range: true
+    config.add_facet_field 'subject_era_ssim', label: 'Era', limit: 5, index_range: [*(0..2), *('A'..'Z')]
+    config.add_facet_field 'genre_ssim', label: 'Genre', limit: 5, index_range: true
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -38,4 +38,21 @@ RSpec.feature 'View Search Results', type: :system, js: false do
       )
     end
   end
+
+  context 'A-Z facet navigation' do
+    before do
+      delete_all_documents_from_solr
+      build_solr_docs(TEST_ITEM.merge(subject_era_ssim: ['1990-', 'History', 'Social Science', '19th Century', 'Example', 'Another Example']))
+      visit root_path
+      click_on 'search'
+    end
+
+    it 'has A-Z navigation for certain facets', js: true do
+      click_on('Era')
+      click_on('more')
+      click_on('A-Z Sort')
+      expect(page).to have_link('1')
+      expect(page).to have_link('C')
+    end
+  end
 end


### PR DESCRIPTION
Connected to: #440 
`app/controllers/catalog_controller.rb` : Adds index_range for A-Z navigation selection options
`spec/` : Adds spec to demonstrate options show up

![image](https://user-images.githubusercontent.com/17075287/114922142-572e4600-9df9-11eb-8fb3-4eb8ad389673.png)
