### PR TITLE
Citations sorted by type (#570).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ Rails/Output:
 
 Rails/OutputSafety:
     Exclude:
+        - 'app/helpers/citation_modal_helper.rb'
         - 'app/models/concerns/blacklight/solr/document/marc_export.rb'
 
 RSpec/DescribeClass:

--- a/app/assets/stylesheets/blacklight_catalog/_citations.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_citations.scss
@@ -24,3 +24,6 @@ div.modal-header.citations {
       }
   }
 }
+
+.citation-header { margin: 1.5rem 0;}
+.citation-text { margin-bottom: 1rem;}

--- a/app/helpers/citation_modal_helper.rb
+++ b/app/helpers/citation_modal_helper.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+module CitationModalHelper
+  def render_citations(documents)
+    return process_mult_documents_citations(documents) if documents.count > 1 && cit_method_respond_test(documents)
+    return process_single_document_citations(documents) if cit_method_respond_test(documents)
+    ''
+  end
+
+  def process_mult_documents_citations(documents)
+    mla_cit_arr = documents.inject([]) do |arr, doc|
+      arr << tag.div(doc.send(:export_as_mla_citation_txt).html_safe, class: 'citation-text')
+    end
+    apa_cit_arr = documents.inject([]) do |arr, doc|
+      arr << tag.div(doc.send(:export_as_apa_citation_txt).html_safe, class: 'citation-text')
+    end
+
+    safe_join(
+      [
+        tag.h2(t('blacklight.citation.mla'), class: 'citation-header'),
+        mla_cit_arr,
+        tag.h2(t('blacklight.citation.apa'), class: 'citation-header'),
+        apa_cit_arr
+      ].flatten, ''
+    )
+  end
+
+  def process_single_document_citations(documents)
+    safe_join(
+      [
+        tag.h2(t('blacklight.citation.mla'), class: 'citation-header'),
+        tag.div(documents.first.send(:export_as_mla_citation_txt).html_safe, class: 'citation-text'),
+        tag.h2(t('blacklight.citation.apa'), class: 'citation-header'),
+        tag.div(documents.first.send(:export_as_apa_citation_txt).html_safe, class: 'citation-text')
+      ].flatten, ''
+    )
+  end
+
+  def cit_method_respond_test(documents)
+    documents.all? { |d| d.respond_to?(:export_as_mla_citation_txt) && d.respond_to?(:export_as_apa_citation_txt) }
+  end
+end

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -12,15 +12,5 @@
     </div>
     <div class='col-11'><%= t('blacklight.tools.citation_warning') %></div>
   </div>
-  <% @documents.each do |document| %>
-    <% if document.respond_to?(:export_as_mla_citation_txt) %>
-      <h2><%= t('blacklight.citation.mla') %></h2>
-      <%= document.send(:export_as_mla_citation_txt).html_safe %><br/><br/>
-    <% end %>
-
-    <% if document.respond_to?(:export_as_apa_citation_txt) %>
-      <h2><%= t('blacklight.citation.apa') %></h2>
-      <%= document.send(:export_as_apa_citation_txt).html_safe %><br/><br/>
-    <% end %>
-  <% end %>
+  <%= render_citations(@documents) %>
 </div>


### PR DESCRIPTION
- .rubocop.yml: removes the cop for html_safe.
- app/assets/stylesheets/blacklight_catalog/_citations.scss: gives space between citations' headers and text.
- app/helpers/citation_modal_helper.rb: builds out the layout of each type of citation list.
- app/views/catalog/_citation.html.erb: replaces stock logic with call to new helper.

<img width="905" alt="Screen Shot 2021-05-26 at 4 27 52 PM" src="https://user-images.githubusercontent.com/18330149/119728651-b7c19180-be41-11eb-997b-6fa94c19b2ed.png">
<img width="873" alt="Screen Shot 2021-05-26 at 4 28 09 PM" src="https://user-images.githubusercontent.com/18330149/119728667-bb551880-be41-11eb-95b8-df768dcf451a.png">
