### PR TITLE
 Refines responsive header stying (#574). 

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_navbar.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_navbar.scss
@@ -82,9 +82,10 @@ a.nav-link.last {
 }
 
 @media (min-width: 768px) {
-  .navbar-collapse.utility-nav.collapse {
+  #user-util-collapse > .navbar-nav > .nav-item.mobile-only {
     display: none !important;
   }
+
   .non-collapse-navbar {
     display: flex;
     flex-basis: auto;
@@ -97,6 +98,14 @@ a.nav-link.last {
 @media (max-width: 767px) {
   .non-mobile-links {
     display: none !important;
+  }
+  .container { max-width: unset !important; }
+  .navbar { padding: 0 0.9375rem !important; }
+  .navbar-search.navbar.navbar-light.bg-light.mb-3 > .container {
+    padding: 0;
+
+    > div { padding: 1rem 0;}
+    > form.search-query-form { padding-bottom: 0;}
   }
 }
 

--- a/app/assets/stylesheets/blacklight_catalog/_navbar.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_navbar.scss
@@ -100,19 +100,19 @@ a.nav-link.last {
     display: none !important;
   }
   .container { max-width: unset !important; }
-  .navbar { padding: 0 0.9375rem !important; }
+  .navbar { padding: 0 $navbar-padding-mobile-x !important; }
   .navbar-search.navbar.navbar-light.bg-light.mb-3 > .container {
     padding: 0;
 
-    > div { padding: 1rem 0;}
+    > div { padding: map-get($spacers, 3) 0; }
     > form.search-query-form { 
       padding-bottom: 0;
       padding-right: 0;
 
       > .input-group > select { 
-        min-width: 10%;
-        width: 15%;
-        padding: 0.375rem 1.25rem 0.375rem 0.5rem
+        min-width: $search-form-mobile-min-width;
+        width: $search-form-mobile-width;
+        padding: $search-form-mobile-padding-y $search-form-mobile-padding-right $search-form-mobile-padding-y $search-form-mobile-padding-left;
       }
     }
   }
@@ -120,8 +120,8 @@ a.nav-link.last {
 
 @media (max-width: 575px) {
   .navbar-search.navbar.navbar-light.bg-light.mb-3 > .container > form.search-query-form > .input-group > select { 
-    min-width: 20%;
-    width: 25%;
+    min-width: $search-form-mobile-sm-min-width;
+    width: $search-form-mobile-sm-width;
   }
 }
 

--- a/app/assets/stylesheets/blacklight_catalog/_navbar.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_navbar.scss
@@ -96,7 +96,7 @@ a.nav-link.last {
 }
 
 @media (max-width: 767px) {
-  .non-mobile-links {
+  .non-mobile-links, .btn.btn-md.btn-primary.btn-login.rounded-0.mb-2 {
     display: none !important;
   }
   .container { max-width: unset !important; }
@@ -105,7 +105,23 @@ a.nav-link.last {
     padding: 0;
 
     > div { padding: 1rem 0;}
-    > form.search-query-form { padding-bottom: 0;}
+    > form.search-query-form { 
+      padding-bottom: 0;
+      padding-right: 0;
+
+      > .input-group > select { 
+        min-width: 10%;
+        width: 15%;
+        padding: 0.375rem 1.25rem 0.375rem 0.5rem
+      }
+    }
+  }
+}
+
+@media (max-width: 575px) {
+  .navbar-search.navbar.navbar-light.bg-light.mb-3 > .container > form.search-query-form > .input-group > select { 
+    min-width: 20%;
+    width: 25%;
   }
 }
 

--- a/app/assets/stylesheets/blacklight_catalog/_variables.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_variables.scss
@@ -59,6 +59,7 @@ $nav-link-padding-x:                1rem;
 
 $navbar-padding-y:                  0;
 $navbar-padding-x:                  1.875rem;
+$navbar-padding-mobile-x:           0.9375rem;
 
 $branding-organization-font-size:            0.875rem;
 $branding-division-font-size:                $h4-font-size;
@@ -115,6 +116,15 @@ $search-form-q-padding-x:           1.25rem;
 
 $search-form-button-width:          6rem;
 $search-form-button-padding-x:      1.5625rem;
+
+$search-form-mobile-min-width:      10%;
+$search-form-mobile-width:          15%;
+$search-form-mobile-sm-min-width:   20%;
+$search-form-mobile-sm-width:       25%;
+$search-form-mobile-padding-y:      0.375rem;
+$search-form-mobile-padding-right:  1.25rem;
+$search-form-mobile-padding-left:   0.5rem;
+
 
 // Hero Image
 

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -6,7 +6,7 @@
     <div class="col-md-12">
       <div class="row non-mobile-links">
         <div class="non-collapse-navbar">
-          <%= render 'shared/static_links' %>
+          <%= render 'shared/static_links', mobile: false %>
         </div>
       </div>
       <div class="row justify-content-between branding-row header-main">
@@ -34,6 +34,7 @@
         </button>
 
         <div class="collapse navbar-collapse justify-content-md-end" id="user-util-collapse">
+          <%= render 'shared/static_links', mobile: true %>
           <%= render 'shared/user_util_links' %>
         </div>
       </div>

--- a/app/views/shared/_static_links.html.erb
+++ b/app/views/shared/_static_links.html.erb
@@ -1,11 +1,11 @@
 <ul class="navbar-nav">
-  <li class="nav-item"><%= link_to "Home", root_path, class: "nav-link" %></li>
-  <li class="nav-item"><%= link_to "About Catalog", about_path, class: "nav-link" %></li>
-  <li class="nav-item"><%= link_to "Contact", contact_path, class: "nav-link last" %></li>
+  <li class="nav-item<%= " mobile-only" if mobile %>"><%= link_to "Home", root_path, class: "nav-link" %></li>
+  <li class="nav-item<%= " mobile-only" if mobile %>"><%= link_to "About Catalog", about_path, class: "nav-link" %></li>
+  <li class="nav-item<%= " mobile-only" if mobile %>"><%= link_to "Contact", contact_path, class: "nav-link last" %></li>
 </ul>
 <ul class="navbar-nav">
   <%= render_nav_actions do |config, action|%>
-    <li class="nav-item"><%= action %></li>
+    <li class="nav-item<%= " mobile-only" if mobile %>"><%= action %></li>
   <% end %>
-  <li class="nav-item"><%= link_to "Help", help_path, class: "nav-link last"  %></li>
+  <li class="nav-item<%= " mobile-only" if mobile %>"><%= link_to "Help", help_path, class: "nav-link last"  %></li>
 </ul>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -13,6 +13,9 @@
       <li class="nav-item">
         <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: 'btn btn-md btn-primary btn-login rounded-0 mb-2' %>
       </li>
+      <li class="nav-item mobile-only">
+        <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: 'nav-link' %>
+      </li>
     <% end %>
   <% end %>
 </ul>


### PR DESCRIPTION
- app/assets/stylesheets/blacklight_catalog/_navbar.scss: hides unneeded elements and styles the others.
- app/views/shared/_header_navbar.html.erb: adds the missing links to the right areas, and passes along a class variable making it easier to hide links.
- app/views/shared/_static_links.html.erb: inserts `mobile-only` class into elements that should be hidden on smaller screens.
- app/views/shared/_user_util_links.html.erb: puts a standard link on the mobile view instead of button.