### PR TITLE
Implements the Print functionality (#433).

### DIFF
--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -17,11 +17,11 @@ $(document).ready(function() {
         var c = content.substr(0, showChar);
         var h = content;
         var html =
-          '<div class="truncate-text" style="display:block">' +
+          '<div class="truncate-text" id="trunc-short-text" style="display:block">' +
           c +
           '<span class="moreellipses">' +
           ellipsestext +
-          '&nbsp;&nbsp;<a href="" class="moreless more">Read more</a></span></span></div><div class="truncate-text" style="display:none">' +
+          '&nbsp;&nbsp;<a href="" class="moreless more">Read more</a></span></span></div><div class="truncate-text" id="trunc-full-text" style="display:none">' +
           h +
           '&nbsp;&nbsp;<a href="" class="moreless less">Read Less</a></span></div>';
 

--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -8,3 +8,4 @@
 @import 'blacklight_catalog/body_html';
 @import 'blacklight_catalog/more_less';
 @import 'blacklight_catalog/advanced_search_form';
+@import 'blacklight_catalog/print';

--- a/app/assets/stylesheets/blacklight_catalog/_print.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_print.scss
@@ -1,0 +1,25 @@
+@media print {
+  #appliedParams, .pagination-search-widgets, #where-to-find-section, #trunc-short-text, .moreless.less, .page-sidebar.col-lg-3,
+    .additional-titles.btn.btn-link.additional-fields, .btn.btn-link.additional-authors-collapse, .footer-version { 
+      display: none !important; 
+  }
+  #trunc-full-text { display: block !important; }
+  #extended-terms { display: flex !important; }
+  #extended-author-addl { display: inline !important; }
+  dd { margin-bottom: 1rem; }
+  dt { font-weight: bold !important; }
+  a { 
+    text-decoration: none !important;
+    color: #212529;
+    background-color: none;
+  }
+  h4 { 
+    padding-left: 0px !important;
+    padding-right: 0px !important 
+  }
+  #main-container { max-width: 2500px !important; }
+  @page { 
+    size: auto; 
+    margin: 25mm 25mm 25mm 25mm;  
+  }
+}

--- a/app/helpers/tools_sidebar_helper.rb
+++ b/app/helpers/tools_sidebar_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module ToolsSidebarHelper
   def render_print_in_toolbar
-    link_to(t('blacklight.tools.print'), '/#', class: 'nav-link', target: "_blank", rel: 'noopener noreferrer')
+    link_to(t('blacklight.tools.print'), '#', onclick: 'javascript:print()', class: 'nav-link')
   end
 
   def render_help_in_toolbar

--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div id='where-to-find-section'>
   <%= tag.h2 t('catalog.show.find_it_header'), class: "find-it-header" %><br/>
   <p>
     <button id="physical-<%= document.id %>" class="availability" data-url="<%= "#{openurl(document.id,'getit')}" %>" value="Physical copy">Physical copy</button>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -1,0 +1,42 @@
+<%# Overrides Blacklight 7.4.1 erb of same name to add in print CSS, L#16 %>
+<!DOCTYPE html>
+<%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Internet Explorer use the highest version available -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title><%= render_page_title %></title>
+    <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
+    <%= favicon_link_tag %>
+    <%= stylesheet_link_tag "application", media: "all" %>
+    <%= stylesheet_link_tag 'application', media: 'print' %>
+    <%= javascript_include_tag "application" %>
+    <%= csrf_meta_tags %>
+    <%= content_for(:head) %>
+  </head>
+  <body class="<%= render_body_class %>">
+    <div id="skip-link">
+      <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+      <%= content_for(:skip_links) %>
+    </div>
+    <%= render partial: 'shared/header_navbar' %>
+
+  <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
+    <%= content_for(:container_header) %>
+
+    <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
+
+    <div class="row">
+      <%= content_for?(:content) ? yield(:content) : yield %>
+    </div>
+  </main>
+
+    <%= render partial: 'shared/footer' %>
+    <%= render partial: 'shared/modal' %>
+  </body>
+<% end %>


### PR DESCRIPTION
1. app/assets/javascripts/catalog.js: adds ids into the html that feeds the more/less options.
2. app/assets/stylesheets/blacklight.scss: inserts an import call for the new print partial.
3. app/assets/stylesheets/blacklight_catalog/_print.scss: creates CSS focused solely on the print page.
4. app/helpers/tools_sidebar_helper.rb: changes link to fire off JavaScript's print method.
5. app/views/catalog/_show_request_options.html.erb: provides the wrapping div an id to style it easily.
6. app/views/layouts/blacklight/base.html.erb: inserts the print stylesheet tag to the overridden base page.