### PR TITLE
Revise title fields 529

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -258,14 +258,14 @@ class CatalogController < ApplicationController
       'author_tesim', 'author_display_ssim', 'author_vern_ssim', 'author_si', 'author_addl_display_tesim'
     ]
     title_fields = [
-      'title_tesim', 'title_display_tesim', 'title_vern_display_tesim', 'title_ssort',
-      'title_addl_tesim', 'title_abbr_tesim', 'title_added_entry_tesim', 'title_enhanced_tesim',
-      'title_former_tesim', 'title_graphic_tesim', 'title_host_item_tesim', 'title_key_tesi',
-      'title_series_ssim', 'title_translation_tesim', 'title_varying_tesim'
+      'title_tesim', 'title_vern_display_tesim', 'title_addl_tesim', 'title_abbr_tesim',
+      'title_added_entry_tesim', 'title_enhanced_tesim', 'title_former_tesim',
+      'title_host_item_tesim', 'title_key_tesim', 'title_translation_tesim', 'title_varying_tesim',
+      'title_later_tesim', 'title_series_tesim'
     ]
     title_advanced_fields = [
       'title_addl_tesim', 'title_added_entry_tesim', 'title_abbr_tesim', 'title_former_tesim',
-      'title_later_ssim', 'title_host_item_tesim', 'title_translation_tesim', 'title_varying_tesim'
+      'title_later_tesim', 'title_host_item_tesim', 'title_translation_tesim', 'title_varying_tesim'
     ]
     author_advanced_fields = [
       'author_addl_display_tesim', 'author_tesim'

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -176,8 +176,9 @@ to_field 'title_former_ssim', extract_marc('247abcdefgnp:780abcdgikmnorstuwxyz')
 to_field 'title_former_tesim', extract_marc('247abcdefgnp')
 to_field 'title_graphic_tesim', extract_marc("880#{ATOZ}")
 to_field 'title_host_item_tesim', extract_marc("773#{ATOZ}:774#{ATOZ}")
-to_field 'title_key_tesi', extract_marc('222ab'), first_only
+to_field 'title_key_tesim', extract_marc('222ab')
 to_field 'title_later_ssim', extract_marc('785abcdgikmnorstuxyz')
+to_field 'title_later_tesim', extract_marc('785abcdgikmnorstuxyz')
 to_field 'title_main_display_tesim', extract_marc('245abfgknps', alternate_script: false), trim_punctuation
 to_field 'title_series_ssim', extract_marc(title_series_str(ATOG))
 to_field 'title_series_tesim', extract_marc(title_series_str(ATOG))

--- a/spec/support/solr_documents/item.rb
+++ b/spec/support/solr_documents/item.rb
@@ -46,6 +46,7 @@ TEST_ITEM = {
   title_uniform_ssim: ['Uniform Title'],
   title_former_ssim: ['Former Titles'],
   title_later_ssim: ['Later Titles'],
+  title_later_tesim: ['Later Titles'],
   emory_collection_tesim: ["Emory's Collection"],
   finding_aid_url_ssim: ['http://www.example.com text: Finding Aid Text'],
   table_of_contents_tesim: ["1,2: Freddy's Coming For You"],

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -5,11 +5,10 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
   let(:fields) do
     [
       'author_tesim', 'author_display_ssim', 'author_vern_ssim', 'author_si', 'author_addl_display_tesim',
-      'title_tesim', 'title_vern_display_tesim', 'title_ssort', 'title_addl_tesim',
-      'title_abbr_tesim', 'title_added_entry_tesim', 'title_enhanced_tesim', 'subject_tsim',
-      'title_former_tesim', 'title_graphic_tesim', 'title_host_item_tesim', 'title_key_tesi',
-      'title_series_ssim', 'title_translation_tesim', 'title_varying_tesim', 'text_tesi',
-      'local_call_number_tesim'
+      'title_tesim', 'title_vern_display_tesim', 'title_addl_tesim', 'title_abbr_tesim',
+      'title_added_entry_tesim', 'title_enhanced_tesim', 'subject_tsim', 'title_former_tesim',
+      'title_host_item_tesim', 'title_key_tesim', 'title_series_tesim', 'title_translation_tesim',
+      'title_varying_tesim', 'text_tesi', 'local_call_number_tesim', 'title_later_tesim'
     ]
   end
 
@@ -90,18 +89,17 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     expect(result_titles).to contain_exactly(
       'Target in title_tesim',
       'Target in title_vern_display_tesim',
-      'Target in title_ssort',
       'Target in title_addl_tesim',
       'Target in title_abbr_tesim',
       'Target in title_added_entry_tesim',
       'Target in title_enhanced_tesim',
       'Target in title_former_tesim',
-      'Target in title_graphic_tesim',
       'Target in title_host_item_tesim',
-      'Target in title_key_tesi',
-      'Target in title_series_ssim',
+      'Target in title_key_tesim',
+      'Target in title_series_tesim',
       'Target in title_translation_tesim',
-      'Target in title_varying_tesim'
+      'Target in title_varying_tesim',
+      'Target in title_later_tesim'
     )
   end
 

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
     it 'shows the section when format_ssim populated' do
       visit solr_document_path(id)
 
-      expect(page).to have_css('h2', text: 'MORE OPTIONS')
+      expect(page).to have_css('h2', text: 'More Options')
       expect(page).to have_link('Find more information about Books')
     end
 
@@ -293,7 +293,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
       end
 
       it 'does not show the section' do
-        expect(page).not_to have_css('h2', text: 'MORE OPTIONS')
+        expect(page).not_to have_css('h2', text: 'More Options')
         expect(page).not_to have_link('Find more information about Books')
       end
     end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
     it 'shows the section when format_ssim populated' do
       visit solr_document_path(id)
 
-      expect(page).to have_css('h2', text: 'More Options')
+      expect(page).to have_css('h2', text: 'MORE OPTIONS')
       expect(page).to have_link('Find more information about Books')
     end
 
@@ -293,7 +293,7 @@ RSpec.describe "View a item's show page", type: :system, js: true do
       end
 
       it 'does not show the section' do
-        expect(page).not_to have_css('h2', text: 'More Options')
+        expect(page).not_to have_css('h2', text: 'MORE OPTIONS')
         expect(page).not_to have_link('Find more information about Books')
       end
     end


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: switches out all string fields to the `_tesim` counterparts.
- lib/marc_indexer.rb: converts one field to multi and creates a doppleganger of another field in text format.
- spec/*: resets expectations for the altered Search Fields.