### PR TITLE
Modifies spellcheck suggestion requirements

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -399,7 +399,7 @@ class CatalogController < ApplicationController
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
-    config.spell_max = 5
+    config.spell_max = 0
 
     # Configuration for autocomplete suggestor
     config.autocomplete_enabled = true

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -55,4 +55,15 @@ RSpec.feature 'View Search Results', type: :system, js: false do
       expect(page).to have_link('C')
     end
   end
+
+  context 'spellcheck suggestions', js: true do
+    it 'shows suggestions only when no results are found' do
+      # blank search will return our test item in the search results, therefore, no suggestions will be displayed
+      expect(page).not_to have_content 'Did you mean'
+      fill_in 'q', with: '1234'
+      click_on 'search'
+      # above search will return no results, therefore, suggestions will be displayed
+      expect(page).to have_content 'Did you mean'
+    end
+  end
 end


### PR DESCRIPTION
* Connected to: #492 
* We are modifying the number of results required for spellcheck suggestions to show up. Previously this was set to 5. This has been changed to zero. Meaning now we will show spellcheck suggestions to the user only if there are no results found. Even if there is one result returned, we will not show suggestions.

Suggestions when no results returned:
![image](https://user-images.githubusercontent.com/17075287/116620970-86bc7280-a910-11eb-849e-1d0b2c29db57.png)

No suggestions when at least one result is returned:
![image](https://user-images.githubusercontent.com/17075287/116621010-92a83480-a910-11eb-86b3-bc3a64bee2cf.png)
