### PR TITLE
Style modals fixes for citation and direct link

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_citations.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_citations.scss
@@ -10,12 +10,12 @@ div.modal-header.citations {
 }
 
 // Citation Warning
-.citation-warning.row {
+.citation-warning {
   background-color: #E9BF55;
   color: #091C44;
   margin: inherit;
   margin-bottom: 2rem;
-  .col-1 {
+  .icon {
       text-align: center;
       margin: auto 0;
       svg {
@@ -25,5 +25,5 @@ div.modal-header.citations {
   }
 }
 
-.citation-header { margin: 1.5rem 0;}
+.citation-header { margin: 1.5rem 0 .5rem; font-size: 1.125rem; font-weight: 600;}
 .citation-text { margin-bottom: 1rem;}

--- a/app/helpers/citation_modal_helper.rb
+++ b/app/helpers/citation_modal_helper.rb
@@ -8,10 +8,10 @@ module CitationModalHelper
 
   def process_mult_documents_citations(documents)
     mla_cit_arr = documents.inject([]) do |arr, doc|
-      arr << tag.div(doc.send(:export_as_mla_citation_txt).html_safe, class: 'citation-text')
+      arr << tag.p(doc.send(:export_as_mla_citation_txt).html_safe, class: 'citation-text')
     end
     apa_cit_arr = documents.inject([]) do |arr, doc|
-      arr << tag.div(doc.send(:export_as_apa_citation_txt).html_safe, class: 'citation-text')
+      arr << tag.p(doc.send(:export_as_apa_citation_txt).html_safe, class: 'citation-text')
     end
 
     safe_join(
@@ -28,9 +28,9 @@ module CitationModalHelper
     safe_join(
       [
         tag.h2(t('blacklight.citation.mla'), class: 'citation-header'),
-        tag.div(documents.first.send(:export_as_mla_citation_txt).html_safe, class: 'citation-text'),
+        tag.p(documents.first.send(:export_as_mla_citation_txt).html_safe, class: 'citation-text'),
         tag.h2(t('blacklight.citation.apa'), class: 'citation-header'),
-        tag.div(documents.first.send(:export_as_apa_citation_txt).html_safe, class: 'citation-text')
+        tag.p(documents.first.send(:export_as_apa_citation_txt).html_safe, class: 'citation-text')
       ].flatten, ''
     )
   end

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -1,16 +1,21 @@
 <%# Overwrite of Blacklight 7.4.1 partial of same name. L#9 includes text advising users that citations are auto-generated. %>
 <div class="modal-header">
-  <h1><%= t('blacklight.tools.citation') %></h1>
+  <h5 class="mb-0"><%= t('blacklight.tools.citation') %></h5>
   <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
+
 <div class="modal-body">
-  <div class='citation-warning row'>
-    <div class='col-1'>
-      <svg xmlns="http://www.w3.org/2000/svg"><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"></path></svg>
+  <div class='citation-warning d-flex flex-row px-3 py-2'>
+    <div class="icon  mr-3 align-self-center">
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"></path>
+      </svg>
     </div>
-    <div class='col-11'><%= t('blacklight.tools.citation_warning') %></div>
+
+    <%= t('blacklight.tools.citation_warning') %>
+
   </div>
   <%= render_citations(@documents) %>
 </div>

--- a/app/views/catalog/_direct_link_modal.html.erb
+++ b/app/views/catalog/_direct_link_modal.html.erb
@@ -1,5 +1,5 @@
 <div id="direct-link" class="modal-header">
-	<h1><%= t('blacklight.tools.direct_link') %></h1>
+	<h5 class="mb-0"><%= t('blacklight.tools.direct_link') %></h5>
   <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
     <span aria-hidden="true">&times;</span>
   </button>

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -170,10 +170,10 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
           # all they tested for was the Cite modal title as well.
           execute_script("document.querySelector('#citationLink').click()")
           within '#blacklight-modal' do
-            expect(page).to have_css('h1', text: 'Cite')
+            expect(page).to have_css('h5', text: 'Cite')
           end
 
-          within 'div.modal-body .citation-warning.row .col-11' do
+          within 'div.modal-body .citation-warning' do
             expect(page).to have_content(expected_warning_text)
           end
         end
@@ -189,7 +189,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
         it 'has the correct direct link' do
           click_on 'Direct Link'
           within '#modal-window' do
-            expect(page).to have_css('h1', text: 'Direct Link')
+            expect(page).to have_css('h5', text: 'Direct Link')
             expect(page).to have_selector('input[value="www.example.com/catalog/123"]')
           end
         end


### PR DESCRIPTION
The existing styles that were cleaned up:
- smaller modal titles
- smaller citation titles
- cleaner markup for citations