### PR TITLE
Adds the online table to the AJAX-delivered Availability diisplay (#462).

### DIFF
--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -18,11 +18,37 @@
       var physicalLibrary = data['<%= document.id %>']['physical']['library'];
       var physicalCallNumber = data['<%= document.id %>']['physical']['call_number'];
       var physicalAvailable = data['<%= document.id %>']['physical']['available'];
-      var availabilityHtml = 
-        '<table class="table"><thead><tr><th scope="col"><%= t('blacklight.availability.at_library') %></th><th scope="col"><%= t('blacklight.availability.call_number') %></th><th scope="col"><%= t('blacklight.availability.status') %></th></tr></thead><tbody><tr><td>' +
-        physicalLibrary + '</td><td>' + physicalCallNumber + '</td><td>' + physicalAvailable +
-        '</td></tr></tbody></table>';
+      var onlineLinks = data['<%= document.id %>']['online']['links'];
+      var onlineUresolver = data['<%= document.id %>']['online']['uresolver'];
+      var onlineTds = '';
+      var availabilityHtml = '';
+      
       if (physicalLibrary && physicalAvailable) {
+        availabilityHtml +=
+          '<table class="table"><thead><tr><th scope="col"><%= t('blacklight.availability.at_library') %></th><th scope="col"><%= t('blacklight.availability.call_number') %></th><th scope="col"><%= t('blacklight.availability.status') %></th></tr></thead><tbody><tr><td>' +
+          physicalLibrary + '</td><td>' + physicalCallNumber + '</td><td>' + physicalAvailable +
+          '</td></tr></tbody></table>';
+      }
+
+      if (onlineLinks.length > 0) {
+        var linksArr = onlineLinks.map((link) => {
+          return '<tr><td><%= t('blacklight.availability.access_online') %></td><td><a target="_blank" href="' + Object.keys(link)[0] + '">' + (Object.values(link)[0] || Object.keys(link)[0]) +
+          '</a></td></tr>';
+        })
+        onlineTds += linksArr.join('');
+      }
+
+      if (onlineUresolver) {
+        onlineTds += '<tr><td><a target="_blank" href="<%= openurl(document.id,'viewit') %>">' + (onlineTds ? '<%= t('blacklight.availability.view_more_options') %>' : '<%= t('blacklight.availability.view_options') %>') +
+          '</a></td><td>&nbsp;</td></tr>';
+      }
+
+      if (onlineTds) {
+        availabilityHtml += '<table class="table"><thead><tr><th scope="col"><%= t('blacklight.availability.online') %></th><th scope="col">&nbsp;</th></tr></thead><tbody>' +
+          onlineTds + '</tbody></table>';
+      }
+
+      if ((physicalLibrary && physicalAvailable) || (onlineLinks || onlineUresolver)) {
         Rails.$(".where-to-find-table")[0].innerHTML = availabilityHtml;
       }
     }

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -2,9 +2,13 @@ en:
   blacklight:
     application_name: 'Blacklight'
     availability:
+      access_online: 'Access online:'
       at_library: 'At the Library'
       call_number: 'Call Number'
+      online: 'Online'
       status: 'Status'
+      view_more_options: 'View more access options'
+      view_options: 'View access options'
     bookmarks:
       add:
         button: 'Bookmark Item'

--- a/spec/requests/alma_availability_requests_spec.rb
+++ b/spec/requests/alma_availability_requests_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe 'Alma Availability requests', type: :request do
           "library": "Rose Library (MARBL) (Library Service Center)",
           "call_number": "PT2613 .M45 Z92 2006",
           "available": '<span class="item-available">Available</span>'
+        },
+        "online": {
+          "links": [{ "http://www.example2.com": "Link Text for Book" }],
+          "uresolver": false
         }
       }
     }.to_json
@@ -22,6 +26,10 @@ RSpec.describe 'Alma Availability requests', type: :request do
           "library": "Multiple libraries/locations",
           "call_number": "-",
           "available": '<span class="item-available">One or more copies available</span>'
+        },
+        "online": {
+          "links": [{ "http://www.example2.com": "Link Text for Book" }],
+          "uresolver": false
         }
       }
     }.to_json

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -118,12 +118,14 @@ RSpec.describe "View a item's show page", type: :system, js: true do
   end
 
   context 'displaying availability table' do
-    it 'shows the Available table' do
-      expect(find_all('.where-to-find-table table.table')).not_to be_empty
-      [
-        'At the Library', 'Call Number', 'Status', 'UNIV (Library Service Center)',
-        'PT2613 .M45 Z92 2006', 'Available'
-      ].each { |t| expect(page).to have_content(t) }
+    it 'shows the Available and Online tables' do
+      expect(find_all('.where-to-find-table')).not_to be_empty
+      within '.where-to-find-table' do
+        [
+          'At the Library', 'Call Number', 'Status', 'UNIV (Library Service Center)',
+          'PT2613 .M45 Z92 2006', 'Available', 'Online', 'Access online:', 'Link Text for Book'
+        ].each { |t| expect(page).to have_content(t) }
+      end
     end
 
     it 'shows as Unavailable in the table' do
@@ -132,18 +134,24 @@ RSpec.describe "View a item's show page", type: :system, js: true do
       visit solr_document_path('456')
 
       expect(find_all('.where-to-find-table table.table')).not_to be_empty
-      [
-        'At the Library', 'Call Number', 'Status', 'Robert W. Woodruff Library: Book Stacks',
-        'PT2613 .M45 Z92 2006', 'No copies available'
-      ].each { |t| expect(page).to have_content(t) }
+      within '.where-to-find-table' do
+        [
+          'At the Library', 'Call Number', 'Status', 'Robert W. Woodruff Library: Book Stacks',
+          'PT2613 .M45 Z92 2006', 'No copies available', 'Online', 'Access online:',
+          'Link Text for Book'
+        ].each { |t| expect(page).to have_content(t) }
+      end
     end
 
-    it 'shows no table' do
+    it 'shows online table only' do
       delete_all_documents_from_solr
       build_solr_docs(TEST_ITEM.merge(id: '789'))
       visit solr_document_path('789')
 
-      expect(find_all('.where-to-find-table table.table')).to be_empty
+      expect(find_all('.where-to-find-table table.table')).not_to be_empty
+      within '.where-to-find-table table.table' do
+        ['Online', 'Access online:', 'Link Text for Book'].each { |t| expect(page).to have_content(t) }
+      end
     end
   end
 


### PR DESCRIPTION
- app/services/alma_availability_service.rb: incorporates logic needed to determine what should be shown about online items.
- app/views/catalog/_show_request_options.html.erb: adds code to display the online items.
- config/locales/blacklight.en.yml: localizes the text used in the table.
- spec/*: updates and tests the expectations of the table behavior.

<img width="1160" alt="Screen Shot 2021-04-27 at 1 40 54 PM" src="https://user-images.githubusercontent.com/18330149/116287307-3ef5e980-a75e-11eb-82a9-4e09ab740bab.png">
