### PR TITLE
Reads ENV vars from server.

### DIFF
--- a/config/deploy/arch.rb
+++ b/config/deploy/arch.rb
@@ -55,15 +55,16 @@
 #     # password: "please use keys"
 #   }
 
-before 'deploy:check:linked_files', "deploy:copy_env"
-before 'deploy:symlink:linked_files', "deploy:copy_env"
+before 'deploy:check:linked_files', "deploy:copy_secrets"
+before 'deploy:symlink:linked_files', "deploy:copy_secrets"
 namespace :deploy do
-  task :copy_env do
+  task :copy_secrets do
     on roles("web") do
-      upload!(".env.#{fetch(:stage).downcase}", "#{shared_path}/.env.production")
       upload!("./config/secrets.yml", "#{shared_path}/config/secrets.yml")
     end
   end
+
+  after :starting, 'envvars:load'
 end
 
 set :stage, :ARCH

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -57,15 +57,16 @@
 
 set :stage, :PROD
 
-before 'deploy:check:linked_files', "deploy:copy_env"
-before 'deploy:symlink:linked_files', "deploy:copy_env"
+before 'deploy:check:linked_files', "deploy:copy_secrets"
+before 'deploy:symlink:linked_files', "deploy:copy_secrets"
 namespace :deploy do
-  task :copy_env do
+  task :copy_secrets do
     on roles("web") do
-      upload!(".env.#{fetch(:stage).downcase}", "#{shared_path}/.env.production")
       upload!("./config/secrets.yml", "#{shared_path}/config/secrets.yml")
     end
   end
+
+  after :starting, 'envvars:load'
 end
 
 set :ec2_region, %w[us-east-1]

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -57,15 +57,16 @@
 
 set :stage, :TEST
 
-before 'deploy:check:linked_files', "deploy:copy_env"
-before 'deploy:symlink:linked_files', "deploy:copy_env"
+before 'deploy:check:linked_files', "deploy:copy_secrets"
+before 'deploy:symlink:linked_files', "deploy:copy_secrets"
 namespace :deploy do
-  task :copy_env do
+  task :copy_secrets do
     on roles("web") do
-      upload!(".env.blackcat-test", "#{shared_path}/.env.production")
       upload!("./config/secrets.yml", "#{shared_path}/config/secrets.yml")
     end
   end
+
+  after :starting, 'envvars:load'
 end
 
 set :ec2_region, %w[us-east-1]

--- a/lib/capistrano/tasks/envvars.rake
+++ b/lib/capistrano/tasks/envvars.rake
@@ -1,18 +1,18 @@
+# frozen_string_literal: true
+
 namespace :envvars do
-    desc 'Load environment variables'
-    task :load do
-        # Grab the current value of :default_env
-        environment = fetch(:default_env, {})
+  desc 'Load environment variables'
+  task :load do
+    # Grab the current value of :default_env
+    environment = fetch(:default_env, {})
 
-        on roles(:app) do
-            # Read in the environment file
-            env_file = "/opt/blacklight-catalog/shared/config/environment_variables.yml"
-            YAML.load(File.open(env_file)).each do |key, value|
-                environment.store(key, value)
-            end if File.exists?(env_file)
+    on roles(:app) do
+      # Read in the environment file
+      env_file = "/opt/blacklight-catalog/shared/config/environment_variables.yml"
+      YAML.safe_load(File.open(env_file)).each { |key, value| environment.store(key, value) } if File.exist?(env_file)
 
-            # Finally, update the global :default_env variable again
-            set :default_env, environment
-        end
+      # Finally, update the global :default_env variable again
+      set :default_env, environment
     end
+  end
 end

--- a/lib/capistrano/tasks/envvars.rake
+++ b/lib/capistrano/tasks/envvars.rake
@@ -1,0 +1,18 @@
+namespace :envvars do
+    desc 'Load environment variables'
+    task :load do
+        # Grab the current value of :default_env
+        environment = fetch(:default_env, {})
+
+        on roles(:app) do
+            # Read in the environment file
+            env_file = "/opt/blacklight-catalog/shared/config/environment_variables.yml"
+            YAML.load(File.open(env_file)).each do |key, value|
+                environment.store(key, value)
+            end if File.exists?(env_file)
+
+            # Finally, update the global :default_env variable again
+            set :default_env, environment
+        end
+    end
+end


### PR DESCRIPTION
- config/deploy/*: removes logic pulling ENVs from the local machine and includes call that takes them from the home servers.
- lib/capistrano/tasks/envvars.rake: processes yaml on server side to populate environment variables.

No screenshots necessary.

