### PR TITLE
Refines year sort oldest, newest

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -393,11 +393,12 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    config.add_sort_field 'score desc, pub_date_isi desc, title_si asc', label: 'relevance'
-    config.add_sort_field 'pub_date_isi desc, title_si asc', label: 'year'
+    config.add_sort_field 'score desc, pub_date_isim desc, title_si asc', label: 'relevance'
+    config.add_sort_field 'pub_date_isim asc, title_ssort asc', label: 'Year (oldest)'
+    config.add_sort_field 'pub_date_isim desc, title_ssort asc', label: 'Year (newest)'
     config.add_sort_field 'author_si asc, title_si asc', label: 'author'
-    config.add_sort_field 'title_ssort asc, pub_date_isi desc', label: 'Title (A-Z)'
-    config.add_sort_field 'title_ssort desc, pub_date_isi desc', label: 'Title (Z-A)'
+    config.add_sort_field 'title_ssort asc, pub_date_isim desc', label: 'Title (A-Z)'
+    config.add_sort_field 'title_ssort desc, pub_date_isim desc', label: 'Title (Z-A)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/spec/system/sort_results_spec.rb
+++ b/spec/system/sort_results_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
   before do
     delete_all_documents_from_solr
     build_solr_docs([llama, newt, eagle])
+    visit root_path
+    click_on 'search'
   end
 
   let(:llama) do
@@ -34,10 +36,6 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
   end
 
   context 'sort by Title' do
-    before do
-      visit root_path
-      click_on 'search'
-    end
     it 'has correct sorting behavior for Title (A-Z)' do
       click_on('relevance')
       click_on('Title (A-Z)')
@@ -52,6 +50,24 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
       expect(page).to have_content('3. Eagle Excellence')
       expect(page).to have_content('2. Llama Love')
       expect(page).to have_content('1. Newt Nutrition')
+    end
+  end
+
+  context 'sort by Year' do
+    it 'has correct sorting behavior for Year (oldest)' do
+      click_on('relevance')
+      click_on('Year (oldest)')
+      expect(page).to have_content('1. Eagle Excellence')
+      expect(page).to have_content('2. Llama Love')
+      expect(page).to have_content('3. Newt Nutrition')
+    end
+
+    it 'has correct sorting behavior for Year (newest)' do
+      click_on('relevance')
+      click_on('Year (newest)')
+      expect(page).to have_content('1. Newt Nutrition')
+      expect(page).to have_content('2. Llama Love')
+      expect(page).to have_content('3. Eagle Excellence')
     end
   end
 end


### PR DESCRIPTION
* **app/controllers/catalog_controller.rb**: Corrects field used for year sorting `pub_date_isim` and secondary sorting field is `title_ssort asc`
* **spec/system/sort_results_spec.rb**: Spec to show the same working