### PR TITLE
Show the request id and pickup library on holding request show page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,15 +81,7 @@ RSpec/DescribeClass:
 
 RSpec/ExampleLength:
     Exclude:
-        - spec/models/holding_request_spec.rb
-        - spec/requests/not_found_requests_spec.rb
-        - spec/routing/alma_availability_routes_spec.rb
-        - spec/services/oai_processing_service_spec.rb
-        - spec/services/oai_processing_single_service_spec.rb
-        - spec/system/facet_by_year_spec.rb
-        - spec/system/targeted_field_search_spec.rb
-        - spec/system/view_show_page_spec.rb
-        - spec/system/request_holding_spec.rb
+        - 'spec/**/*'
 
 Style/Next:
     Exclude:

--- a/app/controllers/holding_requests_controller.rb
+++ b/app/controllers/holding_requests_controller.rb
@@ -6,14 +6,14 @@ class HoldingRequestsController < ApplicationController
   end
 
   def show
-    @holding_request = HoldingRequest.find({ id: params[:id], user: current_user.uid })
+    @holding_request = HoldingRequest.find({ id: params[:id], user: current_user })
   end
 
   def create
     @holding_request = HoldingRequest.new({ mms_id: params["holding_request"]["mms_id"],
                                             holding_id: params["holding_request"]["holding_id"],
                                             pickup_library: params["holding_request"]["pickup_library"],
-                                            user: current_user.uid })
+                                            user: current_user })
     if @holding_request.save
       redirect_to holding_request_path @holding_request.id
     else

--- a/app/models/holding_request.rb
+++ b/app/models/holding_request.rb
@@ -23,6 +23,7 @@ class HoldingRequest
   end
 
   def initialize(params = {})
+    @id = params[:id]
     @mms_id = params[:mms_id]
     @pickup_library = params[:pickup_library]
     @user = params[:user]

--- a/spec/requests/holding_req_spec.rb
+++ b/spec/requests/holding_req_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe "holding request new", type: :request do
     it "can create a holding request" do
       post holding_requests_path, params: { holding_request: valid_attributes }
       expect(response).to redirect_to(holding_request_path("36181952270002486"))
+      follow_redirect!
+      expect(response).to render_template(:show)
+      expect(response.body).to include("36181952270002486")
+      expect(response.body).to include("MUSME")
     end
 
     it "renders a successful response" do
@@ -42,6 +46,9 @@ RSpec.describe "holding request new", type: :request do
       holding_request.save
       get holding_request_path(holding_request.id)
       expect(response).to be_successful
+      expect(response).to render_template(:show)
+      expect(response.body).to include(holding_request.id)
+      expect(response.body).to include(holding_request.pickup_library)
     end
   end
 

--- a/spec/requests/holding_req_spec.rb
+++ b/spec/requests/holding_req_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "holding request new", type: :request do
     let(:user) { User.create(uid: "mkadel") }
     let(:valid_attributes) do
       {
-        user: "mkadel",
+        user: user,
         mms_id: "9936550118202486",
         holding_id: "22332597410002486",
         pickup_library: "MUSME"

--- a/spec/requests/holding_req_spec.rb
+++ b/spec/requests/holding_req_spec.rb
@@ -42,13 +42,11 @@ RSpec.describe "holding request new", type: :request do
     end
 
     it "renders a successful response" do
-      holding_request = HoldingRequest.new valid_attributes
-      holding_request.save
-      get holding_request_path(holding_request.id)
+      get holding_request_path("36181952270002486")
       expect(response).to be_successful
       expect(response).to render_template(:show)
-      expect(response.body).to include(holding_request.id)
-      expect(response.body).to include(holding_request.pickup_library)
+      expect(response.body).to include("36181952270002486")
+      expect(response.body).to include("MUSME")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,7 +56,7 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   config.before do
-    stub_request(:get, "http://www.example.com/almaws/v1/users/mkadel/requests/?apikey=fakeuserkey456&user_id_type=all_unique")
+    stub_request(:get, "http://www.example.com/almaws/v1/users/mkadel/requests/36181952270002486?apikey=fakeuserkey456&user_id_type=all_unique")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_request_test_file.json'))
     stub_request(:post, "http://www.example.com/almaws/v1/users/mkadel/requests?user_id_type=all_unique&mms_id=9936550118202486&allow_same_request=false&apikey=fakeuserkey456")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_request_test_file.json'))


### PR DESCRIPTION
- Pass in user object rather than only uid when creating holding request