### PR TITLE
Revises the title/volume/edition layout of APA citations (#536).

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -331,10 +331,10 @@ module Blacklight::Solr::Document::MarcExport
       # Get Pub Date
       get_pub_date_from_solr_apa(solr_doc, build_arr)
       # Get title/edition/volume info
-      build_title_vol_ed_sections_apa(solr_doc, build_arr)
+      build_title_apa(solr_doc, build_arr)
     else
       # Get title/edition/volume info
-      build_title_vol_ed_sections_apa(solr_doc, build_arr)
+      build_title_apa(solr_doc, build_arr)
       # Get Pub Date
       get_pub_date_from_solr_apa(solr_doc, build_arr)
     end
@@ -386,15 +386,6 @@ module Blacklight::Solr::Document::MarcExport
     build_str
   end
 
-  def get_vol_ed_from_solr_apa(solr_doc)
-    vol1 = solr_doc['title_display_partnumber_tesim']&.first&.strip
-    vol2 = solr_doc['title_display_partname_tesim']&.first&.strip
-    edition = solr_doc['edition_tsim']&.first&.strip
-    joined_str = [vol1, vol2, edition].compact.join(', ')
-    return "(#{joined_str})" if joined_str.present?
-    joined_str
-  end
-
   def get_publisher_from_solr_apa(solr_doc, build_arr)
     publisher = solr_doc['published_tesim']&.first&.strip
     build_arr << "#{clean_end_punctuation(remove_sq_brackets(publisher))}." if publisher.present?
@@ -405,14 +396,9 @@ module Blacklight::Solr::Document::MarcExport
     build_arr << clean_end_punctuation(doi) if doi.present?
   end
 
-  def build_title_vol_ed_sections_apa(solr_doc, build_arr)
-    title = get_title_from_solr_apa(solr_doc)
-    vol_ed = get_vol_ed_from_solr_apa(solr_doc)
-    build_arr << if title.present? && vol_ed.present?
-                   "<i>" + title + "</i>" + " #{vol_ed}."
-                 elsif title.present? && vol_ed.blank?
-                   "<i>" + title + "</i>."
-                 end
+  def build_title_apa(solr_doc, build_arr)
+    title = solr_doc['title_citation_ssi'].present? ? replace_whitespace_colon(solr_doc['title_citation_ssi']) : ''
+    build_arr << "<i>#{title}</i>." if title.present?
   end
 
   def get_author_from_solr_mla(record, build_arr)
@@ -539,5 +525,9 @@ module Blacklight::Solr::Document::MarcExport
 
   def remove_sq_brackets(str)
     str.gsub(/\[|\]/, '')
+  end
+
+  def replace_whitespace_colon(str)
+    str.gsub(/\s:/, ':')
   end
 end

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -159,6 +159,7 @@ to_field 'local_call_number_tesim', extract_call_number
 
 # Title Fields
 #    Primary Title
+to_field 'title_citation_ssi', extract_marc('245abnp'), trim_punctuation, first_only
 to_field 'title_display_partname_tesim', extract_marc('245p'), trim_punctuation
 to_field 'title_display_partnumber_tesim', extract_marc('245n'), trim_punctuation
 to_field 'title_display_tesim', extract_marc('245a', alternate_script: false), trim_punctuation


### PR DESCRIPTION
- app/models/concerns/blacklight/solr/document/marc_export.rb: removes the current logic to build APA titles and points the new title to a brand new Solr field.
- lib/marc_indexer.rb: maps a new field with everything needed to produce an APA citation title.

<img width="792" alt="Screen Shot 2021-05-20 at 4 06 14 PM" src="https://user-images.githubusercontent.com/18330149/119042268-982ff200-b985-11eb-863a-5a71627ec695.png">
<img width="743" alt="Screen Shot 2021-05-20 at 4 07 13 PM" src="https://user-images.githubusercontent.com/18330149/119042273-9a924c00-b985-11eb-975a-4e7a1ac358a0.png">
