### PR TITLE
Adds ability to request at item level

### DIFF
--- a/app/controllers/hold_requests_controller.rb
+++ b/app/controllers/hold_requests_controller.rb
@@ -27,6 +27,6 @@ class HoldRequestsController < ApplicationController
   private
 
   def hold_request_params
-    params.require(:hold_request).permit(:id, :mms_id, :title, :holding_id, :pickup_library, :not_needed_after, :comment, :user, :holding_library, :holding_location)
+    params.require(:hold_request).permit(:id, :mms_id, :title, :holding_id, :pickup_library, :not_needed_after, :comment, :user, :holding_library, :holding_location, :holding_item_id)
   end
 end

--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -142,6 +142,7 @@ module Statusable
     holding_items = items_by_holding_record(holding_id, user)
     holding_items.xpath("//item/item_data").each do |node|
       item_info = {
+        pid: node.xpath("pid")&.inner_text,
         barcode: node.xpath("barcode")&.inner_text,
         type: node.xpath("physical_material_type").attr("desc")&.value,
         policy: item_policy(node, user),

--- a/app/views/hold_requests/_form.html.erb
+++ b/app/views/hold_requests/_form.html.erb
@@ -1,6 +1,7 @@
 <%= simple_form_for @hold_request do |f| %>
   <%= f.input :mms_id, value: @hold_request.mms_id, readonly: true %>
   <%= f.input :pickup_library, collection: @hold_request.pickup_library_options.map { |h| [h[:label], h[:value]] }, required: true, prompt: "--" %>
+  <%= f.input :holding_item_id, collection: @hold_request.items.map { |h| [h[:label], h[:value]] }, required: true, prompt: "--" unless @hold_request.items.empty? %>
   <%= f.input :not_needed_after, as: :date, :input_html => { :value => Date.today} %>
   <%= f.input :comment %>
   <%= f.submit %>

--- a/spec/fixtures/alma_item_records/22187557270002486.xml
+++ b/spec/fixtures/alma_item_records/22187557270002486.xml
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<items total_record_count="4">
+  <item link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486/items/23187557230002486">
+    <bib_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486">
+      <mms_id>990011434390302486</mms_id>
+      <title>Early keyboard journal /</title>
+      <author>Southeastern Historical Keyboard Society (U.S.)</author>
+      <issn>0899-8132</issn>
+      <complete_edition/>
+      <network_numbers>
+        <network_number>X0098037#Ar</network_number>
+        <network_number>(Sirsi) o09837764</network_number>
+        <network_number>(OCoLC)09837764</network_number>
+        <network_number>u1903912</network_number>
+        <network_number>(Aleph)001143439EMU01</network_number>
+      </network_numbers>
+      <place_of_publication>Athens, Ga. :</place_of_publication>
+      <date_of_publication>1983-</date_of_publication>
+      <publisher_const>Southeastern Historical Keyboard Society and the University of Georgia School of Music</publisher_const>
+    </bib_data>
+    <holding_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486">
+      <holding_id>22187557270002486</holding_id>
+      <permanent_call_number_type desc="Library of Congress classification">0</permanent_call_number_type>
+      <permanent_call_number>ML549 .E38</permanent_call_number>
+      <call_number_type desc="Library of Congress classification">0</call_number_type>
+      <call_number>ML549 .E38</call_number>
+      <accession_number/>
+      <copy_id>1</copy_id>
+      <in_temp_location>false</in_temp_location>
+      <temp_library/>
+      <temp_location/>
+      <temp_call_number_type/>
+      <temp_call_number/>
+      <temp_call_number_source/>
+      <temp_policy/>
+    </holding_data>
+    <item_data>
+      <pid>23187557230002486</pid>
+      <barcode>010002762510</barcode>
+      <creation_date>2015-12-03Z</creation_date>
+      <modification_date>2015-12-03Z</modification_date>
+      <base_status desc="Item in place">1</base_status>
+      <awaiting_reshelving>false</awaiting_reshelving>
+      <physical_material_type desc="Bound Issue">ISSBD</physical_material_type>
+      <policy desc="4 Day Loan">05</policy>
+      <provenance/>
+      <po_line>94929</po_line>
+      <is_magnetic>false</is_magnetic>
+      <arrival_date>2014-01-24Z</arrival_date>
+      <expected_arrival_date>2010-03-12Z</expected_arrival_date>
+      <year_of_issue/>
+      <enumeration_a>25-29</enumeration_a>
+      <enumeration_b/>
+      <enumeration_c/>
+      <enumeration_d/>
+      <enumeration_e/>
+      <enumeration_f/>
+      <enumeration_g/>
+      <enumeration_h/>
+      <chronology_i>2010-2012</chronology_i>
+      <chronology_j/>
+      <chronology_k/>
+      <chronology_l/>
+      <chronology_m/>
+      <break_indicator/>
+      <pattern_type/>
+      <linking_number/>
+      <type_of_unit/>
+      <description>v.25-29(2010-2012)</description>
+      <receiving_operator>import</receiving_operator>
+      <process_type/>
+      <inventory_number/>
+      <inventory_price/>
+      <library desc="Marian K. Heilbrun Music Media">MUSME</library>
+      <location desc="Music and Media Book Stacks">STACK</location>
+      <alternative_call_number/>
+      <alternative_call_number_type/>
+      <storage_location_id/>
+      <pages/>
+      <pieces/>
+      <public_note/>
+      <fulfillment_note/>
+      <due_date_policy>Log in for more information</due_date_policy>
+      <internal_note_1/>
+      <internal_note_2/>
+      <internal_note_3/>
+      <statistics_note_1/>
+      <statistics_note_2/>
+      <statistics_note_3/>
+      <requested>false</requested>
+      <physical_condition/>
+    </item_data>
+  </item>
+  <item link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486/items/23187557240002486">
+    <bib_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486">
+      <mms_id>990011434390302486</mms_id>
+      <title>Early keyboard journal /</title>
+      <author>Southeastern Historical Keyboard Society (U.S.)</author>
+      <issn>0899-8132</issn>
+      <complete_edition/>
+      <network_numbers>
+        <network_number>X0098037#Ar</network_number>
+        <network_number>(Sirsi) o09837764</network_number>
+        <network_number>(OCoLC)09837764</network_number>
+        <network_number>u1903912</network_number>
+        <network_number>(Aleph)001143439EMU01</network_number>
+      </network_numbers>
+      <place_of_publication>Athens, Ga. :</place_of_publication>
+      <date_of_publication>1983-</date_of_publication>
+      <publisher_const>Southeastern Historical Keyboard Society and the University of Georgia School of Music</publisher_const>
+    </bib_data>
+    <holding_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486">
+      <holding_id>22187557270002486</holding_id>
+      <permanent_call_number_type desc="Library of Congress classification">0</permanent_call_number_type>
+      <permanent_call_number>ML549 .E38</permanent_call_number>
+      <call_number_type desc="Library of Congress classification">0</call_number_type>
+      <call_number>ML549 .E38</call_number>
+      <accession_number/>
+      <copy_id>1</copy_id>
+      <in_temp_location>false</in_temp_location>
+      <temp_library/>
+      <temp_location/>
+      <temp_call_number_type/>
+      <temp_call_number/>
+      <temp_call_number_source/>
+      <temp_policy/>
+    </holding_data>
+    <item_data>
+      <pid>23187557240002486</pid>
+      <barcode>010003021393</barcode>
+      <creation_date>2015-12-03Z</creation_date>
+      <modification_date>2017-08-29Z</modification_date>
+      <base_status desc="Item in place">1</base_status>
+      <awaiting_reshelving>false</awaiting_reshelving>
+      <physical_material_type desc="Bound Issue">ISSBD</physical_material_type>
+      <policy desc="Non-circ., Reading Rm Only">02</policy>
+      <provenance/>
+      <po_line>94929</po_line>
+      <is_magnetic>false</is_magnetic>
+      <arrival_date>2017-05-04Z</arrival_date>
+      <expected_arrival_date>2014-03-12Z</expected_arrival_date>
+      <year_of_issue/>
+      <enumeration_a>30</enumeration_a>
+      <enumeration_b/>
+      <enumeration_c/>
+      <enumeration_d/>
+      <enumeration_e/>
+      <enumeration_f/>
+      <enumeration_g/>
+      <enumeration_h/>
+      <chronology_i>2014</chronology_i>
+      <chronology_j/>
+      <chronology_k/>
+      <chronology_l/>
+      <chronology_m/>
+      <break_indicator/>
+      <pattern_type/>
+      <linking_number/>
+      <type_of_unit/>
+      <description>v.30(2013)</description>
+      <receiving_operator>2060484</receiving_operator>
+      <process_type/>
+      <inventory_number/>
+      <inventory_price/>
+      <library desc="Marian K. Heilbrun Music Media">MUSME</library>
+      <location desc="Music and Media Book Stacks">STACK</location>
+      <alternative_call_number/>
+      <alternative_call_number_type/>
+      <storage_location_id/>
+      <pages/>
+      <pieces/>
+      <public_note/>
+      <fulfillment_note/>
+      <due_date_policy>Log in for more information</due_date_policy>
+      <internal_note_1/>
+      <internal_note_2/>
+      <internal_note_3>Process Status: NA</internal_note_3>
+      <statistics_note_1/>
+      <statistics_note_2/>
+      <statistics_note_3/>
+      <requested>false</requested>
+      <physical_condition/>
+    </item_data>
+  </item>
+  <item link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486/items/23187557250002486">
+    <bib_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486">
+      <mms_id>990011434390302486</mms_id>
+      <title>Early keyboard journal /</title>
+      <author>Southeastern Historical Keyboard Society (U.S.)</author>
+      <issn>0899-8132</issn>
+      <complete_edition/>
+      <network_numbers>
+        <network_number>X0098037#Ar</network_number>
+        <network_number>(Sirsi) o09837764</network_number>
+        <network_number>(OCoLC)09837764</network_number>
+        <network_number>u1903912</network_number>
+        <network_number>(Aleph)001143439EMU01</network_number>
+      </network_numbers>
+      <place_of_publication>Athens, Ga. :</place_of_publication>
+      <date_of_publication>1983-</date_of_publication>
+      <publisher_const>Southeastern Historical Keyboard Society and the University of Georgia School of Music</publisher_const>
+    </bib_data>
+    <holding_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486">
+      <holding_id>22187557270002486</holding_id>
+      <permanent_call_number_type desc="Library of Congress classification">0</permanent_call_number_type>
+      <permanent_call_number>ML549 .E38</permanent_call_number>
+      <call_number_type desc="Library of Congress classification">0</call_number_type>
+      <call_number>ML549 .E38</call_number>
+      <accession_number/>
+      <copy_id>1</copy_id>
+      <in_temp_location>false</in_temp_location>
+      <temp_library/>
+      <temp_location/>
+      <temp_call_number_type/>
+      <temp_call_number/>
+      <temp_call_number_source/>
+      <temp_policy/>
+    </holding_data>
+    <item_data>
+      <pid>23187557250002486</pid>
+      <barcode>010001311175</barcode>
+      <creation_date>2015-12-03Z</creation_date>
+      <modification_date>2015-12-03Z</modification_date>
+      <base_status desc="Item in place">1</base_status>
+      <awaiting_reshelving>false</awaiting_reshelving>
+      <physical_material_type desc="Bound Issue">ISSBD</physical_material_type>
+      <policy desc="4 Day Loan">05</policy>
+      <provenance/>
+      <po_line>94929</po_line>
+      <is_magnetic>false</is_magnetic>
+      <arrival_date>2007-12-20Z</arrival_date>
+      <year_of_issue/>
+      <enumeration_a>21-24</enumeration_a>
+      <enumeration_b>21-24</enumeration_b>
+      <enumeration_c/>
+      <enumeration_d/>
+      <enumeration_e/>
+      <enumeration_f/>
+      <enumeration_g/>
+      <enumeration_h/>
+      <chronology_i>2003</chronology_i>
+      <chronology_j/>
+      <chronology_k/>
+      <chronology_l/>
+      <chronology_m/>
+      <break_indicator/>
+      <pattern_type/>
+      <linking_number/>
+      <type_of_unit/>
+      <description>V.21-24 2003-2006</description>
+      <receiving_operator>import</receiving_operator>
+      <process_type/>
+      <inventory_number/>
+      <inventory_price/>
+      <library desc="Marian K. Heilbrun Music Media">MUSME</library>
+      <location desc="Music and Media Book Stacks">STACK</location>
+      <alternative_call_number/>
+      <alternative_call_number_type/>
+      <storage_location_id/>
+      <pages/>
+      <pieces/>
+      <public_note/>
+      <fulfillment_note/>
+      <due_date_policy>Log in for more information</due_date_policy>
+      <internal_note_1/>
+      <internal_note_2/>
+      <internal_note_3/>
+      <statistics_note_1/>
+      <statistics_note_2/>
+      <statistics_note_3/>
+      <requested>false</requested>
+      <physical_condition/>
+    </item_data>
+  </item>
+  <item link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486/items/23187557260002486">
+    <bib_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486">
+      <mms_id>990011434390302486</mms_id>
+      <title>Early keyboard journal /</title>
+      <author>Southeastern Historical Keyboard Society (U.S.)</author>
+      <issn>0899-8132</issn>
+      <complete_edition/>
+      <network_numbers>
+        <network_number>X0098037#Ar</network_number>
+        <network_number>(Sirsi) o09837764</network_number>
+        <network_number>(OCoLC)09837764</network_number>
+        <network_number>u1903912</network_number>
+        <network_number>(Aleph)001143439EMU01</network_number>
+      </network_numbers>
+      <place_of_publication>Athens, Ga. :</place_of_publication>
+      <date_of_publication>1983-</date_of_publication>
+      <publisher_const>Southeastern Historical Keyboard Society and the University of Georgia School of Music</publisher_const>
+    </bib_data>
+    <holding_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486">
+      <holding_id>22187557270002486</holding_id>
+      <permanent_call_number_type desc="Library of Congress classification">0</permanent_call_number_type>
+      <permanent_call_number>ML549 .E38</permanent_call_number>
+      <call_number_type desc="Library of Congress classification">0</call_number_type>
+      <call_number>ML549 .E38</call_number>
+      <accession_number/>
+      <copy_id>1</copy_id>
+      <in_temp_location>false</in_temp_location>
+      <temp_library/>
+      <temp_location/>
+      <temp_call_number_type/>
+      <temp_call_number/>
+      <temp_call_number_source/>
+      <temp_policy/>
+    </holding_data>
+    <item_data>
+      <pid>23187557260002486</pid>
+      <barcode>010000833858</barcode>
+      <creation_date>2015-12-03Z</creation_date>
+      <modification_date>2015-12-03Z</modification_date>
+      <base_status desc="Item in place">1</base_status>
+      <awaiting_reshelving>false</awaiting_reshelving>
+      <physical_material_type desc="Bound Issue">ISSBD</physical_material_type>
+      <policy desc="4 Day Loan">05</policy>
+      <provenance/>
+      <po_line>94929</po_line>
+      <is_magnetic>false</is_magnetic>
+      <arrival_date>2003-10-09Z</arrival_date>
+      <year_of_issue/>
+      <enumeration_a>18-20</enumeration_a>
+      <enumeration_b>18-20</enumeration_b>
+      <enumeration_c/>
+      <enumeration_d/>
+      <enumeration_e/>
+      <enumeration_f/>
+      <enumeration_g/>
+      <enumeration_h/>
+      <chronology_i>2000</chronology_i>
+      <chronology_j/>
+      <chronology_k/>
+      <chronology_l/>
+      <chronology_m/>
+      <break_indicator/>
+      <pattern_type/>
+      <linking_number/>
+      <type_of_unit/>
+      <description>V.18-20 2000-2002</description>
+      <receiving_operator>import</receiving_operator>
+      <process_type/>
+      <inventory_number/>
+      <inventory_price/>
+      <library desc="Marian K. Heilbrun Music Media">MUSME</library>
+      <location desc="Music and Media Book Stacks">STACK</location>
+      <alternative_call_number/>
+      <alternative_call_number_type/>
+      <storage_location_id/>
+      <pages/>
+      <pieces/>
+      <public_note/>
+      <fulfillment_note/>
+      <due_date_policy>Log in for more information</due_date_policy>
+      <internal_note_1/>
+      <internal_note_2/>
+      <internal_note_3/>
+      <statistics_note_1/>
+      <statistics_note_2/>
+      <statistics_note_3>Maintenance count: 002</statistics_note_3>
+      <requested>false</requested>
+      <physical_condition/>
+    </item_data>
+  </item>
+</items>

--- a/spec/fixtures/alma_multiple_holdings_item_level.xml
+++ b/spec/fixtures/alma_multiple_holdings_item_level.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bib>
+  <mms_id>990011434390302486</mms_id>
+  <record_format>marc21</record_format>
+  <linked_record_id/>
+  <title>Early keyboard journal /</title>
+  <author>Southeastern Historical Keyboard Society (U.S.)</author>
+  <issn>0899-8132</issn>
+  <network_numbers>
+    <network_number>X0098037#Ar</network_number>
+    <network_number>(Sirsi) o09837764</network_number>
+    <network_number>(OCoLC)09837764</network_number>
+    <network_number>u1903912</network_number>
+    <network_number>(Aleph)001143439EMU01</network_number>
+  </network_numbers>
+  <place_of_publication>Athens, Ga. :</place_of_publication>
+  <date_of_publication>1983-</date_of_publication>
+  <publisher_const>Southeastern Historical Keyboard Society and the University of Georgia School of Music,</publisher_const>
+  <holdings link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/990011434390302486/holdings"/>
+  <created_by>import</created_by>
+  <created_date>2015-12-03Z</created_date>
+  <last_modified_by>System</last_modified_by>
+  <last_modified_date>2020-04-19Z</last_modified_date>
+  <suppress_from_publishing>false</suppress_from_publishing>
+  <suppress_from_external_search>false</suppress_from_external_search>
+  <sync_with_oclc>NONE</sync_with_oclc>
+  <sync_with_libraries_australia>NONE</sync_with_libraries_australia>
+  <originating_system>OTHER</originating_system>
+  <originating_system_id>001143439-EMU01</originating_system_id>
+  <cataloging_level desc="Default Level">00</cataloging_level>
+  <record>
+    <leader>01784cas a2200517 a 4500</leader>
+    <controlfield tag="001">990011434390302486</controlfield>
+    <controlfield tag="005">20200419105522.0</controlfield>
+    <controlfield tag="008">830823c19839999gauar     o   0   a0eng d</controlfield>
+    <datafield ind1=" " ind2=" " tag="010">
+      <subfield code="a">   86644319 </subfield>
+      <subfield code="z">sn 85010813</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="022">
+      <subfield code="a">0899-8132</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(Aleph)001143439EMU01</subfield>
+    </datafield>
+    <datafield ind1="9" ind2=" " tag="035">
+      <subfield code="a">u1903912</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)09837764</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(Sirsi) o09837764</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">X0098037#Ar</subfield>
+      <subfield code="b">CLU</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">INT</subfield>
+      <subfield code="c">INT</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">CLU</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">DLC</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">DLC</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">IUL</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">NSD</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">NSD</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">EYM</subfield>
+      <subfield code="d">UtOrBLW</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="042">
+      <subfield code="a">lc</subfield>
+      <subfield code="a">nsdp</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="050">
+      <subfield code="a">ML549.8</subfield>
+      <subfield code="b">.E2</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="082">
+      <subfield code="a">786/.05</subfield>
+      <subfield code="2">19</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="210">
+      <subfield code="a">Early keyboard j.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="222">
+      <subfield code="a">Early keyboard journal</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="245">
+      <subfield code="a">Early keyboard journal /</subfield>
+      <subfield code="c">Southeastern Historical Keyboard Society.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="1" tag="264">
+      <subfield code="a">Athens, Ga. :</subfield>
+      <subfield code="b">Southeastern Historical Keyboard Society and the University of Georgia School of Music,</subfield>
+      <subfield code="c">1983-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">volumes :</subfield>
+      <subfield code="b">illustrations ;</subfield>
+      <subfield code="c">22 cm</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="310">
+      <subfield code="a">Annual</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">volume</subfield>
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="362">
+      <subfield code="a">Vol. 1 (1982-83)-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Title from cover.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Keyboard instruments</subfield>
+      <subfield code="v">Periodicals.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Keyboard instrument music</subfield>
+      <subfield code="v">Periodicals.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Instrumental music</subfield>
+      <subfield code="x">History and criticism</subfield>
+      <subfield code="v">Periodicals.</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="710">
+      <subfield code="a">Southeastern Historical Keyboard Society (U.S.)</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="710">
+      <subfield code="a">University of Georgia.</subfield>
+      <subfield code="b">School of Music.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="901">
+      <subfield code="c">Mus</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">RDA ENRICHED</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">verified 10/00. recon 2</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">emuldr</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">SCHD ¿d 20001027 ¿g 0 ¿e 4 ¿f 8 ¿v v.18- ¿y 2000-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="910">
+      <subfield code="a">MARS</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="940">
+      <subfield code="a">COVID19</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="a">EMU/rg2</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="a">9DT</subfield>
+      <subfield code="2">20001027</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="966">
+      <subfield code="a">GENERAL HAS: v.18- 2000-date</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="994">
+      <subfield code="a">Z0</subfield>
+      <subfield code="b">EMU</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="INT">
+      <subfield code="a">P</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="INST">
+      <subfield code="a">01GALI_EMORY</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="AVA">
+      <subfield code="0">990011434390302486</subfield>
+      <subfield code="8">22187557270002486</subfield>
+      <subfield code="a">01GALI_EMORY</subfield>
+      <subfield code="b">MUSME</subfield>
+      <subfield code="c">Book Stacks</subfield>
+      <subfield code="d">ML549 .E38</subfield>
+      <subfield code="e">available</subfield>
+      <subfield code="f">4</subfield>
+      <subfield code="g">0</subfield>
+      <subfield code="v">from:18-20 2000 until:30 2014 </subfield>
+      <subfield code="j">STACK</subfield>
+      <subfield code="k">0</subfield>
+      <subfield code="p">1</subfield>
+      <subfield code="q">Marian K. Heilbrun Music Media</subfield>
+    </datafield>
+  </record>
+  <requests>0</requests>
+</bib>

--- a/spec/models/hold_request_spec.rb
+++ b/spec/models/hold_request_spec.rb
@@ -115,6 +115,12 @@ RSpec.describe HoldRequest do
     expect(hr.title_request_url).to eq expected_url
   end
 
+  it "builds correct url for a title request with item pid" do
+    hr = described_class.new(mms_id: "9936550118202486", holding_id: "22332597410002486", holding_item_id: "23187557230002486", user: user)
+    expected_url = "http://www.example.com/almaws/v1/users/janeq/requests?user_id_type=all_unique&mms_id=9936550118202486&item_pid=23187557230002486&allow_same_request=false&apikey=fakeuserkey456"
+    expect(hr.title_request_url).to eq expected_url
+  end
+
   it "gives a list of allowed libraries for pickup for an Oxford user with an Oxford book" do
     stub_request(:get, "http://www.example.com/almaws/v1/users/janeq?user_id_type=all_unique&view=full&expand=none&apikey=fakeuserkey456")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_users/full_user_record_oxford.xml'), headers: {})
@@ -147,5 +153,15 @@ RSpec.describe HoldRequest do
     expect(hr.holding_to_request).to eq(hr.physical_holdings.first)
     expect(hr.pickup_library_options).to eq([{ label: "Marian K. Heilbrun Music Media", value: "MUSME" }])
     expect(hr.holding_library).to eq({ label: "Marian K. Heilbrun Music Media", value: "MUSME" })
+  end
+
+  describe "#items" do
+    it "returns holding_items in an array" do
+      hr = described_class.new(mms_id: "990011434390302486")
+      expect(hr.items).to eq [{ label: "ML549 .E38 v.25-29(2010-2012)", value: "23187557230002486" },
+                              { label: "ML549 .E38 v.30(2013)", value: "23187557240002486" },
+                              { label: "ML549 .E38 V.21-24 2003-2006", value: "23187557250002486" },
+                              { label: "ML549 .E38 V.18-20 2000-2002", value: "23187557260002486" }]
+    end
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe SolrDocument do
 
       it "can get the due_date_policy based on the user" do
         expect(solr_doc.items_by_holding_query("22319997630002486", user)).to eq "/holdings/22319997630002486/items?expand=due_date_policy&user_id=janeq&apikey="
-        expect(solr_doc.physical_holdings(user).first[:items_by_holding].first).to eq({ barcode: "010002752069", type: "Bound Issue",
+        expect(solr_doc.physical_holdings(user).first[:items_by_holding].first).to eq({ barcode: "010002752069", type: "Bound Issue", pid: "23236301160002486",
                                                                                         policy: { policy_desc: "30 Day Loan Storage", policy_id: "17", due_date_policy: "28 Days Loan" },
                                                                                         description: "v.75(2013)", status: "Item in place" })
         expect(solr_doc.hold_requestable?).to eq true
@@ -122,7 +122,7 @@ RSpec.describe SolrDocument do
 
       it "can get the due_date_policy for a guest user" do
         expect(solr_doc.items_by_holding_query("22319997630002486")).to eq "/holdings/22319997630002486/items?expand=due_date_policy&user_id=GUEST&apikey="
-        expect(solr_doc.physical_holdings.first[:items_by_holding].first).to eq({ barcode: "010002752069", type: "Bound Issue",
+        expect(solr_doc.physical_holdings.first[:items_by_holding].first).to eq({ barcode: "010002752069", type: "Bound Issue", pid: "23236301160002486",
                                                                                   policy: { policy_desc: "30 Day Loan Storage", policy_id: "17", due_date_policy: "Loanable" },
                                                                                   description: "v.75(2013)", status: "Item in place" })
         expect(solr_doc.hold_requestable?).to eq true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -166,5 +166,9 @@ RSpec.configure do |config|
       :get,
       "https://jalapeno.alma.exlibrisgroup.com/view/oai/tabasco/request?identifier=oai:alma.blah:single_record&metadataPrefix=marc21&verb=GetRecord"
     ).to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file.xml'), headers: {})
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990011434390302486?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail,requests&view=full")
+      .to_return(status: 200, body: File.read(fixture_path + '/alma_multiple_holdings_item_level.xml'), headers: {})
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486/items?apikey=fakebibkey123&expand=due_date_policy&user_id=GUEST")
+      .to_return(status: 200, body: File.read(fixture_path + '/alma_item_records/22187557270002486.xml'), headers: {})
   end
 end

--- a/spec/system/hold_request_spec.rb
+++ b/spec/system/hold_request_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe "Create a request for a holding", type: :system, js: true, alma: 
       .to_return(status: 200, body: File.read(fixture_path + '/alma_users/full_user_record.xml'), headers: {})
     stub_request(:post, "http://www.example.com/almaws/v1/users/janeq/requests?user_id_type=all_unique&mms_id=9936550118202486&allow_same_request=false&apikey=fakeuserkey456")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_request_test_file.json'))
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990011434390302486/holdings/22187557270002486/items?apikey=fakebibkey123&expand=due_date_policy&user_id=janeq")
+      .to_return(status: 200, body: File.read(fixture_path + '/alma_item_records/22187557270002486.xml'), headers: {})
   end
 
   it "has a button to request a hold" do
@@ -50,5 +52,11 @@ RSpec.describe "Create a request for a holding", type: :system, js: true, alma: 
     click_on("Create Hold request")
     expect(page).to have_content("Hold Request")
     expect(page).to have_content('Hold request was successfully created.')
+  end
+
+  it 'has a dropdown with item level call number and description for unique item level descriptions' do
+    sign_in(user)
+    visit new_hold_request_path(hold_request: { mms_id: "990011434390302486" })
+    expect(page).to have_select("hold_request_holding_item_id", with_options: ["ML549 .E38 V.21-24 2003-2006"])
   end
 end


### PR DESCRIPTION
Connected to: #682 
* We are adding the ability to request specific items when there's more than one item available for a title. This info is available in the description of the item. Unique item level descriptions are used to tell if an item is unique.
* We are adding a dropdown field that will list the call number and description from which users can choose a particular item to request.
* We are also adding `item_pid` when available to the POST url for create request.

Changes:
**app/controllers/hold_requests_controller.rb:** Adds new param to collect `item_pid`
**app/models/concerns/statusable.rb**: Asks for `item_pid` from item info
**app/models/hold_request.rb**: Adds `item_pid` to POST url if available. Also, adds `items` method to fetch unique items for a title
**app/views/hold_requests/_form.html.erb**: Adds dropdown for item level selection if unique items exist
**spec/***: Adds unit and feature tests

When unique items for a title are available:
![image](https://user-images.githubusercontent.com/17075287/123490401-f2098480-d5e1-11eb-9168-3e331071d171.png)

![image](https://user-images.githubusercontent.com/17075287/123490386-ea49e000-d5e1-11eb-9b86-fbb3865a1a42.png)


When unique items for a title are not available:
![image](https://user-images.githubusercontent.com/17075287/123490155-8b846680-d5e1-11eb-99cb-6376eede8fb8.png)
