### PR TITLE
 Restricts the Request Article to autorized users (#701). 

### DIFF
--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -149,7 +149,7 @@ module Statusable
     @call_number = availability.at_xpath('subfield[@code="d"]')&.inner_text
   end
 
-  def items_by_holding_values(holding_id, user = nil)
+  def items_by_holding_values(holding_id, user = nil) # rubocop:disable Metrics/MethodLength
     items = []
     holding_items = items_by_holding_record(holding_id, user)
     holding_items.xpath("//item/item_data").each do |node|
@@ -165,7 +165,7 @@ module Statusable
       items.append(item_info)
     end
     items
-  end
+  end # rubocop:enable Metrics/MethodLength
 
   def item_policy(node, _user)
     policy_desc = node.xpath('policy').attr("desc")&.value
@@ -205,12 +205,9 @@ module Statusable
 
   def doc_delivery?(phys_holdings, user = nil)
     return false if user.blank? || user.guest
-    phys_holdings&.any? { |h| holding_doc_delivery?(h, user.user_group) }
-  end
-
-  def holding_doc_delivery?(holding, user_group)
-    service = DOC_DELIVERY_SERVICES[holding[:library][:value]]
-    return service.new(user_group, holding).document_delivery? if service.present?
-    false
+    phys_holdings&.any? do |h|
+      service = DOC_DELIVERY_SERVICES[h[:library][:value]]
+      service.present? ? service.new(user.user_group, h).document_delivery? : false
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,15 +46,6 @@ class User < ApplicationRecord
     "#{ENV['ALMA_API_URL']}/almaws/v1/users/#{uid}?user_id_type=all_unique&view=full&expand=none&apikey=#{ENV['ALMA_USER_KEY']}"
   end
 
-  def doc_delivery?
-    return false if guest
-    doc_delivery_user_group_ids.include?(user_group)
-  end
-
-  def doc_delivery_user_group_ids
-    %w[01 02 03 04 09 10 12 20 22 23 24 25]
-  end
-
   # When a user authenticates via shibboleth, find their User object or make
   # a new one. Populate it with data we get from shibboleth.
   # @param [OmniAuth::AuthHash] auth

--- a/app/services/verification/bus_user_verification_service.rb
+++ b/app/services/verification/bus_user_verification_service.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Verification::BusUserVerificationService < Verification::IlliadVerificationService
+  def document_delivery?
+    analyze_values(COMMON_IDS_6, "STOR", BOOK_ISS, @document_holding) ||
+      analyze_values(COMMON_IDS, "STACK", OSIZE_BOOK_ISS, @document_holding)
+  end
+end

--- a/app/services/verification/chem_user_verification_service.rb
+++ b/app/services/verification/chem_user_verification_service.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Verification::ChemUserVerificationService < Verification::IlliadVerificationService
+  def document_delivery?
+    analyze_values(COMMON_IDS, "NEWBK", BOOK_ISSBD_REFBK, @document_holding) ||
+      analyze_values(%w[01 02 09 20 23], "REF", %w[REFBK], @document_holding) ||
+      analyze_values(%w[03], "REF", BDVOL_BOOK_ISS, @document_holding) ||
+      analyze_values(COMMON_IDS, "STACK", BOOK_ISS, @document_holding) ||
+      analyze_values(%w[01 03 04 09 20 23 24 25], "STOR", BOOK_ISS, @document_holding)
+  end
+end

--- a/app/services/verification/hlth_user_verification_service.rb
+++ b/app/services/verification/hlth_user_verification_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Verification::HlthUserVerificationService < Verification::IlliadVerificationService
+  COMMON_HEALTH_IDS = %w[01 09 20 23].freeze
+
+  def document_delivery?
+    book_iss_analyses(@document_holding) ||
+      analyze_values(%w[02 03 04 25], "CIRC", %w[BOOK], @document_holding) ||
+      analyze_values(%w[01 02 09 10 20 23], "CPACT", %w[BOOK REFBK], @document_holding) ||
+      analyze_values(%w[01 02 03 09 20 23 25], "NEWBK", %w[BOOK], @document_holding) ||
+      analyze_values(%w[01 02 03 04 09 10 20 23 25], "OSIZE", %w[BOOK], @document_holding) ||
+      analyze_values(COMMON_HEALTH_IDS, "RFDESK", %w[BOOK], @document_holding)
+  end
+
+  def book_iss_analyses(holding)
+    analyze_values(%w[01 02 03 04 09 20 23 25], "PER", BOOK_ISS, holding) ||
+      analyze_values(COMMON_HEALTH_IDS, "REF", BOOK_ISSBD_REFBK, holding) ||
+      analyze_values(COMMON_IDS_2, "STACK", %w[BOOK ISS REFBK RESV], holding) ||
+      analyze_values(%w[01 04 09 20 23 24 25], "STOR", BOOK_ISS, holding) ||
+      analyze_values(%w[02], "STOR", BOOK_ISS_MLTVL, holding)
+  end
+end

--- a/app/services/verification/illiad_verification_service.rb
+++ b/app/services/verification/illiad_verification_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Verification::IlliadVerificationService
+  COMMON_IDS = %w[01 02 03 04 09 10 20 23].freeze
+  COMMON_IDS_2 = %w[01 02 03 04 09 20 23].freeze
+  COMMON_IDS_3 = %w[01 02 03 04 09 10 20 23 24].freeze
+  COMMON_IDS_4 = %w[01 02 03 04 09 10 20 23 24 25].freeze
+  COMMON_IDS_5 = %w[01 02 03 04 09 20 23 24 25].freeze
+  COMMON_IDS_6 = %w[01 03 04 09 10 20 23 24 25].freeze
+  BOOK_ISS = %w[BOOK ISSBD ISSUE].freeze
+  OSIZE_BOOK_ISS = %w[OSIZE BOOK ISSBD ISSUE].freeze
+  BOOK_ISSBD_REFBK = %w[BOOK ISSBD REFBK].freeze
+  BDVOL_BOOK_ISS = %w[BDVOL BOOK ISSBD ISSUE].freeze
+  BOOK_ISS_MLTVL = %w[BOOK ISSBD ISSUE MLTVL].freeze
+  BOOK_ISSBD = %w[BOOK ISSBD].freeze
+  BOOK_ISSUE_MLTVL_REFBK = %w[BOOK ISSUE MLTVL REFBK].freeze
+  BOOK_ISS_REFBK = %w[BOOK ISSBD ISSUE REFBK].freeze
+  BOOK_ISS_RESV = %w[BOOK ISSBD ISSUE RESV].freeze
+
+  def initialize(user_group_id, document_holding)
+    @user_group_id = user_group_id
+    @document_holding = document_holding
+  end
+
+  def item_location(holding)
+    holding[:location][:value]
+  end
+
+  def item_type_codes(holding)
+    holding[:items_by_holding]&.map { |i| i[:type_code] }&.compact&.uniq
+  end
+
+  def analyze_values(user_groups, location, expected_type_codes, holding)
+    user_groups.include?(@user_group_id) && item_location(holding) == location && (expected_type_codes & item_type_codes(holding)).present?
+  end
+
+  def analyze_values_from_location_array(location_array, id_array, type_array, holding)
+    location_array.any? do |location|
+      analyze_values(id_array, location, type_array, holding)
+    end
+  end
+end

--- a/app/services/verification/law_user_verification_service.rb
+++ b/app/services/verification/law_user_verification_service.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Verification::LawUserVerificationService < Verification::IlliadVerificationService
+  def document_delivery?
+    analyze_values(%w[01 03 09 10 12 20 23], "STACK", %w[BOOK GVDOC ISSBD ISSUE REFBK LSLF], @document_holding)
+  end
+end

--- a/app/services/verification/lsc_user_verification_service.rb
+++ b/app/services/verification/lsc_user_verification_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Verification::LscUserVerificationService < Verification::IlliadVerificationService
+  LSC_COMMON = %w[01 02 03 04 10 20 22 23 24 25].freeze
+
+  def document_delivery?
+    location_array_analyses(@document_holding) ||
+      book_analyses(@document_holding) ||
+      analyze_values(COMMON_IDS_3, "MSTOR", %w[BOOK SCORE], @document_holding) ||
+      analyze_values(COMMON_IDS_3, "TSTOR", %w[ISSBD ISSUE SCORE], @document_holding) ||
+      analyze_values(COMMON_IDS_3, "USTOR", %w[BOOK ISSBD SCORE], @document_holding) ||
+      analyze_values(%w[01 09 10 20 23], "USTORJ", %w[ISSBD], @document_holding)
+  end
+
+  def location_array_analyses(holding)
+    analyze_values_from_location_array(%w[HSTORJ MSTORJ SSTORJ TSTORJ USTORJ], COMMON_IDS_3, BOOK_ISS, holding) ||
+      analyze_values_from_location_array(%w[HSTOR MSTORNC SSTOR], COMMON_IDS_3, BOOK_ISSBD, holding) ||
+      analyze_values_from_location_array(%w[USTORGD USTORNC], LSC_COMMON, %w[BOOK FICHE FILM GOVRECORD ISSBD ISSUE], holding) ||
+      analyze_values_from_location_array(%w[BSTORJ HSTORNC], COMMON_IDS_3, %w[ISSBD], holding)
+  end
+
+  def book_analyses(holding)
+    analyze_values(COMMON_IDS_3, "BSTOR", %w[BOOK], holding) ||
+      analyze_values(%w[01 02 04 09 10 20 23 24], "TSTOR", %w[BOOK], holding) ||
+      analyze_values(COMMON_IDS_4, "USTOR", %w[BOOK], holding)
+  end
+end

--- a/app/services/verification/musme_user_verification_service.rb
+++ b/app/services/verification/musme_user_verification_service.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Verification::MusmeUserVerificationService < Verification::IlliadVerificationService
+  def document_delivery?
+    analyze_values_from_location_array(
+      %w[NEWBK REF], COMMON_IDS, BOOK_ISSUE_MLTVL_REFBK, @document_holding
+    ) ||
+      analyze_values(COMMON_IDS_2, "STACK", BOOK_ISS_REFBK, @document_holding) ||
+      analyze_values(COMMON_IDS_5, "STOR", BOOK_ISS, @document_holding)
+  end
+end

--- a/app/services/verification/oxfd_user_verification_service.rb
+++ b/app/services/verification/oxfd_user_verification_service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Verification::OxfdUserVerificationService < Verification::IlliadVerificationService
+  def document_delivery?
+    analyze_values_from_location_array(
+      %w[CIRC NEWBK OGTR ONFLY], COMMON_IDS_3, %w[BOOK], @document_holding
+    ) ||
+      analyze_values_from_location_array(
+        %w[OSIZE STACK], COMMON_IDS_3, BOOK_ISS_REFBK, @document_holding
+      ) ||
+      analyze_values_from_location_array(
+        %w[PER RESRV], COMMON_IDS_3, BOOK_ISS_RESV, @document_holding
+      ) ||
+      analyze_values(%w[01 02 03 04 09 20 23 24], "GRNOV", %w[BOOK], @document_holding) ||
+      analyze_values(COMMON_IDS_3, "REF", %w[BOOK ISSUE REFBK], @document_holding)
+  end
+end

--- a/app/services/verification/theo_user_verification_service.rb
+++ b/app/services/verification/theo_user_verification_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Verification::TheoUserVerificationService < Verification::IlliadVerificationService
+  THEO_COMMON = %w[01 02 03 09 10 20 23].freeze
+  THEO_COMMON_2 = %w[02 03 10].freeze
+  THEO_COMMON_3 = %w[01 02 03 04 23 24 25].freeze
+
+  def document_delivery?
+    book_analyses(@document_holding) ||
+      analyze_values(THEO_COMMON, "PER", BOOK_ISSBD, @document_holding) ||
+      analyze_values(THEO_COMMON_2, "STACK", %w[BOOK CDROM], @document_holding) ||
+      analyze_values(THEO_COMMON_2, "STOR", BOOK_ISS_MLTVL, @document_holding) ||
+      analyze_values(%w[02 03 04 10 24 25], "STOR", BOOK_ISS, @document_holding)
+  end
+
+  def book_analyses(holding)
+    analyze_values_from_location_array(%w[CIRC CPER ONFLY], THEO_COMMON, %w[BOOK], holding) ||
+      analyze_values_from_location_array(%w[REF RFDESK REFOV], THEO_COMMON_3, %w[BOOK], holding) ||
+      analyze_values_from_location_array(%w[OSIZE PEROZ], THEO_COMMON_2, %w[BOOK], holding) ||
+      analyze_values(%w[01 03 04 09 20 23 25], "STACK", %w[BOOK], holding)
+  end
+end

--- a/app/services/verification/univ_user_verification_service.rb
+++ b/app/services/verification/univ_user_verification_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Verification::UnivUserVerificationService < Verification::IlliadVerificationService
+  def document_delivery?
+    book_iss_analyses(@document_holding) || book_iss_mltvl_analyses(@document_holding) ||
+      analyze_values_from_location_array(%w[REF REFOV], COMMON_IDS_4, BDVOL_BOOK_ISS, @document_holding) ||
+      analyze_values(COMMON_IDS_4, "CPER", %w[BDVOL ISSBD ISSUE], @document_holding) ||
+      analyze_values(COMMON_IDS_4, "NEWBK", %w[BOOK], @document_holding) ||
+      analyze_values(%w[01 02 09 20 23 24], "STDOC", %w[BOOK MLTVL], @document_holding)
+  end
+
+  def book_iss_analyses(holding)
+    analyze_values_from_location_array(%w[OSIZE ULFO], COMMON_IDS_5, BOOK_ISS, holding) ||
+      analyze_values(%w[10], "STDOC", BOOK_ISS, holding) ||
+      analyze_values(COMMON_IDS_6, "STO96", BOOK_ISS, holding) ||
+      analyze_values(%w[02 04 25], "STOR", BOOK_ISS, holding)
+  end
+
+  def book_iss_mltvl_analyses(holding)
+    analyze_values(COMMON_IDS_4, "STACK", BOOK_ISS_MLTVL, holding) ||
+      analyze_values(%w[01 03 09 10 20 23 24 25], "STOR", BOOK_ISS_MLTVL, holding)
+  end
+end

--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -1,3 +1,4 @@
+<% physical_holdings = document.physical_holdings(current_or_guest_user) %>
 <div class="where-to-find-table">
   <div class="row justify-content-between">
     <div class="col-sm-4">
@@ -11,7 +12,7 @@
         <% if document.hold_requestable?(current_or_guest_user) %>
           <%= link_to "Hold request", new_hold_request_path(hold_request: {mms_id: document.id, title: document['title_display_tesim']&.first}), class: "dropdown-item" %>
         <% end %>
-        <% if current_or_guest_user&.doc_delivery? %>
+        <% if document.doc_delivery?(physical_holdings, current_or_guest_user) %>
           <%= link_to "Request Article or Chapter", '/#', class: "dropdown-item" %>
         <% end %>
       </div>
@@ -29,7 +30,7 @@
         </tr>
       </thead>
       <tbody>
-        <% document.physical_holdings(current_or_guest_user).each.with_index(1) do |holding, index| %>
+        <% physical_holdings.each.with_index(1) do |holding, index| %>
           <tr id="physical-holding-<%= index.to_s %>">
             <td><%= colonizer(holding[:library][:label], holding[:location][:label]) %></td>
             <td><%= holding[:call_number] %></td>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe SolrDocument do
         expect(solr_doc.items_by_holding_query("22319997630002486")).to eq "/holdings/22319997630002486/items?expand=due_date_policy&user_id=GUEST&apikey="
         expect(solr_doc.physical_holdings.first[:items_by_holding].first).to eq({ barcode: "010002752069", type: "Bound Issue", pid: "23236301160002486",
                                                                                   policy: { policy_desc: "30 Day Loan Storage", policy_id: "17", due_date_policy: "Loanable" },
-                                                                                  description: "v.75(2013)", status: "Item in place" })
+                                                                                  description: "v.75(2013)", status: "Item in place", type_code: "ISSBD" })
         expect(solr_doc.hold_requestable?).to eq true
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe User do
         expect(user.uid).to eq "janeq"
         expect(user.user_group).to eq "03"
         expect(user.oxford_user?).to eq false
-        expect(user.doc_delivery?).to be_truthy
       end
 
       it "has an oxford user group from alma" do
@@ -70,7 +69,6 @@ RSpec.describe User do
         expect(user.uid).to eq "janeq"
         expect(user.user_group).to eq "23"
         expect(user.oxford_user?).to eq true
-        expect(user.doc_delivery?).to be_truthy
       end
     end
   end

--- a/spec/system/user_login_spec.rb
+++ b/spec/system/user_login_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'User login', type: :system, js: true do
 
     it "does not have dev login options" do
       visit("/")
-      click_on("Login")
+      click_on("Login", match: :first)
       ["Uid", "Password"].each do |content|
         expect(page).not_to have_content(content)
       end


### PR DESCRIPTION
- app/models/concerns/statusable.rb: adds method to `solr_document` to determine if it is "deliverable".
- app/models/user.rb: removes method that didn't have sufficient logic.
- app/services/verification/*: institutes methods to determine if holding data permits the user to request document through Illiad.
- app/views/catalog/_show_request_options.html.erb: tying existing link to new logic method. The physical holding is variablized at the top of the partial for faster loading.
- spec/*: tests new methods and refactors others to pass rspec. 


https://user-images.githubusercontent.com/18330149/123712489-68a3bd80-d840-11eb-8fb2-2cc271489df6.mov

