### PR TITLE
Adjusts the Print screen styling (#561).

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_print.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_print.scss
@@ -1,5 +1,5 @@
 @media print {
-  #appliedParams, .pagination-search-widgets, #where-to-find-section, #trunc-short-text, .moreless.less, .page-sidebar.col-lg-3,
+  #appliedParams, .pagination-search-widgets, #where-to-find-section, #trunc-short-text, .moreless.less, .page-sidebar.col-lg-3, footer,
     .additional-titles.btn.btn-link.additional-fields, .btn.btn-link.additional-authors-collapse, .footer-version, .availability-badge { 
       display: none !important; 
   }

--- a/app/assets/stylesheets/blacklight_catalog/_show_page.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_show_page.scss
@@ -24,7 +24,7 @@ h1.show-header {
   }
 }
 
-.document-metadata {
+.document-metadata, .collapsible-document-metadata {
   dt {
     font-family:  "Cardo", serif;
     font-weight: 500;


### PR DESCRIPTION
- app/assets/stylesheets/blacklight_catalog/_print.scss: adds `footer`element to exclusion list.
- app/assets/stylesheets/blacklight_catalog/_show_page.scss: includes the collapsible dts into the same styling as the non-collapsible dts.