### PR TITLE
Change the text in the citation modal to reflect editions.

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -4,6 +4,9 @@ en:
     bookmarks:
       add:
         button: 'Bookmark Item'
+    citation:
+      mla: 'MLA (8th Edition)'
+      apa: 'APA (7th Edition)'
     search:
       bookmarks:
         absent: 'Bookmark Item'


### PR DESCRIPTION
config/locales/blacklight.en.yml: Changes text to reflect the Citation editions.

<img width="1207" alt="Screen Shot 2021-04-23 at 11 02 15 AM" src="https://user-images.githubusercontent.com/18330149/115891205-d1774f80-a423-11eb-84a9-c9c8f4cb6e9a.png">
