### PR TITLE
Moves affiliate login button

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,8 +2,6 @@
 
 <%= render "devise/shared/links" %>
 
-<%= link_to "Affiliate login", alma_social_login_url %>
-
 <% if AuthConfig.use_database_auth? %>
   <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <div class="form-inputs">

--- a/app/views/static/contact.html.erb
+++ b/app/views/static/contact.html.erb
@@ -70,3 +70,5 @@
               </div>
             </div>
           </div>
+
+<%= link_to "Affiliate login", alma_social_login_url %>


### PR DESCRIPTION
* We are moving the affiliate login button away from the normal login page until we can test the functionality and it is approved.