### PR TITLE
Corrects Rspec anomalies.

### DIFF
--- a/app/views/advanced/_advanced_search_facets_as_select.html.erb
+++ b/app/views/advanced/_advanced_search_facets_as_select.html.erb
@@ -5,7 +5,7 @@
   Also incorporates the manual input field for Publication Date range from Penn, 
   as well.
 %>
-<% facets_from_request(facet_field_names).each do |display_facet| %>
+<% facets_from_request(facet_field_names, @response).each do |display_facet| %>
   <% if display_facet.items.present? %>
     <div class="form-group advanced-search-facet">
       <%= label_tag display_facet.name.parameterize, class: 'col-sm-3 control-label' do %>

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
       it 'shows the section when format_ssim populated' do
         visit solr_document_path(id)
 
-        expect(page).to have_css('h2', text: 'MORE OPTIONS')
+        expect(page.body).to have_css('h2', text: 'More Options')
         expect(page).to have_link('Find more information about Books')
       end
 
@@ -322,7 +322,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
         end
 
         it 'does not show the section' do
-          expect(page).not_to have_css('h2', text: 'MORE OPTIONS')
+          expect(page.body).not_to have_css('h2', text: 'More Options')
           expect(page).not_to have_link('Find more information about Books')
         end
       end
@@ -338,7 +338,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
 
     it "shows the location header", alma: true do
       expect(page).to have_content("Where to find it")
-      expect(page).to have_content("REQUEST OPTIONS")
+      expect(page.body).to have_content("Request Options")
       expect(page).to have_content("Marian K. Heilbrun Music Media")
       expect(page).to have_content("Circulation Desk")
       expect(page).to have_content("ML410 .M5 H87 2019 CD-SOUND")
@@ -368,9 +368,9 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
 
     it "shows item level holdings information" do
       click_link('3 copies, 3 available, 0 requests')
-      expect(page).to have_content('010002885298')
-      expect(page).to have_content('Item in place')
-      expect(page).to have_content('barcode')
+      expect(page.body).to have_content('010002885298')
+      expect(page.body).to have_content('Item in place')
+      expect(page.body).to have_content('barcode')
     end
 
     it "has a button to request holdings" do


### PR DESCRIPTION
- app/views/advanced/_advanced_search_facets_as_select.html.erb: adds `@response` to accommodate the deprecated behavior warning. 
- spec/system/view_show_page_spec.rb: alleviates the anomaly that the test environment checks the page before CSS styling is applied, while the CI checks it afterwards. Per https://stackoverflow.com/questions/11316249/case-insensitive-rspec-match, checking the body of the page instead of just the rendered page value will return the same in both environments. 

No screenshots necessary.