### PR TITLE
Removes colon from library table cell if no subtitle follows (#633).

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -3,7 +3,104 @@
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
 
-  def openurl(mms_id, service = "viewit")
-    openurl_base + "rfr_id=info:sid/primo.exlibrisgroup.com&u.ignore_date_coverage=true&svc_dat=#{service}&rft.mms_id=#{mms_id}"
+  def generic_solr_value_to_url(value)
+    url_arr = build_arr_links_text_split(values_of_field(value))
+    return safe_join(url_arr, tag('br')) if url_arr.present?
+    ''
+  end
+
+  def build_arr_links_text_split(values)
+    values.map do |v|
+      url, text = pull_url_text_from_str(v)
+      tag.a(text, href: url, target: '_blank', rel: 'noopener noreferrer')
+    end
+  end
+
+  def pull_url_text_from_str(str)
+    link_pieces = str.split(' text: ')
+    # url first, text second
+    [link_pieces.first, (link_pieces.size > 1 ? link_pieces[1] : link_pieces.first)]
+  end
+
+  def multiple_values_new_line(value)
+    safe_join(values_of_field(value), tag('br'))
+  end
+
+  def combine_author_vern(value)
+    combined_values = value[:document].combined_author_display_vern
+    return safe_join(combined_values, tag('br')) if combined_values.present?
+    ''
+  end
+
+  def multilined_links_to_facet(value)
+    field = value[:field]
+    ret_vals = value[:values].uniq.map { |v| link_to v, "/?f%5B#{field}%5D%5B%5D=" + CGI.escape(v) } if value[:values].present?
+    return safe_join(ret_vals, tag('br')) if ret_vals.present?
+    ''
+  end
+
+  def author_additional_format(value)
+    ret_str = nil
+    if value[:values].size <= 5
+      ret_str = multilined_links_to_facet_author_addl(value[:values])
+    else
+      build_arr = [multilined_links_to_facet_author_addl(value[:values].first(5))]
+      build_arr.push(
+        author_additional_collapse_span(
+          multilined_links_to_facet_author_addl(value[:values][5..(value[:values].size - 1)])
+        )
+      )
+      build_arr.push(author_additional_collapse_link)
+      ret_str = safe_join(build_arr, tag('br'))
+    end
+    ret_str
+  end
+
+  def author_additional_collapse_link
+    link_to('',
+          '#extended-author-addl',
+          class: 'btn btn-link additional-authors-collapse collapsed',
+          data: { toggle: 'collapse' },
+          role: "button",
+          'aria-expanded' => "false",
+          'aria-controls' => "extended-author-addl")
+  end
+
+  def author_additional_collapse_span(values)
+    tag.span(values, id: 'extended-author-addl', class: 'collapse collapsible-addl-authors')
+  end
+
+  def multilined_links_to_facet_author_addl(values)
+    ret_vals = values.map do |v|
+      line_pieces = v.split(' relator: ')
+      quer_disp = line_pieces[0]
+      relator = line_pieces.size == 2 ? line_pieces[1] : nil
+
+      ret_line = link_to(quer_disp, ("/?f%5Bauthor_addl_ssim%5D%5B%5D=" + CGI.escape(quer_disp))).to_s
+      ret_line += ", #{relator}" if relator.present?
+      ret_line
+    end
+    return safe_join(ret_vals, tag('br')) if ret_vals.present?
+    ''
+  end
+
+  def values_of_field(value)
+    value[:document][value[:field]]
+  end
+
+  def multilined_links_to_title_search(value)
+    links = build_title_search_links(values_of_field(value), value[:document]['format_ssim'].map { |v| CGI.escape(v) })
+    return safe_join(links, tag('br')) if links.present?
+    ''
+  end
+
+  def build_title_search_links(record_values, record_formats)
+    record_values.map do |v|
+      query = "/?"
+      query += safe_join(record_formats.map { |f| "f%5Bformat_ssim%5D%5B%5D=#{f}" }, "&") if record_formats.present?
+      query += record_formats.present? ? "&q=#{CGI.escape(v)}" : "q=#{CGI.escape(v)}"
+      query += "&search_field=title"
+      link_to v, query
+    end
   end
 end

--- a/app/helpers/show_page_helper.rb
+++ b/app/helpers/show_page_helper.rb
@@ -1,28 +1,5 @@
 # frozen_string_literal: true
 module ShowPageHelper
-  def generic_solr_value_to_url(value)
-    url_arr = build_arr_links_text_split(values_of_field(value))
-    return safe_join(url_arr, tag('br')) if url_arr.present?
-    ''
-  end
-
-  def build_arr_links_text_split(values)
-    values.map do |v|
-      url, text = pull_url_text_from_str(v)
-      tag.a(text, href: url, target: '_blank', rel: 'noopener noreferrer')
-    end
-  end
-
-  def pull_url_text_from_str(str)
-    link_pieces = str.split(' text: ')
-    # url first, text second
-    [link_pieces.first, (link_pieces.size > 1 ? link_pieces[1] : link_pieces.first)]
-  end
-
-  def multiple_values_new_line(value)
-    safe_join(values_of_field(value), tag('br'))
-  end
-
   def vernacular_title_populator(document)
     vern_titles = document['title_vern_display_tesim']&.map&.with_index(1) do |t, i|
       tag.h2(t, class: "vernacular_title_#{i}")
@@ -32,87 +9,14 @@ module ShowPageHelper
     ''
   end
 
-  def combine_author_vern(value)
-    combined_values = value[:document].combined_author_display_vern
-    return safe_join(combined_values, tag('br')) if combined_values.present?
-    ''
-  end
-
-  def multilined_links_to_facet(value)
-    field = value[:field]
-    ret_vals = value[:values].uniq.map { |v| link_to v, "/?f%5B#{field}%5D%5B%5D=" + CGI.escape(v) } if value[:values].present?
-    return safe_join(ret_vals, tag('br')) if ret_vals.present?
-    ''
-  end
-
-  def author_additional_format(value)
-    ret_str = nil
-    if value[:values].size <= 5
-      ret_str = multilined_links_to_facet_author_addl(value[:values])
-    else
-      build_arr = [multilined_links_to_facet_author_addl(value[:values].first(5))]
-      build_arr.push(
-        author_additional_collapse_span(
-          multilined_links_to_facet_author_addl(value[:values][5..(value[:values].size - 1)])
-        )
-      )
-      build_arr.push(author_additional_collapse_link)
-      ret_str = safe_join(build_arr, tag('br'))
-    end
-    ret_str
-  end
-
-  def author_additional_collapse_link
-    link_to('',
-          '#extended-author-addl',
-          class: 'btn btn-link additional-authors-collapse collapsed',
-          data: { toggle: 'collapse' },
-          role: "button",
-          'aria-expanded' => "false",
-          'aria-controls' => "extended-author-addl")
-  end
-
-  def author_additional_collapse_span(values)
-    tag.span(values, id: 'extended-author-addl', class: 'collapse collapsible-addl-authors')
-  end
-
-  def multilined_links_to_facet_author_addl(values)
-    ret_vals = values.map do |v|
-      line_pieces = v.split(' relator: ')
-      quer_disp = line_pieces[0]
-      relator = line_pieces.size == 2 ? line_pieces[1] : nil
-
-      ret_line = link_to(quer_disp, ("/?f%5Bauthor_addl_ssim%5D%5B%5D=" + CGI.escape(quer_disp))).to_s
-      ret_line += ", #{relator}" if relator.present?
-      ret_line
-    end
-    return safe_join(ret_vals, tag('br')) if ret_vals.present?
-    ''
-  end
-
-  def values_of_field(value)
-    value[:document][value[:field]]
-  end
-
   def direct_link(document_id)
     link = solr_document_path(document_id)
     link_text = Rails.env.development? ? 'localhost:3000' : ENV['BLACKLIGHT_BASE_URL'] || ''
     link_text + link
   end
 
-  def multilined_links_to_title_search(value)
-    links = build_title_search_links(values_of_field(value), value[:document]['format_ssim'].map { |v| CGI.escape(v) })
-    return safe_join(links, tag('br')) if links.present?
-    ''
-  end
-
-  def build_title_search_links(record_values, record_formats)
-    record_values.map do |v|
-      query = "/?"
-      query += safe_join(record_formats.map { |f| "f%5Bformat_ssim%5D%5B%5D=#{f}" }, "&") if record_formats.present?
-      query += record_formats.present? ? "&q=#{CGI.escape(v)}" : "q=#{CGI.escape(v)}"
-      query += "&search_field=title"
-      link_to v, query
-    end
+  def colonizer(first_str, second_str)
+    return "#{first_str}: #{second_str}" if first_str.present? && second_str.present?
+    first_str
   end
 end

--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -14,8 +14,8 @@
       <tbody>
         <% document.physical_holdings.each.with_index(1) do |holding, index| %>
           <tr id="physical-holding-<%= index.to_s %>">
-            <td><%= "#{holding[:library][:label]}: #{holding[:location][:label]}" %></td>
-            <td><%=holding[:call_number] %></td>
+            <td><%= colonizer(holding[:library][:label], holding[:location][:label]) %></td>
+            <td><%= holding[:call_number] %></td>
             <td><a href="#" class="toggle-table"><% if holding[:availability][:availability_phrase] != "check_holdings" %>
                 <%= pluralize(holding[:availability][:copies], 'copy') +
                       ", #{holding[:availability][:available]} available" +

--- a/spec/helpers/catalog_helpers_spec.rb
+++ b/spec/helpers/catalog_helpers_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CatalogHelper, type: :helper do
+  let(:value) { SHOW_PAGE_VALUE }
+  let(:multivalue) do
+    dupe = SHOW_PAGE_VALUE.dup
+    dupe[:document][dupe[:field]] = 'http://www.example.com', 'http://www.example.com/2'
+    dupe
+  end
+  let(:multivalue_with_text) do
+    dupe = SHOW_PAGE_VALUE.dup
+    dupe[:document][dupe[:field]] = "http://www.example.com text: This is the link's text, bro", "http://www.example.com/2 text: Bro, this link's got text, too"
+    dupe
+  end
+
+  context '#generic_solr_value_to_url' do
+    it 'converts a single value to an anchor tag' do
+      expect(helper.generic_solr_value_to_url(value)).to eq(
+        "<a href=\"http://www.example.com\" target=\"_blank\" rel=\"noopener noreferrer\">http://www.example.com</a>"
+      )
+    end
+
+    it 'converts a multiple values into two anchor tags separated by a breakline' do
+      expect(helper.generic_solr_value_to_url(multivalue)).to eq(
+        "<a href=\"http://www.example.com\" target=\"_blank\" rel=\"noopener noreferrer\">http://www.example.com</a>" \
+          "<br /><a href=\"http://www.example.com/2\" target=\"_blank\" rel=\"noopener noreferrer\">http://www.example.com/2</a>"
+      )
+    end
+
+    it 'converts a multiple values into two anchor tags separated by a breakline and plucks text' do
+      expect(helper.generic_solr_value_to_url(multivalue_with_text)).to eq(
+        "<a href=\"http://www.example.com\" target=\"_blank\" rel=\"noopener noreferrer\">" \
+          "This is the link&#39;s text, bro</a><br /><a href=\"http://www.example.com/2\" target=\"_blank\" " \
+          "rel=\"noopener noreferrer\">Bro, this link&#39;s got text, too</a>"
+      )
+    end
+  end
+
+  context '#multiple_values_new_line' do
+    it 'converts a multiple values into two values separated by a breakline' do
+      expect(helper.multiple_values_new_line(multivalue)).to eq(
+        "http://www.example.com<br />http://www.example.com/2"
+      )
+    end
+  end
+
+  context '#author_additional_format' do
+    let(:value) do
+      dupe = SHOW_PAGE_VALUE.dup
+      dupe[:values] = ["Tim Jenkins"]
+      dupe
+    end
+    let(:value_with_relator) do
+      dupe = SHOW_PAGE_VALUE.dup
+      dupe[:values] = ["Tim Jenkins relator: editor."]
+      dupe
+    end
+    let(:value_with_6_auth_addl) do
+      dupe = SHOW_PAGE_VALUE.dup
+      dupe[:values] = [
+        "Tim Jenkins relator: editor.",
+        "Sally Jenkins",
+        "Betsy Jenkins",
+        "Sal Weitzman relator: ghost writer.",
+        "Mike Birbiglia",
+        "Tim Conway relator: moral support."
+      ]
+      dupe
+    end
+
+    it 'converts a single valued additional author into a facet search hyperlink' do
+      expect(helper.author_additional_format(value)).to eq(
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Jenkins\">Tim Jenkins</a>"
+      )
+    end
+
+    it 'converts a single valued additional author with relator into a facet search hyperlink, leaving relator out of the link' do
+      expect(helper.author_additional_format(value_with_relator)).to eq(
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Jenkins\">Tim Jenkins</a>, editor."
+      )
+    end
+
+    it 'converts a values array with more than 5 items into a new-lined list with a collapsible after 5' do # rubocop:disable RSpec/ExampleLength
+      expect(helper.author_additional_format(value_with_6_auth_addl)).to eq(
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Jenkins\">Tim Jenkins</a>, editor.<br />" \
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Sally+Jenkins\">Sally Jenkins</a><br />" \
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Betsy+Jenkins\">Betsy Jenkins</a><br />" \
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Sal+Weitzman\">Sal Weitzman</a>, ghost writer.<br />" \
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Mike+Birbiglia\">Mike Birbiglia</a><br />" \
+        "<span id=\"extended-author-addl\" class=\"collapse collapsible-addl-authors\">" \
+        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Conway\">Tim Conway</a>, moral support.</span><br />" \
+        "<a class=\"btn btn-link additional-authors-collapse collapsed\" data-toggle=\"collapse\"" \
+        " role=\"button\" aria-expanded=\"false\" aria-controls=\"extended-author-addl\" href=\"#extended-author-addl\"></a>"
+      )
+    end # rubocop:enable RSpec/ExampleLength
+  end
+
+  context '#multilined_links_to_title_search' do
+    let(:value) { SHOW_PAGE_VALUE.dup.merge(field: "title_former_ssim") }
+    let(:later_value) { SHOW_PAGE_VALUE.dup.merge(field: "title_later_ssim") }
+    let(:multi_value) do
+      dupe = SHOW_PAGE_VALUE.dup
+      dupe[:field] = "title_former_ssim"
+      dupe[:document]["title_former_ssim"] = [
+        "Contemporary keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955",
+        "Music technology buyer's guide 1099-2839"
+      ]
+      dupe
+    end
+    let(:value_no_format) do
+      dupe = SHOW_PAGE_VALUE.dup
+      dupe[:field] = "title_former_ssim"
+      dupe[:document]["format_ssim"] = []
+      dupe[:document]["title_former_ssim"] = ["Music technology buyer's guide 1099-2839"]
+      dupe
+    end
+    let(:value_empty) do
+      dupe = SHOW_PAGE_VALUE.dup
+      dupe[:field] = "title_former_ssim"
+      dupe[:document]["title_former_ssim"] = []
+      dupe
+    end
+
+    it 'processes a record value to link to a title search (former)' do
+      expect(helper.multilined_links_to_title_search(value)).to eq(
+        "<a href=\"/?f%5Bformat_ssim%5D%5B%5D=Book&amp;q=Contemporary+keyboard+" \
+        "0361-5820+%28DLC%29+76641315+%28OCoLC%292246955&amp;search_field=title\">" \
+        "Contemporary keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955</a>"
+      )
+    end
+
+    it 'processes a record value to link to a title search (later)' do
+      expect(helper.multilined_links_to_title_search(later_value)).to eq(
+        "<a href=\"/?f%5Bformat_ssim%5D%5B%5D=Book&amp;q=Music+technology+buyer%27s" \
+        "+guide+1099-2839&amp;search_field=title\">Music technology buyer&#39;s " \
+        "guide 1099-2839</a>"
+      )
+    end
+
+    it 'processes multiple record values to links to title search (former)' do
+      expect(helper.multilined_links_to_title_search(multi_value)).to eq(
+        "<a href=\"/?f%5Bformat_ssim%5D%5B%5D=Book&amp;q=Contemporary+keyboard+0361-5820" \
+        "+%28DLC%29+76641315+%28OCoLC%292246955&amp;search_field=title\">Contemporary" \
+        " keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955</a><br /><a href=\"/?f%5B" \
+        "format_ssim%5D%5B%5D=Book&amp;q=Music+technology+buyer%27s+guide+1099-2839&amp;" \
+        "search_field=title\">Music technology buyer&#39;s guide 1099-2839</a>"
+      )
+    end
+
+    it 'processes a record value to link to title search (former) with no format assigned' do
+      expect(helper.multilined_links_to_title_search(value_no_format)).to eq(
+        "<a href=\"/?q=Music+technology+buyer%27s+guide+1099-2839&amp;search_field=title\">" \
+        "Music technology buyer&#39;s guide 1099-2839</a>"
+      )
+    end
+
+    it 'returns nothing when field empty' do
+      expect(helper.multilined_links_to_title_search(value_empty)).to be_empty
+    end
+  end
+end

--- a/spec/helpers/show_page_helpers_spec.rb
+++ b/spec/helpers/show_page_helpers_spec.rb
@@ -15,50 +15,8 @@ RSpec.describe ShowPageHelper, type: :helper do
     )
   end
 
-  let(:value) { SHOW_PAGE_VALUE }
-  let(:multivalue) do
-    dupe = SHOW_PAGE_VALUE.dup
-    dupe[:document][dupe[:field]] = 'http://www.example.com', 'http://www.example.com/2'
-    dupe
-  end
-  let(:multivalue_with_text) do
-    dupe = SHOW_PAGE_VALUE.dup
-    dupe[:document][dupe[:field]] = "http://www.example.com text: This is the link's text, bro", "http://www.example.com/2 text: Bro, this link's got text, too"
-    dupe
-  end
   let(:solr_doc) { SolrDocument.find(TEST_ITEM[:id]) }
   let(:solr_doc2) { SolrDocument.find('456') }
-
-  context '#generic_solr_value_to_url' do
-    it 'converts a single value to an anchor tag' do
-      expect(helper.generic_solr_value_to_url(value)).to eq(
-        "<a href=\"http://www.example.com\" target=\"_blank\" rel=\"noopener noreferrer\">http://www.example.com</a>"
-      )
-    end
-
-    it 'converts a multiple values into two anchor tags separated by a breakline' do
-      expect(helper.generic_solr_value_to_url(multivalue)).to eq(
-        "<a href=\"http://www.example.com\" target=\"_blank\" rel=\"noopener noreferrer\">http://www.example.com</a>" \
-          "<br /><a href=\"http://www.example.com/2\" target=\"_blank\" rel=\"noopener noreferrer\">http://www.example.com/2</a>"
-      )
-    end
-
-    it 'converts a multiple values into two anchor tags separated by a breakline and plucks text' do
-      expect(helper.generic_solr_value_to_url(multivalue_with_text)).to eq(
-        "<a href=\"http://www.example.com\" target=\"_blank\" rel=\"noopener noreferrer\">" \
-          "This is the link&#39;s text, bro</a><br /><a href=\"http://www.example.com/2\" target=\"_blank\" " \
-          "rel=\"noopener noreferrer\">Bro, this link&#39;s got text, too</a>"
-      )
-    end
-  end
-
-  context '#multiple_values_new_line' do
-    it 'converts a multiple values into two values separated by a breakline' do
-      expect(helper.multiple_values_new_line(multivalue)).to eq(
-        "http://www.example.com<br />http://www.example.com/2"
-      )
-    end
-  end
 
   context '#vernacular_title_populator' do
     it 'converts a single valued vernacular title into a h2 with class name' do
@@ -74,57 +32,6 @@ RSpec.describe ShowPageHelper, type: :helper do
     end
   end
 
-  context '#author_additional_format' do
-    let(:value) do
-      dupe = SHOW_PAGE_VALUE.dup
-      dupe[:values] = ["Tim Jenkins"]
-      dupe
-    end
-    let(:value_with_relator) do
-      dupe = SHOW_PAGE_VALUE.dup
-      dupe[:values] = ["Tim Jenkins relator: editor."]
-      dupe
-    end
-    let(:value_with_6_auth_addl) do
-      dupe = SHOW_PAGE_VALUE.dup
-      dupe[:values] = [
-        "Tim Jenkins relator: editor.",
-        "Sally Jenkins",
-        "Betsy Jenkins",
-        "Sal Weitzman relator: ghost writer.",
-        "Mike Birbiglia",
-        "Tim Conway relator: moral support."
-      ]
-      dupe
-    end
-
-    it 'converts a single valued additional author into a facet search hyperlink' do
-      expect(helper.author_additional_format(value)).to eq(
-        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Jenkins\">Tim Jenkins</a>"
-      )
-    end
-
-    it 'converts a single valued additional author with relator into a facet search hyperlink, leaving relator out of the link' do
-      expect(helper.author_additional_format(value_with_relator)).to eq(
-        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Jenkins\">Tim Jenkins</a>, editor."
-      )
-    end
-
-    it 'converts a values array with more than 5 items into a new-lined list with a collapsible after 5' do # rubocop:disable RSpec/ExampleLength
-      expect(helper.author_additional_format(value_with_6_auth_addl)).to eq(
-        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Jenkins\">Tim Jenkins</a>, editor.<br />" \
-        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Sally+Jenkins\">Sally Jenkins</a><br />" \
-        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Betsy+Jenkins\">Betsy Jenkins</a><br />" \
-        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Sal+Weitzman\">Sal Weitzman</a>, ghost writer.<br />" \
-        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Mike+Birbiglia\">Mike Birbiglia</a><br />" \
-        "<span id=\"extended-author-addl\" class=\"collapse collapsible-addl-authors\">" \
-        "<a href=\"/?f%5Bauthor_addl_ssim%5D%5B%5D=Tim+Conway\">Tim Conway</a>, moral support.</span><br />" \
-        "<a class=\"btn btn-link additional-authors-collapse collapsed\" data-toggle=\"collapse\"" \
-        " role=\"button\" aria-expanded=\"false\" aria-controls=\"extended-author-addl\" href=\"#extended-author-addl\"></a>"
-      )
-    end # rubocop:enable RSpec/ExampleLength
-  end
-
   context '#direct_link' do
     around do |example|
       ENV['BLACKLIGHT_BASE_URL'] = 'www.example.com'
@@ -136,67 +43,17 @@ RSpec.describe ShowPageHelper, type: :helper do
     end
   end
 
-  context '#multilined_links_to_title_search' do
-    let(:value) { SHOW_PAGE_VALUE.dup.merge(field: "title_former_ssim") }
-    let(:later_value) { SHOW_PAGE_VALUE.dup.merge(field: "title_later_ssim") }
-    let(:multi_value) do
-      dupe = SHOW_PAGE_VALUE.dup
-      dupe[:field] = "title_former_ssim"
-      dupe[:document]["title_former_ssim"] = [
-        "Contemporary keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955",
-        "Music technology buyer's guide 1099-2839"
-      ]
-      dupe
-    end
-    let(:value_no_format) do
-      dupe = SHOW_PAGE_VALUE.dup
-      dupe[:field] = "title_former_ssim"
-      dupe[:document]["format_ssim"] = []
-      dupe[:document]["title_former_ssim"] = ["Music technology buyer's guide 1099-2839"]
-      dupe
-    end
-    let(:value_empty) do
-      dupe = SHOW_PAGE_VALUE.dup
-      dupe[:field] = "title_former_ssim"
-      dupe[:document]["title_former_ssim"] = []
-      dupe
+  context '#colonizer' do
+    it 'takes two arguments and titles/subtitles them' do
+      expect(helper.colonizer('Ace Ventura', 'Pet Detective')).to eq('Ace Ventura: Pet Detective')
     end
 
-    it 'processes a record value to link to a title search (former)' do
-      expect(helper.multilined_links_to_title_search(value)).to eq(
-        "<a href=\"/?f%5Bformat_ssim%5D%5B%5D=Book&amp;q=Contemporary+keyboard+" \
-        "0361-5820+%28DLC%29+76641315+%28OCoLC%292246955&amp;search_field=title\">" \
-        "Contemporary keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955</a>"
-      )
+    it 'takes the first argument and a nil second argument and returns just the first argument' do
+      expect(helper.colonizer('Stanley Kubrick', nil)).to eq('Stanley Kubrick')
     end
 
-    it 'processes a record value to link to a title search (later)' do
-      expect(helper.multilined_links_to_title_search(later_value)).to eq(
-        "<a href=\"/?f%5Bformat_ssim%5D%5B%5D=Book&amp;q=Music+technology+buyer%27s" \
-        "+guide+1099-2839&amp;search_field=title\">Music technology buyer&#39;s " \
-        "guide 1099-2839</a>"
-      )
-    end
-
-    it 'processes multiple record values to links to title search (former)' do
-      expect(helper.multilined_links_to_title_search(multi_value)).to eq(
-        "<a href=\"/?f%5Bformat_ssim%5D%5B%5D=Book&amp;q=Contemporary+keyboard+0361-5820" \
-        "+%28DLC%29+76641315+%28OCoLC%292246955&amp;search_field=title\">Contemporary" \
-        " keyboard 0361-5820 (DLC) 76641315 (OCoLC)2246955</a><br /><a href=\"/?f%5B" \
-        "format_ssim%5D%5B%5D=Book&amp;q=Music+technology+buyer%27s+guide+1099-2839&amp;" \
-        "search_field=title\">Music technology buyer&#39;s guide 1099-2839</a>"
-      )
-    end
-
-    it 'processes a record value to link to title search (former) with no format assigned' do
-      expect(helper.multilined_links_to_title_search(value_no_format)).to eq(
-        "<a href=\"/?q=Music+technology+buyer%27s+guide+1099-2839&amp;search_field=title\">" \
-        "Music technology buyer&#39;s guide 1099-2839</a>"
-      )
-    end
-
-    it 'returns nothing when field empty' do
-      expect(helper.multilined_links_to_title_search(value_empty)).to be_empty
+    it 'takes a nil first argument and whatever second argument and returns nil' do
+      expect(helper.colonizer(nil, 'Garbage')).to be_nil
     end
   end
 end


### PR DESCRIPTION
- app/helpers/catalog_helper.rb: removes unused helper, than transfers methods that have more relation to the catalog controller than the show page to this file.
- app/helpers/show_page_helper.rb: removes the methods transferred to the CatalogHelper, and adds the `colonizer` method.
- app/views/catalog/_show_request_options.html.erb: utilizes the new method where the bug was found.
- spec/*: refactors the testing files to match the new homes of the methods, and institutes a new test for the just created helper.
<img width="1206" alt="Screen Shot 2021-06-15 at 10 31 06 AM" src="https://user-images.githubusercontent.com/18330149/122072754-dcb47f00-cdc5-11eb-95e9-f8e37bf10fc4.png">
