### PR TITLE
Responsive style widths for "where to find it" title and button (#694)

### DIFF
--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -1,10 +1,10 @@
 <% physical_holdings = document.physical_holdings(current_or_guest_user) %>
 <div class="where-to-find-table">
   <div class="row justify-content-between align-items-center">
-    <div class="col-sm-6">
+    <div class="col-6">
       <%= tag.h2 t('catalog.show.find_it_header'), class: "section-title find-it-header" %>
     </div>
-    <div class="col-sm-6 request-options">
+    <div class="col-6 request-options">
 
       <div class="btn-group">
         <button class="btn btn-primary rounded-0">Request</button>


### PR DESCRIPTION
Fixes break on smaller screen sizes for "Where to find it" and request button