### PR TITLE
Corrects the metadata fields shown in Search Results (#589).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -139,6 +139,7 @@ class CatalogController < ApplicationController
       label: 'Publication/Creation',
       helper_method: :multiple_values_new_line)
     config.add_index_field 'format_ssim', label: 'Type'
+    config.add_index_field 'edition_tsim', label: 'Edition', helper_method: :multiple_values_new_line
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe CatalogController, type: :controller do
         .blacklight_config
         .index_fields.keys
     end
-    let(:expected_index_fields) { ['author_display_ssim', 'format_ssim', 'publication_main_display_ssim'] }
+    let(:expected_index_fields) do
+      ['author_display_ssim', 'format_ssim', 'publication_main_display_ssim', 'edition_tsim']
+    end
     let(:field_title) { controller.blacklight_config.index.title_field }
 
     context 'field titles' do

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -19,11 +19,13 @@ RSpec.feature 'View Search Results', type: :system, js: false do
     end
 
     it 'has the right metadata labels' do
-      ['Author/Creator:', 'Type:', 'Publication/Creation:'].each { |label| expect(page).to have_content(label) }
+      ['Author/Creator:', 'Type:', 'Publication/Creation:', 'Edition:'].each { |label| expect(page).to have_content(label) }
     end
 
     it 'has the right values' do
-      ['George Jenkins', 'Book', 'A dummy publication'].each { |value| expect(page).to have_content(value) }
+      ['George Jenkins', 'Book', 'A dummy publication', 'A sample edition'].each do |value|
+        expect(page).to have_content(value)
+      end
     end
   end
 


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: adds the Edition field to search results listing.
- spec/controllers/catalog_controller_spec.rb: updates expectations of the shown metadata fields.
- spec/controllers/catalog_controller_spec.rb: tests that the new field shows on the search results page.
<img width="941" alt="Screen Shot 2021-06-10 at 10 02 22 AM" src="https://user-images.githubusercontent.com/18330149/121538765-09862200-c9d3-11eb-9acb-dfe7a9e9ebdf.png">
