### PR TITLE
 @bwatson78 Styles the alerts to match notification styles in Pattern Library (#568).

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -14,6 +14,7 @@
 @import 'blacklight_catalog/footer';
 @import 'blacklight_catalog/layout';
 @import 'blacklight_catalog/navbar';
+@import 'blacklight_catalog/notifications';
 @import 'blacklight_catalog/results_list';
 @import 'blacklight_catalog/search_form';
 @import 'blacklight_catalog/search_history';

--- a/app/assets/stylesheets/blacklight_catalog/_colors.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_colors.scss
@@ -11,6 +11,7 @@ $alt-bright-blue: #5387F7;
 $light-blue: #D0DEFD;
 
 $gold: #E9BF55;
+$dark-gold: #D69A03;
 
 $charcoal: #605858;
 $base-slate: #B6BDCC;
@@ -18,6 +19,8 @@ $light-slate: #E7EAF1;
 $super-light-slate: #E5E7EC;
 $black: #000000;
 $white: #FFFFFF;
+
+$alt-green: #1DB003;
 
 $red:     #B82216;
 $orange:  #AB750C;
@@ -65,3 +68,32 @@ $theme-colors: map-merge(
 
 // static colors
 $explorer-box-shadow:       rgba(231, 234, 241, 0.3);
+
+// notification colors
+$notification-colors: ();
+// stylelint-disable-next-line scss/dollar-variable-default
+$notification-colors: map-merge(
+  (
+    "default-back":     $light-slate,
+    "default-text":     $charcoal,
+    "default-x":        $base-blue,
+    "default-x-hover":  $dark-blue,
+    "info-back":        $base-blue,
+    "info-text":        $white,
+    "info-x":           $gold,
+    "info-x-hover":     $dark-gold,
+    "success-back":     $alt-green,
+    "success-text":     $dark-blue,
+    "success-x":        $base-blue,
+    "success-x-hover":  $dark-blue,
+    "warning-back":     $gold,
+    "warning-text":     $dark-blue,
+    "warning-x":        $base-blue,
+    "warning-x-hover":  $dark-blue,
+    "danger-back":      $red,
+    "danger-text":      $white,
+    "danger-x":         $light-slate,
+    "danger-x-hover":   $base-slate
+  ),
+  $notification-colors
+);

--- a/app/assets/stylesheets/blacklight_catalog/_notifications.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_notifications.scss
@@ -1,65 +1,48 @@
+@import 'colors';
+
 .alert {
-  background-color: #E7EAF1;
-  color: #605858;
+  background-color: map-get($notification-colors, "default-back");
+  color: map-get($notification-colors, "default-text");
   border-radius: unset !important;
   border: unset !important;
   .close { 
-    color: #082B73 !important; 
-    &:hover { color: #091C44 !important; }
+    color: map-get($notification-colors, "default-x") !important; 
+    &:hover { color: map-get($notification-colors, "default-x-hover") !important; }
   }
 }
 
 .alert.alert-info {
-  background-color: #082B73;
-  color: #FFFFFF;
-  border-radius: unset !important;
-  border: unset !important;
+  background-color: map-get($notification-colors, "info-back");
+  color: map-get($notification-colors, "info-text");
   .close { 
-    color: #E9BF55 !important; 
-    &:hover { color: #D69A03 !important; }
+    color: map-get($notification-colors, "info-x") !important; 
+    &:hover { color: map-get($notification-colors, "info-x-hover") !important; }
   }
 }
 
-// .alert.alert-success {
-//   background-color: #1DB003;
-//   color: #091C44;
-//   border-radius: unset !important;
-//   border: unset !important;
-//   .close { 
-//     color: #082B73 !important; 
-//     &:hover { color: #091C44 !important; }
-//   }
-// }
-
 .alert.alert-success {
-  background-color: #FFFFFF;
-  color: #605858;
-  border-radius: unset !important;
-  border: unset !important;
+  background-color: map-get($notification-colors, "success-back");
+  color: map-get($notification-colors, "success-text");
   .close { 
-    color: #336BE6 !important; 
-    &:hover { color: #004990 !important; }
+    color: map-get($notification-colors, "success-x") !important; 
+    &:hover { color: map-get($notification-colors, "success-x-hover") !important; }
   }
 }
 
 .alert.alert-warning {
-  background-color: #E9BF55;
-  color: #091C44;
-  border-radius: unset !important;
-  border: unset !important;
+  background-color: map-get($notification-colors, "warning-back");
+  color: map-get($notification-colors, "warning-text");
   .close { 
-    color: #082B73 !important; 
-    &:hover { color: #091C44 !important; }
+    color: map-get($notification-colors, "warning-x") !important; 
+    &:hover { color: map-get($notification-colors, "warning-x-hover") !important; }
   }
 }
 
 .alert.alert-danger {
-  background-color: #B82216;
-  color: #FFFFFF;
-  border-radius: unset !important;
-  border: unset !important;
+  background-color: map-get($notification-colors, "danger-back");
+  color: map-get($notification-colors, "danger-text");
   .close { 
-    color: #E7EAF1 !important; 
-    &:hover { color: #B6BDCC !important; }
+    color: map-get($notification-colors, "danger-x") !important; 
+    &:hover { color: map-get($notification-colors, "danger-x-hover") !important; }
   }
 }

--- a/app/assets/stylesheets/blacklight_catalog/_notifications.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_notifications.scss
@@ -1,0 +1,65 @@
+.alert {
+  background-color: #E7EAF1;
+  color: #605858;
+  border-radius: unset !important;
+  border: unset !important;
+  .close { 
+    color: #082B73 !important; 
+    &:hover { color: #091C44 !important; }
+  }
+}
+
+.alert.alert-info {
+  background-color: #082B73;
+  color: #FFFFFF;
+  border-radius: unset !important;
+  border: unset !important;
+  .close { 
+    color: #E9BF55 !important; 
+    &:hover { color: #D69A03 !important; }
+  }
+}
+
+// .alert.alert-success {
+//   background-color: #1DB003;
+//   color: #091C44;
+//   border-radius: unset !important;
+//   border: unset !important;
+//   .close { 
+//     color: #082B73 !important; 
+//     &:hover { color: #091C44 !important; }
+//   }
+// }
+
+.alert.alert-success {
+  background-color: #FFFFFF;
+  color: #605858;
+  border-radius: unset !important;
+  border: unset !important;
+  .close { 
+    color: #336BE6 !important; 
+    &:hover { color: #004990 !important; }
+  }
+}
+
+.alert.alert-warning {
+  background-color: #E9BF55;
+  color: #091C44;
+  border-radius: unset !important;
+  border: unset !important;
+  .close { 
+    color: #082B73 !important; 
+    &:hover { color: #091C44 !important; }
+  }
+}
+
+.alert.alert-danger {
+  background-color: #B82216;
+  color: #FFFFFF;
+  border-radius: unset !important;
+  border: unset !important;
+  .close { 
+    color: #E7EAF1 !important; 
+    &:hover { color: #B6BDCC !important; }
+  }
+}


### PR DESCRIPTION
- app/assets/stylesheets/blacklight.scss: partializes the css specific to notifications.
- app/assets/stylesheets/blacklight_catalog/_colors.scss: inserts needed colors into partial, as well as forms a mapping of all the colors to be stubbed for notifications.
- app/assets/stylesheets/blacklight_catalog/_notifications.scss: ties color values to the different types of notifications,

`info` 
<img width="1157" alt="Screen Shot 2021-06-01 at 2 52 46 PM" src="https://user-images.githubusercontent.com/18330149/120381150-0f537780-c2f0-11eb-8a38-2ff6838a17d9.png">
`success` 
<img width="1130" alt="Screen Shot 2021-06-01 at 2 53 26 PM" src="https://user-images.githubusercontent.com/18330149/120381187-1a0e0c80-c2f0-11eb-888c-bc6ea3dc4721.png">
`warning` 
<img width="1138" alt="Screen Shot 2021-06-01 at 2 53 47 PM" src="https://user-images.githubusercontent.com/18330149/120381220-25f9ce80-c2f0-11eb-9278-2b1c291d3944.png">
`danger`
<img width="1127" alt="Screen Shot 2021-06-01 at 2 54 04 PM" src="https://user-images.githubusercontent.com/18330149/120381251-31e59080-c2f0-11eb-82d1-b4cf060e9d31.png">
default
<img width="1145" alt="Screen Shot 2021-06-01 at 2 54 29 PM" src="https://user-images.githubusercontent.com/18330149/120381283-3b6ef880-c2f0-11eb-92d9-7872a01706df.png">


