### PR TITLE
 Revises search results metadata fields shown (#589). 

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_results_list.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_results_list.scss
@@ -23,6 +23,11 @@ article.document {
       margin-bottom: 0;
     }
   }
+
+  > p {
+    margin-bottom: $results-vern-title-bottom-marg;
+    margin-left: $results-vern-title-left-marg;
+  }
 }
 
 dd.document-details {

--- a/app/assets/stylesheets/blacklight_catalog/_variables.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_variables.scss
@@ -192,6 +192,8 @@ $results-drop-menu-min-w:            4.063rem;
 $results-pagination-margin:          0.563rem;
 $results-thumbnail-width:            11.5rem;
 $results-document-bottom-margin:     2rem;
+$results-vern-title-bottom-marg:     0.5rem;
+$results-vern-title-left-marg:       1.75rem;
 
 // Static
 $static-explorer-head-letter-space:     0.038rem;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -134,9 +134,11 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'author_display_ssim', label: 'Author/Creator'
-    config.add_index_field 'format_ssim', label: 'Resource Type'
-    config.add_index_field 'marc_resource_ssim', label: 'Access'
+    config.add_index_field 'author_display_ssim', label: 'Author/Creator', helper_method: :combine_author_vern
+    config.add_index_field('publication_main_display_ssim',
+      label: 'Publication/Creation',
+      helper_method: :multiple_values_new_line)
+    config.add_index_field 'format_ssim', label: 'Type'
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module SearchResultsHelper
+  def vern_title_search_results_populator(document)
+    vern_titles = document['title_vern_display_tesim']&.map&.with_index(1) do |t, i|
+      tag.p(t, class: "vern-title-search-results-#{i}")
+    end
+
+    return safe_join(vern_titles, tag('br')) if vern_titles.present?
+    ''
+  end
+end

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,0 +1,12 @@
+<%# Override of Blacklight v7.4.1 partial of same name; inserts vernacular title helper before the dl L#4 %>
+<% doc_presenter = index_presenter(document) %>
+<%# default partial to display solr document fields in catalog index view -%>
+<%= vern_title_search_results_populator(document) %>
+<dl class="document-metadata dl-invert row">
+
+  <% doc_presenter.fields_to_render.each do |field_name, field| -%>
+    <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
+    <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
+  <% end -%>
+
+</dl>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CatalogController, type: :controller do
         .blacklight_config
         .index_fields.keys
     end
-    let(:expected_index_fields) { ['author_display_ssim', 'format_ssim', 'marc_resource_ssim'] }
+    let(:expected_index_fields) { ['author_display_ssim', 'format_ssim', 'publication_main_display_ssim'] }
     let(:field_title) { controller.blacklight_config.index.title_field }
 
     context 'field titles' do

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -14,12 +14,16 @@ RSpec.feature 'View Search Results', type: :system, js: false do
       expect(page).to have_link('The Title of my Work')
     end
 
+    it 'displays the vernacular title if populated' do
+      expect(page).to have_css('p.vern-title-search-results-1', text: 'Title of my Work')
+    end
+
     it 'has the right metadata labels' do
-      ['Author/Creator:', 'Resource Type:', 'Access:'].each { |label| expect(page).to have_content(label) }
+      ['Author/Creator:', 'Type:', 'Publication/Creation:'].each { |label| expect(page).to have_content(label) }
     end
 
     it 'has the right values' do
-      ['George Jenkins', 'Book', 'Electronic Resource'].each { |value| expect(page).to have_content(value) }
+      ['George Jenkins', 'Book', 'A dummy publication'].each { |value| expect(page).to have_content(value) }
     end
   end
 


### PR DESCRIPTION
- app/assets/stylesheets/blacklight_catalog/_results_list.scss: styles the vernacular title field.
- app/assets/stylesheets/blacklight_catalog/_variables.scss: variable-izes the numeric values.
- app/controllers/catalog_controller.rb: updates the wanted fields on the search results page.
- app/helpers/search_results_helper.rb: copies and modifies the helper method from Show Page.
- app/views/catalog/_index.html.erb: brings in the Blacklight partial to render the vernacular title on the search result list.
- spec/*: updates test expectations.