### PR TITLE
Refactor alma env variables to make production more robust

### DIFF
--- a/app/services/alma_availability_service.rb
+++ b/app/services/alma_availability_service.rb
@@ -50,11 +50,11 @@ class AlmaAvailabilityService
   end
 
   def api_url
-    ENV['ALMA_API_URL'] || 'www.example.com'
+    ENV['ALMA_API_URL'] || "https://api-na.hosted.exlibrisgroup.com"
   end
 
   def api_key
-    ENV['ALMA_API_KEY'] || ""
+    ENV.fetch('ALMA_BIB_KEY')
   end
 
   def multiple_physical_items?(physical_arr)

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -14,13 +14,10 @@ ALMA=
 
 # provide alma_api_url for querying/posting to Alma API
 ALMA_API_URL=
-ALMA_API_KEY=
-ALMA_DELIVERY_DOMAIN=
+ALMA_BIB_KEY=
 
 # provide institution for oai base url fetch
-ALMA_INSTITUTION_CODE=
 INSTITUTION=
-
 
 # provides name for oai set being fetched
 oai_set_name=blacklighttest

--- a/spec/requests/alma_availability_requests_spec.rb
+++ b/spec/requests/alma_availability_requests_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe 'Alma Availability requests', type: :request do
+RSpec.describe 'Alma Availability requests', type: :request, alma: true do
   let(:id) { '990005988630302486' }
   let(:id2) { '990005059530302486' }
   let(:expected_json) do
@@ -47,6 +47,16 @@ RSpec.describe 'Alma Availability requests', type: :request do
         )
       ]
     )
+  end
+
+  around do |example|
+    orig_url = ENV['ALMA_API_URL']
+    orig_key = ENV['ALMA_BIB_KEY']
+    ENV['ALMA_API_URL'] = 'www.example.com'
+    ENV['ALMA_BIB_KEY'] = "fakebibkey123"
+    example.run
+    ENV['ALMA_API_URL'] = orig_url
+    ENV['ALMA_BIB_KEY'] = orig_key
   end
 
   it 'returns the right json when subfield==q is Library Service Center' do

--- a/spec/services/alma_availability_service_spec.rb
+++ b/spec/services/alma_availability_service_spec.rb
@@ -2,11 +2,20 @@
 require 'rails_helper'
 require 'nokogiri'
 
-RSpec.describe AlmaAvailabilityService do
+RSpec.describe AlmaAvailabilityService, alma: true do
   let(:id) { '990005988630302486' }
   let(:id2) { '990005059530302486' }
   let(:service) { described_class.new(id) }
   let(:service2) { described_class.new(id2) }
+  around do |example|
+    orig_url = ENV['ALMA_API_URL']
+    orig_key = ENV['ALMA_BIB_KEY']
+    ENV['ALMA_API_URL'] = 'www.example.com'
+    ENV['ALMA_BIB_KEY'] = "fakebibkey123"
+    example.run
+    ENV['ALMA_API_URL'] = orig_url
+    ENV['ALMA_BIB_KEY'] = orig_key
+  end
 
   describe '#current_availability' do
     it 'returns the correct response #1' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,15 +53,15 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   config.before do
-    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990005988630302486?apikey=&expand=p_avail,e_avail,d_avail&view=full")
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990005988630302486?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail&view=full")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file.xml'), headers: {})
-    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990005059530302486?apikey=&expand=p_avail,e_avail,d_avail&view=full")
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990005059530302486?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail&view=full")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file_2.xml'), headers: {})
-    stub_request(:get, "http://www.example.com/almaws/v1/bibs/123?apikey=&expand=p_avail,e_avail,d_avail&view=full")
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/123?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail&view=full")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file.xml'), headers: {})
-    stub_request(:get, "http://www.example.com/almaws/v1/bibs/456?apikey=&expand=p_avail,e_avail,d_avail&view=full")
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/456?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail&view=full")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file_3.xml'), headers: {})
-    stub_request(:get, "http://www.example.com/almaws/v1/bibs/789?apikey=&expand=p_avail,e_avail,d_avail&view=full")
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/789?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail&view=full")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file_4.xml'), headers: {})
     stub_request(
       :get,

--- a/spec/system/alma_request_options_spec.rb
+++ b/spec/system/alma_request_options_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 require 'rest-client'
 include Warden::Test::Helpers
 
-RSpec.describe 'get it and view it iframes', type: :system, js: true do
+RSpec.describe 'get it and view it iframes', type: :system, js: true, alma: true do
   let(:user) { User.create(uid: 123, provider: 'shibboleth') }
   before do
     delete_all_documents_from_solr
@@ -11,9 +11,15 @@ RSpec.describe 'get it and view it iframes', type: :system, js: true do
   end
 
   around do |example|
+    orig_url = ENV['ALMA_API_URL']
+    orig_key = ENV['ALMA_BIB_KEY']
+    ENV['ALMA_API_URL'] = 'www.example.com'
+    ENV['ALMA_BIB_KEY'] = "fakebibkey123"
     ENV["ALMA"] = "smackety"
     ENV["INSTITUTION"] = "blah"
     example.run
+    ENV['ALMA_API_URL'] = orig_url
+    ENV['ALMA_BIB_KEY'] = orig_key
     ENV["ALMA"] = ""
     ENV["INSTITUTION"] = ""
   end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -1,11 +1,21 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe "View a item's show page", type: :system, js: true do
+RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
   before do
     delete_all_documents_from_solr
     build_solr_docs(TEST_ITEM)
     visit solr_document_path(id)
+  end
+
+  around do |example|
+    orig_url = ENV['ALMA_API_URL']
+    orig_key = ENV['ALMA_BIB_KEY']
+    ENV['ALMA_API_URL'] = 'www.example.com'
+    ENV['ALMA_BIB_KEY'] = "fakebibkey123"
+    example.run
+    ENV['ALMA_API_URL'] = orig_url
+    ENV['ALMA_BIB_KEY'] = orig_key
   end
 
   let(:id) { '123' }
@@ -163,9 +173,10 @@ RSpec.describe "View a item's show page", type: :system, js: true do
 
     context 'direct-link' do
       around do |example|
+        bl_url = ENV['BLACKLIGHT_BASE_URL']
         ENV['BLACKLIGHT_BASE_URL'] = 'www.example.com'
         example.run
-        ENV['BLACKLIGHT_BASE_URL'] = ''
+        ENV['BLACKLIGHT_BASE_URL'] = bl_url
       end
       it 'has the correct direct link' do
         click_on 'Direct Link'


### PR DESCRIPTION
- Sane default for ALMA_API_URL
- Alma has different keys for different functions, so specify which API 
key we are using
  - This also opens up the application to use further alma apis
- Raise an error if the API key is not set, since the production 
application won't work without it