### PR TITLE
Single (Re)Index now doesn't set to_time (#386).

### DIFF
--- a/lib/tasks/marc_index_ingester.rake
+++ b/lib/tasks/marc_index_ingester.rake
@@ -2,7 +2,7 @@
 
 desc "Harvest OAI XML denoted in ENV oai_set_name and index in Solr via Traject"
 task marc_index_ingest: [:environment] do
-  oai_set = ENV['oai_set_name'] || ENV['oai_single_id']
+  oai_set = ENV['oai_single_id'] || ENV['oai_set_name']
   full_index = ENV['full_index'].present?
   to_time = Time.new.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
   single_record = ENV.key?('oai_single_id') ? true : false
@@ -33,7 +33,7 @@ task marc_index_ingest: [:environment] do
 
   # save to date for next time
   log "Storing 'to' time"
-  PropertyBag.set('marc_ingest_time', to_time)
+  PropertyBag.set('marc_ingest_time', to_time) unless single_record
   mmsid_logger&.process_file('ingest_mmsids')
 
   log "Complete!"


### PR DESCRIPTION
lib/tasks/marc_index_ingester.rake: gives priority to `ENV['oai_single_id']` because we're now setting `ENV['oai_set_name']` in the environment variables on the server side and blocks setting `marc_ingext_time` if the indexing is on a single record.