### PR TITLE
Revises subject_tsim field (#532).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -272,7 +272,7 @@ class CatalogController < ApplicationController
       'author_addl_display_tesim', 'author_tesim'
     ]
     subject_advanced_fields = [
-      'subject_tsim', 'subject_display_ssim'
+      'subject_tesim', 'subject_display_ssim'
     ]
     identifier_advanced_fields = [
       'isbn_ssim', 'issn_ssim', 'oclc_ssim', 'other_standard_ids_tesim', 'lccn_ssim', 'id',
@@ -320,7 +320,7 @@ class CatalogController < ApplicationController
     config.add_search_field('subject', label: 'Subjects') do |field|
       field.include_in_advanced_search = false
       field.solr_parameters = {
-        qf: 'subject_tsim',
+        qf: 'subject_tesim',
         pf: ''
       }
     end

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -209,7 +209,7 @@ to_field 'subject_display_ssim', extract_subject_display(ATOZ, ATOG, VTOZ)
 to_field 'subject_era_ssim',  extract_marc("650y:651y:654y:655y"), trim_punctuation
 to_field 'subject_geo_ssim',  extract_marc("651a:650z"), trim_punctuation
 to_field 'subject_ssim', extract_marc("600abcdq:610ab:611adc:630aa:650aa:653aa:654a"), trim_punctuation
-to_field 'subject_tsim', extract_marc(subject_tsim_str(ATOU))
+to_field 'subject_tesim', extract_marc(subject_tesim_str(ATOZ))
 
 # Genre Fields
 to_field 'genre_ssim', extract_marc("655a"), trim_punctuation

--- a/lib/traject/extraction_tools.rb
+++ b/lib/traject/extraction_tools.rb
@@ -121,13 +121,10 @@ module ExtractionTools
     build_arr
   end
 
-  def subject_tsim_str(atou)
+  def subject_tesim_str(atoz)
     %W[
-      600#{atou}
-      610#{atou}
-      611#{atou}
-      630#{atou}
-      650abcde:651ae:653a:654abcde:655abc
+      600#{atoz}:610#{atoz}:611#{atoz}:630#{atoz}:650#{atoz}
+      651#{atoz}:653#{atoz}:654#{atoz}:655#{atoz}
     ].join(':').freeze
   end
 

--- a/spec/support/show_page_value.rb
+++ b/spec/support/show_page_value.rb
@@ -8,7 +8,7 @@ SHOW_PAGE_VALUE = {
     "subject_geo_ssim": ["Texas"], "subject_ssim": ["Frontier and pioneer life", "Electronic books"],
     "title_main_display_tesim": ["The Title of my Work"], "title_details_display_tesim": ["The Title of my Work"],
     "title_addl_tesim": ["More title info"], "title_varying_tesim": ["Variant title"],
-    "subject_tsim": ["A sample subject"], "edition_tsim": ["A sample edition"],
+    "subject_tesim": ["A sample subject"], "edition_tsim": ["A sample edition"],
     "collection_ssim": ["American county histories"], "publication_main_display_ssim": ["A dummy publication"],
     "material_type_display_tesim": ["1 online resource (111 pages)"], "note_general_tsim": ["General note"],
     "publisher_details_display_ssim": ["Atlanta"], "summary_tesim": ["Short summary"],

--- a/spec/support/solr_documents/item.rb
+++ b/spec/support/solr_documents/item.rb
@@ -18,7 +18,7 @@ TEST_ITEM = {
   title_details_display_tesim: ['The Title of my Work'],
   title_addl_tesim: ['More title info'],
   title_varying_tesim: ['Variant title'],
-  subject_tsim: ['A sample subject'],
+  subject_tesim: ['A sample subject'],
   edition_tsim: ['A sample edition'],
   collection_ssim: ['American county histories'],
   publication_main_display_ssim: ['A dummy publication'],

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     [
       'author_tesim', 'author_vern_tesim', 'author_si', 'author_addl_display_tesim',
       'title_tesim', 'title_vern_display_tesim', 'title_addl_tesim', 'title_abbr_tesim',
-      'title_added_entry_tesim', 'title_enhanced_tesim', 'subject_tsim', 'title_former_tesim',
+      'title_added_entry_tesim', 'title_enhanced_tesim', 'subject_tesim', 'title_former_tesim',
       'title_host_item_tesim', 'title_key_tesim', 'title_series_tesim', 'title_translation_tesim',
       'title_varying_tesim', 'text_tesi', 'local_call_number_tesim', 'title_later_tesim',
       'note_production_tesim', 'note_participant_tesim'
@@ -115,6 +115,6 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       result_titles += page.all(:css, 'h3.document-title-heading/a').to_a.map(&:text)
     end
 
-    expect(result_titles).to contain_exactly('Target in subject_tsim')
+    expect(result_titles).to contain_exactly('Target in subject_tesim')
   end
 end


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: updates field name to the English tokenized version.
- lib/marc_indexer.rb: changes the mapped field so that we have more tokenization options.
- lib/traject/extraction_tools.rb: expands the scope of the field's mapping.
- spec/*: switches the field name to the new one.