### PR TITLE
Delimits the facet lists on the Advanced Search page (#473).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -16,7 +16,12 @@ class CatalogController < ApplicationController
     config.advanced_search[:form_solr_parameters] ||= {
       'facet.field' => [
         "marc_resource_ssim", "library_ssim", "format_ssim", "language_ssim", "collection_ssim"
-      ]
+      ],
+      "f.marc_resource_ssim.facet.limit" => -1,
+      "f.library_ssim.facet.limit" => -1,
+      "f.format_ssim.facet.limit" => -1,
+      "f.language_ssim.facet.limit" => -1,
+      "f.collection_ssim.facet.limit" => -1
     }
     config.advanced_search[:form_facet_partial] ||= 'advanced_search_facets_as_select'
 

--- a/app/views/advanced/_advanced_search_facets_as_select.html.erb
+++ b/app/views/advanced/_advanced_search_facets_as_select.html.erb
@@ -18,7 +18,7 @@
                         name: "f_inclusive[#{display_facet.name}][]",
                         id: display_facet.name.parameterize,
                         class: 'form-control selectpicker',
-                        data: { 'live-search': 'true', placeholder: "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}" }) do %>
+                        data: { 'live-search': 'true', placeholder: "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}", 'size': '6' }) do %>
           <% display_facet.items.each do |facet_item| %>
             <%= content_tag :option, value: facet_item.value, selected: facet_value_checked?(display_facet.name, facet_item.value) do %>
               <%= facet_display_value(display_facet.name, facet_item.label) %>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -64,6 +64,37 @@ RSpec.describe CatalogController, type: :controller do
     it { expect(facet_fields).to contain_exactly(*expected_facet_fields) }
   end
 
+  describe 'advanced search facet fields' do
+    let(:adv_search_facets_config) { controller.blacklight_config.advanced_search.form_solr_parameters }
+    let(:expected_facet_fields) do
+      ["marc_resource_ssim", "library_ssim", "format_ssim", "language_ssim", "collection_ssim"]
+    end
+
+    context 'configuration settings' do
+      it 'is set with the expected field names' do
+        expect(adv_search_facets_config['facet.field']).to match_array(expected_facet_fields)
+      end
+
+      context 'facet limits' do
+        let(:limiters) do
+          adv_search_facets_config.select do |k, _v|
+            split_key = k.split('.')
+            expected_facet_fields.include?(split_key[1]) && split_key[0] == 'f'
+          end
+        end
+        let(:limiters_values) { limiters.values }
+
+        it 'matches the expected facet fields' do
+          expect(limiters.uniq.size).to eq(expected_facet_fields.uniq.size)
+        end
+
+        it 'all set to -1 (unlimited in size)' do
+          expect(limiters_values.uniq).to eq([-1])
+        end
+      end
+    end
+  end
+
   describe 'search fields' do
     let(:search_fields) { controller.blacklight_config.search_fields.keys }
     let(:expected_search_fields) { ['keyword', 'title', 'author', 'subject'] }


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: The advanced search gem's default behavior is to deliver all facets listed in the catalog controller and use each of those facet's limit settings. We, however, are limiting the facets delivered to the 5 currently on the page. If we weren't limiting the facets shown, we could add `'facet.limit' => -1` to the settings hash shown as changed in this pull request, and they'd automatically be unlimited. But, since we're are limiting the fields shown, we have to pass an explicit delimit key/value for each field we'd like to show.
- app/views/advanced/_advanced_search_facets_as_select.html.erb: adds the `data-size` of 6 to all selects on this page.
- spec/controllers/catalog_controller_spec.rb: sets up tests that will fail if any aspect of this configuration is changed.