### PR TITLE
Revises published field to tokenized and ordered mapping (#467).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -362,7 +362,7 @@ class CatalogController < ApplicationController
     config.add_search_field('publisher_advanced', label: 'Publisher') do |field|
       field.include_in_simple_select = false
       field.solr_parameters = {
-        qf: 'published_ssm',
+        qf: 'published_tesim',
         pf: ''
       }
     end

--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -393,7 +393,7 @@ module Blacklight::Solr::Document::MarcExport
   end
 
   def get_publisher_from_solr_apa(solr_doc, build_arr)
-    publisher = solr_doc['published_ssm']&.first&.strip
+    publisher = solr_doc['published_tesim']&.first&.strip
 
     build_arr << "#{clean_end_punctuation(publisher)}." if publisher.present?
   end
@@ -431,7 +431,7 @@ module Blacklight::Solr::Document::MarcExport
     vol1 = solr_doc['title_display_partnumber_tesim']&.first&.strip
     vol2 = solr_doc['title_display_partname_tesim']&.first&.strip
     edition = solr_doc['edition_tsim']&.first&.strip
-    joined_str = [vol1.present? ? "vol. " + vol1.to_s : vol1, vol2.present? ? "vol. " + vol2.to_s : vol2, vol1.present? ? "ed. " + edition : edition].compact.join(', ')
+    joined_str = [vol1.present? ? "vol. " + vol1.to_s : vol1, vol2.present? ? "vol. " + vol2.to_s : vol2, edition.present? ? "ed. " + edition : edition].compact.join(', ')
     return joined_str.to_s if joined_str.present?
     joined_str
   end

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -39,6 +39,7 @@ require 'traject/extract_library'
 require 'traject/extract_marc_resource'
 require 'traject/extract_publication_main_display.rb'
 require 'traject/extract_publication_date'
+require 'traject/extract_published'
 require 'traject/extract_publisher_details_display'
 require 'traject/extract_subject_display'
 require 'traject/extract_title_details_display'
@@ -62,6 +63,7 @@ extend ExtractLibrary
 extend ExtractMarcResource
 extend ExtractPublicationMainDisplay
 extend ExtractPublicationDate
+extend ExtractPublished
 extend ExtractPublisherDetailsDisplay
 extend ExtractSubjectDisplay
 extend ExtractTitleDetailsDisplay
@@ -209,7 +211,7 @@ to_field 'genre_ssim', extract_marc("655a"), trim_punctuation
 to_field 'note_publication_dates_tesim', extract_marc('362a')
 to_field 'pub_date_isim', extract_publication_date
 to_field 'publication_main_display_ssim', extract_publication_main_display
-to_field 'published_ssm', extract_marc('260a:264b', alternate_script: false), trim_punctuation
+to_field 'published_tesim', extract_published
 to_field 'published_vern_ssim', extract_marc('260a', alternate_script: :only), trim_punctuation
 to_field 'publisher_details_display_ssim', extract_publisher_details_display
 to_field 'publisher_location_ssim', extract_marc("260a:264a:008[15-17]"), trim_punctuation

--- a/lib/traject/extract_published.rb
+++ b/lib/traject/extract_published.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ExtractPublished
+  def extract_published
+    lambda do |rec, acc|
+      extra_fields = extract_ordered_fields(rec, '264b:260b:502c').flatten
+      acc << extra_fields.first.values.first if extra_fields.present?
+    end
+  end
+end


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: changes field name to the newly mapped one.
- app/models/concerns/blacklight/solr/document/marc_export.rb: same as above, but also corrects syntax error.
- lib/marc_indexer.rb: provides customized mapping to the changed field.
- lib/traject/extract_published.rb: logic feeding the mapping.