### PR TITLE
Show actual number of requests, rather than 0 or 1

### DIFF
--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -120,12 +120,8 @@ module Statusable
     url = base_requests_link + "?status=active&apikey=#{api_bib_key}"
     response = RestClient.get url, { accept: :xml }
     body = Nokogiri::XML(response)
-    request_holding_id = body.at_xpath('user_requests/user_request/holding_id')&.inner_text
-    if holding_id == request_holding_id
-      1
-    else
-      0
-    end
+    request_holding_ids = body.xpath('user_requests/user_request/holding_id').map(&:inner_text)
+    request_holding_ids.count(holding_id)
   end
 
   def physical_holding_values(availability)

--- a/spec/fixtures/alma_request_test_file.xml
+++ b/spec/fixtures/alma_request_test_file.xml
@@ -1,32 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<user_requests total_record_count="1">
+<user_requests total_record_count="2">
   <user_request>
-    <user_primary_id>janeq1</user_primary_id>
-    <request_id>38387672620002486</request_id>
-    <additional_id>383-876-726-2</additional_id>
+    <user_primary_id>mkadel1</user_primary_id>
+    <request_id>36187952390002486</request_id>
+    <additional_id>361-879-523-9</additional_id>
     <request_type>HOLD</request_type>
     <request_sub_type desc="Patron physical item request">PATRON_PHYSICAL</request_sub_type>
     <mms_id>9936550118202486</mms_id>
     <title>MLA handbook.</title>
     <holding_id>22332597410002486</holding_id>
-    <pickup_location>Marian K. Heilbrun Music Media</pickup_location>
+    <pickup_location>Robert W. Woodruff Library</pickup_location>
     <pickup_location_type>LIBRARY</pickup_location_type>
-    <pickup_location_library>MUSME</pickup_location_library>
+    <pickup_location_library>UNIV</pickup_location_library>
     <managed_by_library>Oxford College Library</managed_by_library>
     <managed_by_circulation_desk>Oxford Circulation</managed_by_circulation_desk>
     <managed_by_library_code>OXFD</managed_by_library_code>
     <managed_by_circulation_desk_code>DEFAULT_CIRC_DESK</managed_by_circulation_desk_code>
     <material_type/>
-    <last_interest_date>2021-05-30Z</last_interest_date>
+    <last_interest_date>2021-06-25Z</last_interest_date>
     <volume/>
     <issue/>
     <part/>
     <date_of_publication/>
-    <comment>IGNORE - TESTING</comment>
     <request_status>In Process</request_status>
-    <request_date>2021-05-29Z</request_date>
-    <request_time>2021-05-29T22:53:09.218Z</request_time>
+    <request_date>2021-06-25Z</request_date>
+    <request_time>2021-06-25T13:36:43.007Z</request_time>
     <task_name>Pickup From Shelf</task_name>
-    <expiry_date>2021-05-30Z</expiry_date>
+    <expiry_date>2021-06-25Z</expiry_date>
+  </user_request>
+  <user_request>
+    <user_primary_id>mkadel1</user_primary_id>
+    <request_id>36187952470002486</request_id>
+    <additional_id>361-879-524-7</additional_id>
+    <request_type>HOLD</request_type>
+    <request_sub_type desc="Patron physical item request">PATRON_PHYSICAL</request_sub_type>
+    <mms_id>9936550118202486</mms_id>
+    <title>MLA handbook.</title>
+    <holding_id>22332597410002486</holding_id>
+    <pickup_location>Robert W. Woodruff Library</pickup_location>
+    <pickup_location_type>LIBRARY</pickup_location_type>
+    <pickup_location_library>UNIV</pickup_location_library>
+    <managed_by_library>Oxford College Library</managed_by_library>
+    <managed_by_circulation_desk>Oxford Circulation</managed_by_circulation_desk>
+    <managed_by_library_code>OXFD</managed_by_library_code>
+    <managed_by_circulation_desk_code>DEFAULT_CIRC_DESK</managed_by_circulation_desk_code>
+    <material_type/>
+    <last_interest_date>2021-06-25Z</last_interest_date>
+    <volume/>
+    <issue/>
+    <part/>
+    <date_of_publication/>
+    <comment>test 2 </comment>
+    <request_status>In Process</request_status>
+    <request_date>2021-06-25Z</request_date>
+    <request_time>2021-06-25T13:37:26.617Z</request_time>
+    <task_name>Pickup From Shelf</task_name>
+    <expiry_date>2021-06-25Z</expiry_date>
   </user_request>
 </user_requests>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -82,9 +82,18 @@ RSpec.describe SolrDocument do
 
     it "can calculate complex availability information" do
       expect(solr_doc.physical_holdings[0][:availability]).to eq({ copies: 3, available: 3, requests: 0, availability_phrase: "available" })
-      expect(solr_doc.physical_holdings[1][:availability]).to eq({ copies: 2, available: 2, requests: 1, availability_phrase: "available" })
+      expect(solr_doc.physical_holdings[1][:availability]).to eq({ copies: 2, available: 2, requests: 2, availability_phrase: "available" })
       expect(solr_doc.physical_holdings[2][:availability]).to eq({ copies: 3, available: 1, requests: 0, availability_phrase: "available" })
       expect(solr_doc.online_holdings).to be_empty
+    end
+
+    it "limits the number of calls to the Alma API for bib requests" do
+      stub_bib_request = stub_request(:get, "http://www.example.com/almaws/v1/bibs/9936550118202486?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail,requests&view=full")
+                         .to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file_6.xml'), headers: {})
+      solr_doc.physical_holdings
+      solr_doc.physical_holdings
+      solr_doc.online_holdings
+      expect(stub_bib_request).to have_been_made.once
     end
 
     it "can say whether or not the title is available for a hold request" do

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -361,8 +361,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
     it "shows complex holdings and requests information" do
       expect(page).to have_content('3 copies, 3 available, 0 requests')
       expect(page).to have_content('3 copies, 1 available, 0 requests')
-      expect(page).to have_content('2 copies, 2 available, 1 request')
-      expect(page).not_to have_content('2 copies, 2 available, 1 requests')
+      expect(page).to have_content('2 copies, 2 available, 2 requests')
     end
 
     it "shows item level holdings information" do


### PR DESCRIPTION
First pass just showed 0 or 1 for number of requests, this updates to show real counts by holding_id

![image](https://user-images.githubusercontent.com/45948126/123436508-af718900-d59c-11eb-872b-6f6b8487410f.png)
