### PR TITLE
suppresses the collections facet on advanced search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -15,13 +15,13 @@ class CatalogController < ApplicationController
     config.advanced_search[:query_parser] ||= 'dismax'
     config.advanced_search[:form_solr_parameters] ||= {
       'facet.field' => [
-        "marc_resource_ssim", "library_ssim", "format_ssim", "language_ssim", "collection_ssim"
+        "marc_resource_ssim", "library_ssim", "format_ssim", "language_ssim"
       ],
       "f.marc_resource_ssim.facet.limit" => -1,
       "f.library_ssim.facet.limit" => -1,
       "f.format_ssim.facet.limit" => -1,
       "f.language_ssim.facet.limit" => -1,
-      "f.collection_ssim.facet.limit" => -1
+      "f.collection_ssim.facet.limit" => 0
     }
     config.advanced_search[:form_facet_partial] ||= 'advanced_search_facets_as_select'
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe CatalogController, type: :controller do
   describe 'advanced search facet fields' do
     let(:adv_search_facets_config) { controller.blacklight_config.advanced_search.form_solr_parameters }
     let(:expected_facet_fields) do
-      ["marc_resource_ssim", "library_ssim", "format_ssim", "language_ssim", "collection_ssim"]
+      ["marc_resource_ssim", "library_ssim", "format_ssim", "language_ssim"]
     end
 
     context 'configuration settings' do


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: removes collection facet from advanced search
- spec/controllers/catalog_controller_spec.rb: removes collection facet from advanced search test