### PR TITLE
Fixes indexing errors with pub_date_isim (#558).

### DIFF
--- a/lib/traject/extract_publication_date.rb
+++ b/lib/traject/extract_publication_date.rb
@@ -4,17 +4,9 @@ module ExtractPublicationDate
   def extract_publication_date
     lambda do |rec, acc|
       if rec['008']
-        start_year = start_year(rec)
-        end_year = end_year(rec)
         case rec['008'].value[0o6]
         when 'i', 'k', 'c'
-          if start_year.present? && end_year.present?
-            ret_array = years_to_array(start_year, end_year)
-            ret_array.each { |r| acc << r }
-          else
-            # it could happen that sometimes the start or end year is missing then fallback on traject's pub date method
-            pub_date_from_traject(rec, acc)
-          end
+          possible_range_processing(start_year(rec), end_year(rec), rec, acc)
         else
           # use traject's pub date method if 008[6] is not i, k, or c
           # until we flesh this method out to include all possible date/year scenarios.
@@ -26,7 +18,8 @@ module ExtractPublicationDate
 
   def start_year(rec)
     year = rec['008'].value[0o7, 4]
-    year unless year.include?("u") # return year unless it includes u. We will write a solution for this later.
+    # return year unless it includes anything from the garbage list above. We will write a solution for this later.
+    year unless contains_garbage?(year)
   end
 
   def end_year(rec)
@@ -34,7 +27,8 @@ module ExtractPublicationDate
     if year == '9999'
       Date.current.year.to_s
     else
-      year unless year.include?("u") # return year unless it includes u. We will write a solution for this later.
+      # return year unless it includes anything from the garbage list above. We will write a solution for this later.
+      year unless contains_garbage?(year)
     end
   end
 
@@ -45,5 +39,19 @@ module ExtractPublicationDate
   def pub_date_from_traject(rec, acc)
     date = Traject::Macros::Marc21Semantics.publication_date(rec)
     acc << date if date
+  end
+
+  def contains_garbage?(year)
+    year.match?(/\D/)
+  end
+
+  def possible_range_processing(start_year, end_year, rec, acc)
+    if start_year.present? && end_year.present?
+      ret_array = years_to_array(start_year, end_year)
+      ret_array.each { |r| acc << r }
+    else
+      # it could happen that sometimes the start or end year is missing then fallback on traject's pub date method
+      pub_date_from_traject(rec, acc)
+    end
   end
 end

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -294,6 +294,11 @@ RSpec.describe 'Indexing fields with custom logic' do
       # 981211s1998    caubc  cc a  fs 0   eng d - 008 value with end year missing
       it('has only one date year') { expect(solr_doc['pub_date_isim']).to eq([1998]) }
     end
+
+    context 'when the years have non-digit characters, it kicks the values to the marc21 method' do
+      # 2002 comes from the marc21 publication_date
+      it('is blank') { expect(solr_doc2['pub_date_isim']).to eq([2002]) }
+    end
   end
 
   describe 'publication_main_display_ssim field' do


### PR DESCRIPTION
- lib/traject/extract_publication_date.rb: expands what triggers the logic to kick out to the marc21 method.
- spec/models/marc_indexing_spec.rb: tests the new logic.

No screenshots necessary.