### PR TITLE
Refines the citation modal (#444).

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -9,3 +9,4 @@
 @import 'blacklight_catalog/more_less';
 @import 'blacklight_catalog/advanced_search_form';
 @import 'blacklight_catalog/print';
+@import 'blacklight_catalog/citation';

--- a/app/assets/stylesheets/blacklight_catalog/_citation.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_citation.scss
@@ -1,0 +1,14 @@
+.citation-warning.row {
+    background-color: #E9BF55;
+    color: #091C44;
+    margin: inherit;
+    margin-bottom: 2rem;
+    .col-1 {
+        text-align: center;
+        margin: auto 0;
+        svg {
+            width: 24px;
+            height: 24px;
+        }
+    }
+}

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -1,0 +1,31 @@
+<%# Overwrite of Blacklight 7.4.1 partial of same name. L#9 includes text advising users that citations are auto-generated. %>
+<div class="modal-header">
+  <h1><%= t('blacklight.tools.citation') %></h1>
+  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="modal-body">
+  <div class='citation-warning row'>
+    <div class='col-1'>
+      <svg xmlns="http://www.w3.org/2000/svg"><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"></path></svg>
+    </div>
+    <div class='col-11'><%= t('blacklight.tools.citation_warning') %></div>
+  </div>
+  <% @documents.each do |document| %>
+    <% if document.respond_to?(:export_as_mla_citation_txt) %>
+      <h2><%= t('blacklight.citation.mla') %></h2>
+      <%= document.send(:export_as_mla_citation_txt).html_safe %><br/><br/>
+    <% end %>
+
+    <% if document.respond_to?(:export_as_apa_citation_txt) %>
+      <h2><%= t('blacklight.citation.apa') %></h2>
+      <%= document.send(:export_as_apa_citation_txt).html_safe %><br/><br/>
+    <% end %>
+
+    <% if document.respond_to?(:export_as_chicago_citation_txt) %>
+      <h2><%= t('blacklight.citation.chicago') %></h2>
+      <%= document.send(:export_as_chicago_citation_txt).html_safe %>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -10,6 +10,7 @@ en:
       librarian_view: 
         title: 'Staff View'
     tools:
+      citation_warning: 'These citations are automatically generated and may not always be correct. Remember to check your citations for accuracy before including them in your work.'
       direct_link: 'Direct Link'
       feedback: 'Feedback'
       help: 'Help'

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -75,13 +75,22 @@ RSpec.describe "View a item's show page", type: :system, js: true do
     end
 
     context 'citations' do
-      it 'has the right title header' do
+      let(:expected_warning_text) do
+        'These citations are automatically generated and may not always be correct. ' \
+          'Remember to check your citations for accuracy before including them in your work.'
+      end
+
+      it 'has the right text' do
         # For some reason, the 3 styles load locally, but not here.
         # I looked in blacklight gem's spec for a way to work around this, but
         # all they tested for was the Cite modal title as well.
         execute_script("document.querySelector('#citationLink').click()")
-        within 'div.modal-body' do
-          expect(page).to have_css('h1', class: 'modal-title', text: TEST_ITEM[:title_main_display_tesim].first)
+        within 'div.modal-header' do
+          expect(page).to have_css('h1', text: 'Cite')
+        end
+
+        within 'div.modal-body .citation-warning.row .col-11' do
+          expect(page).to have_content(expected_warning_text)
         end
       end
     end


### PR DESCRIPTION
- app/assets/stylesheets/blacklight.scss and blacklight_catalog/_citation.scss: styles the new citation warning.
- app/views/catalog/_citation.html.erb: overrides the blacklight partial so that the desired warning can be added.
- config/locales/blacklight.en.yml:  localizes the text in the warning.
- spec/system/view_show_page_spec.rb: changes and adds expectations for new warning and layout.

<img width="1294" alt="Screen Shot 2021-04-23 at 10 01 59 AM" src="https://user-images.githubusercontent.com/18330149/115889314-d4714080-a421-11eb-9700-ac2b5060a5d9.png">
