### PR TITLE
Refines the sorting options for Author (#555).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -255,7 +255,7 @@ class CatalogController < ApplicationController
     # or can be specified manually to be different.
 
     author_fields = [
-      'author_tesim', 'author_vern_tesim', 'author_si', 'author_addl_display_tesim',
+      'author_tesim', 'author_vern_tesim', 'author_ssort', 'author_addl_display_tesim',
       'note_participant_tesim', 'note_production_tesim'
     ]
     title_fields = [
@@ -396,7 +396,8 @@ class CatalogController < ApplicationController
     config.add_sort_field 'score desc, pub_date_isim desc, title_si asc', label: 'relevance'
     config.add_sort_field 'pub_date_isim asc, title_ssort asc', label: 'Year (oldest)'
     config.add_sort_field 'pub_date_isim desc, title_ssort asc', label: 'Year (newest)'
-    config.add_sort_field 'author_si asc, title_si asc', label: 'author'
+    config.add_sort_field 'author_ssort asc, title_ssort asc', label: 'Author (A-Z)'
+    config.add_sort_field 'author_ssort desc, title_ssort asc', label: 'Author (Z-A)'
     config.add_sort_field 'title_ssort asc, pub_date_isim desc', label: 'Title (A-Z)'
     config.add_sort_field 'title_ssort desc, pub_date_isim desc', label: 'Title (Z-A)'
 

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -197,7 +197,7 @@ to_field 'author_addl_display_tesim', extract_author_addl_display
 to_field 'author_addl_ssim', extract_marc("700abcdgqt:710abcdgn:711acdegnqe", alternate_script: false), trim_punctuation
 to_field 'author_display_ssim', extract_author_display
 # JSTOR isn't an author. Try to not use it as one
-to_field 'author_si', marc_sortable_author
+to_field 'author_ssort', marc_sortable_author
 to_field 'author_ssim', extract_marc("100abcdq:110abd:111acd:700abcdq:710abd:711acd"), trim_punctuation
 to_field 'author_ssm', extract_marc("100abcdq:110#{ATOZ}:111#{ATOZ}", alternate_script: false)
 to_field 'author_tesim', extract_marc("100abcegqu:110abcdegnu:111acdegjnqu")

--- a/spec/system/sort_results_spec.rb
+++ b/spec/system/sort_results_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
     build_solr_docs([llama, newt, eagle])
     visit root_path
     click_on 'search'
+    click_on 'relevance'
   end
 
   let(:llama) do
@@ -14,7 +15,8 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
       id: '111',
       title_main_display_tesim: ['Llama Love'],
       pub_date_isim: 1920,
-      title_ssort: ['Llama Love']
+      title_ssort: ['Llama Love'],
+      author_ssort: 'Knots, Donald'
     }
   end
 
@@ -23,7 +25,8 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
       id: '222',
       title_main_display_tesim: ['Newt Nutrition'],
       pub_date_isim: 1940,
-      title_ssort: ['Newt Nutrition']
+      title_ssort: ['Newt Nutrition'],
+      author_ssort: 'Tramer, Ben'
     }
   end
 
@@ -31,13 +34,13 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
     {
       id: '333',
       title_main_display_tesim: ['Eagle Excellence'],
-      title_ssort: ['Eagle Excellence']
+      title_ssort: ['Eagle Excellence'],
+      author_ssort: 'Ruehl, Mercedes'
     }
   end
 
   context 'sort by Title' do
     it 'has correct sorting behavior for Title (A-Z)' do
-      click_on('relevance')
       click_on('Title (A-Z)')
       expect(page).to have_content('1. Eagle Excellence')
       expect(page).to have_content('2. Llama Love')
@@ -45,7 +48,6 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
     end
 
     it 'has correct sorting behavior for Title (Z-A)' do
-      click_on('relevance')
       click_on('Title (Z-A)')
       expect(page).to have_content('3. Eagle Excellence')
       expect(page).to have_content('2. Llama Love')
@@ -55,7 +57,6 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
 
   context 'sort by Year' do
     it 'has correct sorting behavior for Year (oldest)' do
-      click_on('relevance')
       click_on('Year (oldest)')
       expect(page).to have_content('1. Eagle Excellence')
       expect(page).to have_content('2. Llama Love')
@@ -63,11 +64,29 @@ RSpec.describe 'Facet the catalog by year', type: :system, js: false do
     end
 
     it 'has correct sorting behavior for Year (newest)' do
-      click_on('relevance')
       click_on('Year (newest)')
       expect(page).to have_content('1. Newt Nutrition')
       expect(page).to have_content('2. Llama Love')
       expect(page).to have_content('3. Eagle Excellence')
+    end
+  end
+
+  context 'sort by Author' do
+    let(:expected_asc_headers) { ['1. Llama Love', '2. Eagle Excellence', '3. Newt Nutrition'] }
+    let(:expected_desc_headers) { ['1. Newt Nutrition', '2. Eagle Excellence', '3. Llama Love'] }
+
+    it 'has correct sorting behavior for Author (A-Z)' do
+      click_on('Author (A-Z)')
+      pulled_headers = find_all('#documents.documents-list article header').map(&:text)
+
+      expect(pulled_headers).to eq(expected_asc_headers)
+    end
+
+    it 'has correct sorting behavior for Author (Z-A)' do
+      click_on('Author (Z-A)')
+      pulled_headers = find_all('#documents.documents-list article header').map(&:text)
+
+      expect(pulled_headers).to eq(expected_desc_headers)
     end
   end
 end

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe 'Search the catalog', type: :system, js: false do
   let(:fields) do
     [
-      'author_tesim', 'author_vern_tesim', 'author_si', 'author_addl_display_tesim',
+      'author_tesim', 'author_vern_tesim', 'author_ssort', 'author_addl_display_tesim',
       'title_tesim', 'title_vern_display_tesim', 'title_addl_tesim', 'title_abbr_tesim',
       'title_added_entry_tesim', 'title_enhanced_tesim', 'subject_tesim', 'title_former_tesim',
       'title_host_item_tesim', 'title_key_tesim', 'title_series_tesim', 'title_translation_tesim',
@@ -66,7 +66,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       expect(result_titles).to contain_exactly(
         'Target in author_tesim',
         'Target in author_vern_tesim',
-        'Target in author_si',
+        'Target in author_ssort',
         'Target in author_addl_display_tesim',
         'Target in note_production_tesim',
         'Target in note_participant_tesim'


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: switches field used for sorting to a `_ssort` ended field. Also uses that new field in the options for sorting.
- lib/marc_indexer.rb: swaps the sort field to the appropriate Solr `_ssort` ending.
- spec/*: updates/adds expectations for field and sorting.
<img width="264" alt="Screen Shot 2021-05-25 at 1 38 30 PM" src="https://user-images.githubusercontent.com/18330149/119543321-88862400-bd5e-11eb-879e-381c7329ccef.png">
