### PR TITLE
Title and sorting margin style fixes (#694)

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_buttons.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_buttons.scss
@@ -73,6 +73,7 @@ span.applied-filter.constraint {
 }
 
 .constraints-container {
+  margin-bottom: 1.5rem;
   .btn.catalog_startOverLink {
     line-height: 1.98;
   }

--- a/app/assets/stylesheets/blacklight_catalog/_sort_widgets.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_sort_widgets.scss
@@ -1,8 +1,7 @@
 @import 'variables';
 
 .pagination-search-widgets {
-  margin-top: map-get($spacers, 4);
-  margin-bottom: map-get($spacers, 2);
+  margin-bottom: 1rem;
 }
 
 div#sortAndPerPage {

--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -1,10 +1,10 @@
 <% physical_holdings = document.physical_holdings(current_or_guest_user) %>
 <div class="where-to-find-table">
   <div class="row justify-content-between align-items-center">
-    <div class="col-sm-4">
+    <div class="col-sm-6">
       <%= tag.h2 t('catalog.show.find_it_header'), class: "section-title find-it-header" %>
     </div>
-    <div class="col-sm-4 request-options">
+    <div class="col-sm-6 request-options">
 
       <div class="btn-group">
         <button class="btn btn-primary rounded-0">Request</button>


### PR DESCRIPTION
- These styles update in certain situations where the pagination isn't visible, the page title doesn't have enough space between it and the return to search
- Increases width of "where to find it" section title and button