### PR TITLE
Adds local call number to keyword search query terms

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -285,7 +285,7 @@ class CatalogController < ApplicationController
     config.add_search_field('keyword', label: 'Keyword') do |field|
       field.include_in_advanced_search = false
       field.solr_parameters = {
-        qf: 'text_tesi id',
+        qf: 'text_tesi id local_call_number_tesim',
         pf: ''
       }
     end

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       'title_tesim', 'title_vern_display_tesim', 'title_ssort', 'title_addl_tesim',
       'title_abbr_tesim', 'title_added_entry_tesim', 'title_enhanced_tesim', 'subject_tsim',
       'title_former_tesim', 'title_graphic_tesim', 'title_host_item_tesim', 'title_key_tesi',
-      'title_series_ssim', 'title_translation_tesim', 'title_varying_tesim', 'text_tesi'
+      'title_series_ssim', 'title_translation_tesim', 'title_varying_tesim', 'text_tesi',
+      'local_call_number_tesim'
     ]
   end
 
@@ -49,7 +50,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
 
     expect(result_titles).to contain_exactly(
       'Target in text_tesi',
-      'Target in id'
+      'Target in id',
+      'Target in local_call_number_tesim'
     )
   end
 


### PR DESCRIPTION
* Connected to: #491 

* We are adding `local_call_number_tesim` to query terms list for keyword because this might not always be captured in `text_tesi`.