### PR TITLE
Refines the title former/later hyperlinks (#618).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -155,8 +155,8 @@ class CatalogController < ApplicationController
     #   Additional/Related Title Information Section
     config.add_show_field 'title_addl_tesim', label: 'Full Title', helper_method: :multiple_values_new_line
     config.add_show_field 'title_uniform_ssim', label: 'Uniform Title', helper_method: :multilined_links_to_facet
-    config.add_show_field 'title_former_ssim', label: 'Former Titles', helper_method: :multilined_links_to_facet
-    config.add_show_field 'title_later_ssim', label: 'Later Titles', helper_method: :multilined_links_to_facet
+    config.add_show_field 'title_former_ssim', label: 'Former Titles', helper_method: :multilined_links_to_title_search
+    config.add_show_field 'title_later_ssim', label: 'Later Titles', helper_method: :multilined_links_to_title_search
     config.add_show_field 'title_series_ssim', label: 'Series Titles', helper_method: :multiple_values_new_line
     config.add_show_field 'emory_collection_tesim', label: 'Collection', helper_method: :multiple_values_new_line
     config.add_show_field('title_added_entry_tesim',

--- a/app/helpers/show_page_helper.rb
+++ b/app/helpers/show_page_helper.rb
@@ -100,14 +100,19 @@ module ShowPageHelper
     link_text + link
   end
 
-  def build_availability_iframes(document_id, physical)
-    tag.iframe('',
-              id: "request-options#{physical ? '-physical' : '-online'}",
-              style: 'border: 1px solid #6c757d;',
-              width: '90%',
-              height: 200,
-              seamless: "seamless",
-              frameBorder: 0,
-              src: openurl(document_id, physical ? 'getit' : 'viewit'))
+  def multilined_links_to_title_search(value)
+    links = build_title_search_links(values_of_field(value), value[:document]['format_ssim'].map { |v| CGI.escape(v) })
+    return safe_join(links, tag('br')) if links.present?
+    ''
+  end
+
+  def build_title_search_links(record_values, record_formats)
+    record_values.map do |v|
+      query = "/?"
+      query += safe_join(record_formats.map { |f| "f%5Bformat_ssim%5D%5B%5D=#{f}" }, "&") if record_formats.present?
+      query += record_formats.present? ? "&q=#{CGI.escape(v)}" : "q=#{CGI.escape(v)}"
+      query += "&search_field=title"
+      link_to v, query
+    end
   end
 end

--- a/spec/helpers/show_page_helpers_spec.rb
+++ b/spec/helpers/show_page_helpers_spec.rb
@@ -135,4 +135,68 @@ RSpec.describe ShowPageHelper, type: :helper do
       expect(helper.direct_link('123')).to eq("www.example.com/catalog/123")
     end
   end
+
+  context '#multilined_links_to_title_search' do
+    let(:value) { SHOW_PAGE_VALUE.dup.merge(field: "title_former_ssim") }
+    let(:later_value) { SHOW_PAGE_VALUE.dup.merge(field: "title_later_ssim") }
+    let(:multi_value) do
+      dupe = SHOW_PAGE_VALUE.dup
+      dupe[:field] = "title_former_ssim"
+      dupe[:document]["title_former_ssim"] = [
+        "Contemporary keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955",
+        "Music technology buyer's guide 1099-2839"
+      ]
+      dupe
+    end
+    let(:value_no_format) do
+      dupe = SHOW_PAGE_VALUE.dup
+      dupe[:field] = "title_former_ssim"
+      dupe[:document]["format_ssim"] = []
+      dupe[:document]["title_former_ssim"] = ["Music technology buyer's guide 1099-2839"]
+      dupe
+    end
+    let(:value_empty) do
+      dupe = SHOW_PAGE_VALUE.dup
+      dupe[:field] = "title_former_ssim"
+      dupe[:document]["title_former_ssim"] = []
+      dupe
+    end
+
+    it 'processes a record value to link to a title search (former)' do
+      expect(helper.multilined_links_to_title_search(value)).to eq(
+        "<a href=\"/?f%5Bformat_ssim%5D%5B%5D=Book&amp;q=Contemporary+keyboard+" \
+        "0361-5820+%28DLC%29+76641315+%28OCoLC%292246955&amp;search_field=title\">" \
+        "Contemporary keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955</a>"
+      )
+    end
+
+    it 'processes a record value to link to a title search (later)' do
+      expect(helper.multilined_links_to_title_search(later_value)).to eq(
+        "<a href=\"/?f%5Bformat_ssim%5D%5B%5D=Book&amp;q=Music+technology+buyer%27s" \
+        "+guide+1099-2839&amp;search_field=title\">Music technology buyer&#39;s " \
+        "guide 1099-2839</a>"
+      )
+    end
+
+    it 'processes multiple record values to links to title search (former)' do
+      expect(helper.multilined_links_to_title_search(multi_value)).to eq(
+        "<a href=\"/?f%5Bformat_ssim%5D%5B%5D=Book&amp;q=Contemporary+keyboard+0361-5820" \
+        "+%28DLC%29+76641315+%28OCoLC%292246955&amp;search_field=title\">Contemporary" \
+        " keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955</a><br /><a href=\"/?f%5B" \
+        "format_ssim%5D%5B%5D=Book&amp;q=Music+technology+buyer%27s+guide+1099-2839&amp;" \
+        "search_field=title\">Music technology buyer&#39;s guide 1099-2839</a>"
+      )
+    end
+
+    it 'processes a record value to link to title search (former) with no format assigned' do
+      expect(helper.multilined_links_to_title_search(value_no_format)).to eq(
+        "<a href=\"/?q=Music+technology+buyer%27s+guide+1099-2839&amp;search_field=title\">" \
+        "Music technology buyer&#39;s guide 1099-2839</a>"
+      )
+    end
+
+    it 'returns nothing when field empty' do
+      expect(helper.multilined_links_to_title_search(value_empty)).to be_empty
+    end
+  end
 end

--- a/spec/support/show_page_value.rb
+++ b/spec/support/show_page_value.rb
@@ -18,7 +18,9 @@ SHOW_PAGE_VALUE = {
     "author_addl_display_tesim": ["Tim Jenkins"], "subject_display_ssim": ["Adventure"],
     "url_suppl_ssim": ["http://www.example.com"], "issn_ssim": ["SOME OTHER MAGICAL NUMBER .12Q"],
     "oclc_ssim": ["8675309"], "other_standard_ids_tesim": ["M080142677"], "publisher_number_tesim": ["H. 4260 H."],
-    "timestamp": "2021-03-18T14:43:52.592Z", "title_vern_display_tesim": ['Title of my Work']
+    "timestamp": "2021-03-18T14:43:52.592Z", "title_vern_display_tesim": ['Title of my Work'],
+    "title_former_ssim": ["Contemporary keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955"],
+    "title_later_ssim": ["Music technology buyer's guide 1099-2839"]
   },
   field: "url_suppl_ssim"
 }.with_indifferent_access.freeze


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: swaps helper methods to newly created function.
- app/helpers/show_page_helper.rb: removes unused iframe method, and creates two methods that form a title query with format facet restriction.
- spec/*: stubs out and tests expectations for new helper method.


https://user-images.githubusercontent.com/18330149/121926021-7ff48e00-cd0b-11eb-96f7-92b1b3305820.mov

