### PR TITLE
Implements a table for physical availability (#461).

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,8 @@ class ApplicationController < ActionController::Base
   end
 
   def alma_availability
-    availability = AlmaAvailabilityService.new(params[:id])&.current_availability
+    document = SolrDocument.find(params[:id])
+    availability = AlmaAvailabilityService.new(params[:id])&.current_avail_table_data(document)
 
     respond_to { |format| format.any { render json: availability } }
   end

--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -399,7 +399,7 @@ module Blacklight::Solr::Document::MarcExport
   end
 
   def get_doi_from_solr_apa(solr_doc, build_arr)
-    doi = solr_doc['other_standard_ids_ssim']&.first&.strip
+    doi = solr_doc['other_standard_ids_tesim']&.first&.strip
 
     build_arr << "(#{clean_end_punctuation(doi)})" if doi.present?
   end

--- a/app/services/alma_availability_service.rb
+++ b/app/services/alma_availability_service.rb
@@ -23,6 +23,18 @@ class AlmaAvailabilityService
     bib
   end
 
+  def current_avail_table_data(document)
+    bib = {}
+    physical = @xml.xpath('bib/record/datafield[@tag="AVA"]')
+    bib[@mms_id] =
+      { physical: {
+        library: library_text(physical, document),
+        call_number: call_number_text(physical),
+        available: available_text(physical)
+      } }
+    bib
+  end
+
   def query_availability
     RestClient.get "#{api_url}/almaws/v1/bibs/#{@mms_id}#{query_inst}#{api_key}"
   end
@@ -37,5 +49,38 @@ class AlmaAvailabilityService
 
   def api_key
     ENV['ALMA_API_KEY'] || ""
+  end
+
+  def multiple_physical_items?(physical_arr)
+    physical_arr.present? && physical_arr.count > 1
+  end
+
+  def library_text(physical_arr, document)
+    multiple_physical_items?(physical_arr) ? 'Multiple libraries/locations' : single_lib_text(physical_arr, document)
+  end
+
+  def single_lib_text(physical_arr, document)
+    library = physical_arr[0]&.at_xpath('subfield[@code="q"]')&.text
+    section = physical_arr[0]&.at_xpath('subfield[@code="c"]')&.text
+    solr_library = document['library_ssim'] - ['Library Service Center'] if document['library_ssim'].present?
+
+    return "#{solr_library.first} (#{library})" if library_center?(library) && section.blank? && solr_library.present?
+    return "#{library}: #{section}" if library.present?
+    ''
+  end
+
+  def library_center?(library_text)
+    library_text == 'Library Service Center'
+  end
+
+  def call_number_text(physical_arr)
+    multiple_physical_items?(physical_arr) ? '-' : physical_arr[0]&.at_xpath('subfield[@code="d"]')&.text
+  end
+
+  def available_text(physical_arr)
+    available_elements = physical_arr.xpath('subfield[@code="e"]').select { |el| el.text == 'available' }
+    return '<span class="item-available">One or more copies available</span>' if available_elements.count > 1
+    return '<span class="item-available">Available</span>' if available_elements.count == 1
+    '<span class="item-not-available">No copies available</span>'
   end
 end

--- a/app/views/catalog/_show_header.html.erb
+++ b/app/views/catalog/_show_header.html.erb
@@ -2,24 +2,3 @@
 <% # bookmark/folder functions -%>
 <%= render_document_heading(document, :tag => :h1) %>
 <%= vernacular_title_populator(document) %>
-<span class="availability-badge"></span>
-
-<script type="text/javascript">
-  $.ajax({
-    url: "/alma_availability/<%= document.id %>.json",
-    type: "get",
-    dataType: 'json',
-    success: function(data) { 
-      var availabilityHtml = '';
-      var physicalExists = data['<%= document.id %>']['physical']['exists'];
-      var physicalAvailable = data['<%= document.id %>']['physical']['available'];  
-
-      if (physicalExists == true && physicalAvailable == true) {
-        availabilityHtml = '<span class="badge badge-success">Available</span>';
-      } else if (physicalExists == true && physicalAvailable == false) {
-        availabilityHtml = '<span class="badge badge-danger">Unavailable</span>';
-      }
-      Rails.$(".availability-badge")[0].innerHTML = availabilityHtml; 
-    }
-  })
-</script>

--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -1,5 +1,6 @@
 <div id='where-to-find-section'>
   <%= tag.h2 t('catalog.show.find_it_header'), class: "find-it-header" %><br/>
+  <div class="where-to-find-table"></div>
   <p>
     <button id="physical-<%= document.id %>" class="availability" data-url="<%= "#{openurl(document.id,'getit')}" %>" value="Physical copy">Physical copy</button>
     <button id="online-<%= document.id %>" class="availability" data-url="<%= "#{openurl(document.id,'viewit')}" %>" value="On-line version">On-line version</button>
@@ -7,3 +8,25 @@
   <iframe id="request-options" style="border: 3px solid black;" width="90%" height=200 seamless="seamless" frameBorder=0 src="<%= "#{openurl(document.id,'getit')}" %>"></iframe> 
   <%= render 'url_display', document: document, presenter: UrlFulltextPresenter, title: t('catalog.show.url_fulltext'), url_field: 'url_fulltext' %>
 </div>
+
+<script type="text/javascript">
+  $.ajax({
+    url: "/alma_availability/<%= document.id %>.json",
+    type: "get",
+    dataType: 'json',
+    success: function(data) { 
+      var physicalLibrary = data['<%= document.id %>']['physical']['library'];
+      var physicalCallNumber = data['<%= document.id %>']['physical']['call_number'];
+      var physicalAvailable = data['<%= document.id %>']['physical']['available'];
+      var availabilityHtml = 
+        '<table class="table"><thead><tr><th scope="col"><%= t('blacklight.availability.at_library') %></th><th scope="col"><%= t('blacklight.availability.call_number') %></th><th scope="col"><%= t('blacklight.availability.status') %></th></tr></thead><tbody><tr><td>' +
+        physicalLibrary + '</td><td>' + physicalCallNumber + '</td><td>' + physicalAvailable +
+        '</td></tr></tbody></table>';
+      if (physicalLibrary && physicalAvailable) {
+        Rails.$(".where-to-find-table")[0].innerHTML = availabilityHtml;
+      }
+    }
+  })
+</script>
+
+

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,6 +1,10 @@
 en:
   blacklight:
     application_name: 'Blacklight'
+    availability:
+      at_library: 'At the Library'
+      call_number: 'Call Number'
+      status: 'Status'
     bookmarks:
       add:
         button: 'Bookmark Item'

--- a/spec/fixtures/alma_availability_test_file.xml
+++ b/spec/fixtures/alma_availability_test_file.xml
@@ -12,7 +12,7 @@
       <subfield code="8">22171079010002486</subfield>
       <subfield code="a">01GALI_EMORY</subfield>
       <subfield code="b">UNIV</subfield>
-      <subfield code="c">Book Stacks</subfield>
+      <subfield code="c"></subfield>
       <subfield code="d">PT2613 .M45 Z92 2006</subfield>
       <subfield code="e">available</subfield>
       <subfield code="f">1</subfield>
@@ -20,7 +20,7 @@
       <subfield code="j">STACK</subfield>
       <subfield code="k">0</subfield>
       <subfield code="p">1</subfield>
-      <subfield code="q">Robert W. Woodruff Library</subfield>
+      <subfield code="q">Library Service Center</subfield>
     </datafield>
     <datafield ind1=" " ind2=" " tag="AVE">
       <subfield code="8">53420344220002486</subfield>

--- a/spec/requests/alma_availability_requests_spec.rb
+++ b/spec/requests/alma_availability_requests_spec.rb
@@ -4,20 +4,52 @@ require 'rails_helper'
 RSpec.describe 'Alma Availability requests', type: :request do
   let(:id) { '990005988630302486' }
   let(:id2) { '990005059530302486' }
-
-  it 'returns the right json (example #1)' do
-    get '/alma_availability/' + id + '.json'
-
-    expect(response.body).to eq(
-      '{"990005988630302486":{"physical":{"exists":true,"available":true},"online":{"exists":true}}}'
+  let(:expected_json) do
+    {
+      "990005988630302486": {
+        "physical": {
+          "library": "Rose Library (MARBL) (Library Service Center)",
+          "call_number": "PT2613 .M45 Z92 2006",
+          "available": '<span class="item-available">Available</span>'
+        }
+      }
+    }.to_json
+  end
+  let(:expected_json2) do
+    {
+      "990005059530302486": {
+        "physical": {
+          "library": "Multiple libraries/locations",
+          "call_number": "-",
+          "available": '<span class="item-available">One or more copies available</span>'
+        }
+      }
+    }.to_json
+  end
+  before do
+    delete_all_documents_from_solr
+    build_solr_docs(
+      [
+        TEST_ITEM.merge(
+          id: id,
+          library_ssim: 'Rose Library (MARBL)'
+        ),
+        TEST_ITEM.merge(
+          id: id2
+        )
+      ]
     )
   end
 
-  it 'returns the right json (example #2)' do
+  it 'returns the right json when subfield==q is Library Service Center' do
+    get '/alma_availability/' + id + '.json'
+
+    expect(response.body).to eq(expected_json)
+  end
+
+  it 'returns the right json when there are multiple copies across different libraries' do
     get '/alma_availability/' + id2 + '.json'
 
-    expect(response.body).to eq(
-      '{"990005059530302486":{"physical":{"exists":true,"available":true},"online":{"exists":false}}}'
-    )
+    expect(response.body).to eq(expected_json2)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,5 +99,9 @@ RSpec.configure do |config|
       :get,
       "https://smackety.alma.exlibrisgroup.com/view/oai/blah/request?metadataPrefix=marc21&set=blacklight4&until=2021-02-23T19:16:10Z&verb=ListRecords"
     ).to_return(status: 200, body: File.read(fixture_path + '/alma_small_set_with_1_new_1_updated_fields.xml'), headers: {})
+    stub_request(
+      :get,
+      "https://jalapeno.alma.exlibrisgroup.com/view/oai/tabasco/request?identifier=oai:alma.blah:single_record&metadataPrefix=marc21&verb=GetRecord"
+    ).to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file.xml'), headers: {})
   end
 end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -117,26 +117,33 @@ RSpec.describe "View a item's show page", type: :system, js: true do
     end
   end
 
-  context 'displaying availability badge' do
-    it 'shows the Available badge' do
-      expect(page).to have_css('span.badge.badge-success', text: 'Available')
+  context 'displaying availability table' do
+    it 'shows the Available table' do
+      expect(find_all('.where-to-find-table table.table')).not_to be_empty
+      [
+        'At the Library', 'Call Number', 'Status', 'UNIV (Library Service Center)',
+        'PT2613 .M45 Z92 2006', 'Available'
+      ].each { |t| expect(page).to have_content(t) }
     end
 
-    it 'shows the Unavailable badge' do
+    it 'shows as Unavailable in the table' do
       delete_all_documents_from_solr
       build_solr_docs(TEST_ITEM.merge(id: '456'))
       visit solr_document_path('456')
 
-      expect(page).to have_css('span.badge.badge-danger', text: 'Unavailable')
+      expect(find_all('.where-to-find-table table.table')).not_to be_empty
+      [
+        'At the Library', 'Call Number', 'Status', 'Robert W. Woodruff Library: Book Stacks',
+        'PT2613 .M45 Z92 2006', 'No copies available'
+      ].each { |t| expect(page).to have_content(t) }
     end
 
-    it 'shows no badge' do
+    it 'shows no table' do
       delete_all_documents_from_solr
       build_solr_docs(TEST_ITEM.merge(id: '789'))
       visit solr_document_path('789')
 
-      expect(page).not_to have_css('span.badge.badge-danger', text: 'Unavailable')
-      expect(page).not_to have_css('span.badge.badge-success', text: 'Available')
+      expect(find_all('.where-to-find-table table.table')).to be_empty
     end
   end
 


### PR DESCRIPTION
- app/controllers/application_controller.rb: since the availability badge is going dormant at the moment (plans for it on the search results page, this is hijacking the existing availability call for the table's use.
- app/models/concerns/blacklight/solr/document/marc_export.rb: corrects the SolrDocument pull after changes were made on a different ticket.
-  app/services/alma_availability_service.rb: institutes another service method, to focus only on the availability elements/text. Also defines helper methods that serve as logic for which text is delivered.
- app/views/catalog/_show_header.html.erb: strips away the script and span below the main title.
- app/views/catalog/_show_request_options.html.erb: adds a div to have the script deliver needed html for availability.
- config/locales/blacklight.en.yml: localizes the table's headers.
- spec/*: changes and tests the expectations of the new API service.