### PR TITLE
Provide links based on Availability AVE field (#634).

### DIFF
--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -10,6 +10,14 @@ module Statusable
     ENV.fetch('ALMA_BIB_KEY')
   end
 
+  def alma_openurl_base
+    ENV.fetch('ALMA_BASE_SANDBOX_URL')
+  end
+
+  def alma_institution
+    ENV.fetch('INSTITUTION')
+  end
+
   # Documentation for availability field from Alma
   # https://knowledge.exlibrisgroup.com/Primo/Knowledge_Articles/What_does_each_subfield_in_the_AVA_tag_hold_when_records_are_extracted_from_Voyager_for_Primo%3F
   def full_record
@@ -121,8 +129,8 @@ module Statusable
   end
 
   def online_holdings
-    return nil unless url_fulltext
-    url_fulltext.map do |entry|
+    return nil if online_from_availability.blank?
+    online_from_availability.map do |entry|
       url_hash = JSON.parse(entry)
       # TODO: Can remove conditional once re-index is completed, and just keep the "if" portion
       if url_hash.keys.include?("url")
@@ -136,5 +144,29 @@ module Statusable
   def physical_holdings
     return nil unless raw_physical_availability
     raw_physical_availability.map { |availability| physical_item_hash(availability) }
+  end
+
+  def online_from_availability
+    ave_availability = full_record.xpath('bib/record/datafield[@tag="AVE"]')
+    ret_array = ave_availability.reduce([]) do |memo, value|
+      next memo unless ave_u_8_present?(ave_availability)
+      memo << {
+        "label" => value.at_xpath('subfield[@code="m"]')&.text || value.at_xpath('subfield[@code="n"]')&.text || value.at_xpath('subfield[@code="t"]')&.text,
+        "url" => build_ave_url(value.at_xpath('subfield[@code="8"]').text)
+      }.to_json
+    end
+    url_fulltext.present? ? url_fulltext + ret_array : ret_array
+  end
+
+  def ave_u_8_present?(availability)
+    availability.at_xpath('subfield[@code="u"]').present? && availability.at_xpath('subfield[@code="8"]').present?
+  end
+
+  def build_ave_url(portfolio_id)
+    "#{alma_openurl_base}/discovery/openurl#{ave_query}#{portfolio_id}"
+  end
+
+  def ave_query
+    "?institution=#{alma_institution}&vid=#{alma_institution}:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid="
   end
 end

--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -129,7 +129,7 @@ module Statusable
   end
 
   def online_holdings
-    return nil if online_from_availability.blank?
+    return [] if online_from_availability.blank?
     online_from_availability.map do |entry|
       url_hash = JSON.parse(entry)
       # TODO: Can remove conditional once re-index is completed, and just keep the "if" portion

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe SolrDocument do
       expect(solr_doc.physical_holdings[0][:availability]).to eq({ copies: 3, available: 3, requests: 0, availability_phrase: "available" })
       expect(solr_doc.physical_holdings[1][:availability]).to eq({ copies: 2, available: 2, requests: 1, availability_phrase: "available" })
       expect(solr_doc.physical_holdings[2][:availability]).to eq({ copies: 3, available: 1, requests: 0, availability_phrase: "available" })
-      expect(solr_doc.online_holdings).to be nil
+      expect(solr_doc.online_holdings).to be_empty
     end
 
     it "can say whether or not the title is available for a hold request" do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -5,11 +5,14 @@ RSpec.describe SolrDocument do
   around do |example|
     orig_url = ENV['ALMA_API_URL']
     orig_key = ENV['ALMA_BIB_KEY']
+    orig_openurl = ENV['ALMA_BASE_SANDBOX_URL']
     ENV['ALMA_API_URL'] = 'http://www.example.com'
+    ENV['ALMA_BASE_SANDBOX_URL'] = 'http://www.example.com/hello'
     ENV['ALMA_BIB_KEY'] = "fakebibkey123"
     example.run
     ENV['ALMA_API_URL'] = orig_url
     ENV['ALMA_BIB_KEY'] = orig_key
+    ENV['ALMA_BASE_SANDBOX_URL'] = orig_openurl
   end
 
   before do
@@ -86,6 +89,9 @@ RSpec.describe SolrDocument do
       [{
         url: "http://proxy.library.emory.edu/login?url=https://doi.org/10.31022/R082-83",
         label: "Online resource from A-R Editions"
+      }, {
+        label: "Online resource from A-R Editions",
+        url: "http://www.example.com/hello/discovery/openurl?institution=&vid=:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53450970510002486"
       }]
     end
 
@@ -106,6 +112,9 @@ RSpec.describe SolrDocument do
       [{
         url: "http://proxy.library.emory.edu/login?url=https://www.sciencedirect.com/science/book/9780702078798",
         label: "Online resource from Elsevier"
+      }, {
+        label: "Online resource from Elsevier",
+        url: "http://www.example.com/hello/discovery/openurl?institution=&vid=:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53445539330002486"
       }]
     end
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -6,13 +6,16 @@ RSpec.describe SolrDocument do
     orig_url = ENV['ALMA_API_URL']
     orig_key = ENV['ALMA_BIB_KEY']
     orig_openurl = ENV['ALMA_BASE_SANDBOX_URL']
+    orig_inst = ENV["INSTITUTION"]
     ENV['ALMA_API_URL'] = 'http://www.example.com'
     ENV['ALMA_BASE_SANDBOX_URL'] = 'http://www.example.com/hello'
     ENV['ALMA_BIB_KEY'] = "fakebibkey123"
+    ENV["INSTITUTION"] = "SOME_INSTITUTION"
     example.run
     ENV['ALMA_API_URL'] = orig_url
     ENV['ALMA_BIB_KEY'] = orig_key
     ENV['ALMA_BASE_SANDBOX_URL'] = orig_openurl
+    ENV["INSTITUTION"] = orig_inst
   end
 
   before do
@@ -91,7 +94,7 @@ RSpec.describe SolrDocument do
         label: "Online resource from A-R Editions"
       }, {
         label: "Online resource from A-R Editions",
-        url: "http://www.example.com/hello/discovery/openurl?institution=&vid=:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53450970510002486"
+        url: "http://www.example.com/hello/discovery/openurl?institution=SOME_INSTITUTION&vid=SOME_INSTITUTION:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53450970510002486"
       }]
     end
 
@@ -114,7 +117,7 @@ RSpec.describe SolrDocument do
         label: "Online resource from Elsevier"
       }, {
         label: "Online resource from Elsevier",
-        url: "http://www.example.com/hello/discovery/openurl?institution=&vid=:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53445539330002486"
+        url: "http://www.example.com/hello/discovery/openurl?institution=SOME_INSTITUTION&vid=SOME_INSTITUTION:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53445539330002486"
       }]
     end
 

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -397,6 +397,10 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
     it "can find the online object" do
       expect(page).to have_content('Canzoni villanesche and villanelle')
       expect(page).to have_link("Online resource from A-R Editions", href: "http://proxy.library.emory.edu/login?url=https://doi.org/10.31022/R082-83")
+      expect(page).to have_link(
+        "Online resource from A-R Editions",
+        href: "http://example2.com/discovery/openurl?institution=SOME_INSTITUTION&vid=SOME_INSTITUTION:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53450970510002486"
+      )
       expect(page).to have_link("Services page", href: "http://example2.com/discovery/openurl?institution=SOME_INSTITUTION&vid=SOME_INSTITUTION:blacklight&rft.mms_id=9937275387802486")
     end
 
@@ -421,6 +425,10 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
     it "can find the funky url object" do
       expect(page).to have_content('Clinical cases in tropical medicine')
       expect(page).to have_link("Online resource from Elsevier", href: "http://proxy.library.emory.edu/login?url=https://www.sciencedirect.com/science/book/9780702078798")
+      expect(page).to have_link(
+        "Online resource from Elsevier",
+        href: "http://example2.com/discovery/openurl?institution=SOME_INSTITUTION&vid=SOME_INSTITUTION:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53445539330002486"
+      )
     end
   end
 


### PR DESCRIPTION
- app/models/concerns/statusable.rb: adds links to records with AVE fields containing a "u" subfield containing "publishing_base_url".
- spec/*: tests for new expectations.

<img width="2391" alt="Screen Shot 2021-06-22 at 9 13 48 AM" src="https://user-images.githubusercontent.com/18330149/122930748-3ecb3200-d33a-11eb-869c-868534a31532.png">
