### PR TITLE
Adds modal for direct link url

### DIFF
--- a/app/helpers/show_page_helper.rb
+++ b/app/helpers/show_page_helper.rb
@@ -96,6 +96,7 @@ module ShowPageHelper
 
   def direct_link(document_id)
     link = solr_document_path(document_id)
-    link_to(t('blacklight.tools.direct_link'), link, class: 'nav-link', target: "_blank", rel: 'noopener noreferrer')
+    link_text = Rails.env.development? ? 'localhost:3000' : ENV['BLACKLIGHT_BASE_URL'] || ''
+    link_text + link
   end
 end

--- a/app/views/catalog/_direct_link.html.erb
+++ b/app/views/catalog/_direct_link.html.erb
@@ -1,1 +1,7 @@
-<%= direct_link(@document.id) if @document.present? %>
+<%= link_to t('blacklight.tools.direct_link'), "", class: 'nav-link', data: {toggle: "modal", target: "#modal-window"} %>
+
+<div id="modal-window" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content"><%= render 'direct_link_modal' %></div>
+  </div>
+</div>

--- a/app/views/catalog/_direct_link_modal.html.erb
+++ b/app/views/catalog/_direct_link_modal.html.erb
@@ -1,0 +1,11 @@
+<div id="direct-link" class="modal-header">
+	<h1><%= t('blacklight.tools.direct_link') %></h1>
+  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="modal-body">
+  <%= t('blacklight.tools.direct_link_url_text') %>
+  <br>
+  <input type="text" id="direct-link-url" style="width: 100%" value="<%= direct_link(@document.id) if @document.present? %>" readonly>
+</div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -19,3 +19,4 @@ en:
       help: 'Help'
       librarian_view: 'Staff View'
       print: 'Print'
+      direct_link_url_text: 'Direct Link URL'

--- a/spec/helpers/show_page_helpers_spec.rb
+++ b/spec/helpers/show_page_helpers_spec.rb
@@ -126,8 +126,13 @@ RSpec.describe ShowPageHelper, type: :helper do
   end
 
   context '#direct_link' do
+    around do |example|
+      ENV['BLACKLIGHT_BASE_URL'] = 'www.example.com'
+      example.run
+      ENV['BLACKLIGHT_BASE_URL'] = ''
+    end
     it 'returns direct_link with correct link text' do
-      expect(helper.direct_link('123')).to eq("<a class=\"nav-link\" target=\"_blank\" rel=\"noopener noreferrer\" href=\"/catalog/123\">Direct Link</a>")
+      expect(helper.direct_link('123')).to eq("www.example.com/catalog/123")
     end
   end
 end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -85,12 +85,27 @@ RSpec.describe "View a item's show page", type: :system, js: true do
         # I looked in blacklight gem's spec for a way to work around this, but
         # all they tested for was the Cite modal title as well.
         execute_script("document.querySelector('#citationLink').click()")
-        within 'div.modal-header' do
+        within '#blacklight-modal' do
           expect(page).to have_css('h1', text: 'Cite')
         end
 
         within 'div.modal-body .citation-warning.row .col-11' do
           expect(page).to have_content(expected_warning_text)
+        end
+      end
+    end
+
+    context 'direct-link' do
+      around do |example|
+        ENV['BLACKLIGHT_BASE_URL'] = 'www.example.com'
+        example.run
+        ENV['BLACKLIGHT_BASE_URL'] = ''
+      end
+      it 'has the correct direct link' do
+        click_on 'Direct Link'
+        within '#modal-window' do
+          expect(page).to have_css('h1', text: 'Direct Link')
+          expect(page).to have_selector('input[value="www.example.com/catalog/123"]')
         end
       end
     end


### PR DESCRIPTION
`app/helpers/show_page_helper.rb`: Modifies helper to return link text with doc id instead of creating an href
`app/views/catalog/_direct_link.html.erb`: Adds a modal specific to direct-link (generalized blacklight_modal will not work here).
`app/views/catalog/_direct_link_modal.html.erb`: Adds modal
`config/locales/blacklight.en.yml`: Adds locale for direct link url
`spec/*`: Modifies spec to test new strategy

Note: Please add `ENV['BLACKLIGHT_BASE_URL']` to your env files for deployments. @mlooney @bwatson78 

Eg: `BLACKLIGHT_BASE_URL=https://blackcat-arch.library.emory.edu`

![image](https://user-images.githubusercontent.com/17075287/115932691-68133300-a45b-11eb-9d5e-fe791b6e4a88.png)
