### PR TITLE
Removes the Chicago citation from Cite Modal (#509).

### DIFF
--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -22,10 +22,5 @@
       <h2><%= t('blacklight.citation.apa') %></h2>
       <%= document.send(:export_as_apa_citation_txt).html_safe %><br/><br/>
     <% end %>
-
-    <% if document.respond_to?(:export_as_chicago_citation_txt) %>
-      <h2><%= t('blacklight.citation.chicago') %></h2>
-      <%= document.send(:export_as_chicago_citation_txt).html_safe %>
-    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
<img width="978" alt="Screen Shot 2021-05-06 at 9 19 48 AM" src="https://user-images.githubusercontent.com/18330149/117304924-44cd8800-ae4c-11eb-8650-78b3ffd58dc2.png">
