### PR TITLE
Bug Fix: Addresses error when viewing Bookmarks page (#750).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -66,7 +66,7 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial(:direct_link, partial: 'direct_link')
     config.add_show_tools_partial(:help, partial: 'help')
     config.add_show_tools_partial(:feedback, partial: 'feedback')
-    config.add_show_tools_partial(:export_as_ris, modal: false)
+    config.add_show_tools_partial(:export_as_ris, partial: 'export_as_ris')
     config.add_show_tools_partial(:librarian_view, label: 'Staff View', if: :render_librarian_view_control?, define_method: false)
 
     config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark', if: :render_bookmarks_control?)

--- a/app/helpers/tools_sidebar_helper.rb
+++ b/app/helpers/tools_sidebar_helper.rb
@@ -13,8 +13,4 @@ module ToolsSidebarHelper
               "https://emory.libwizard.com/f/blacklight?refer_url=#{url}",
               class: 'nav-link', target: "_blank", rel: 'noopener noreferrer')
   end
-
-  def export_as_ris_solr_document_path(opts = {}, *_)
-    solr_document_url(opts[:id], format: :ris) if opts[:id]
-  end
 end

--- a/app/views/catalog/_export_as_ris.html.erb
+++ b/app/views/catalog/_export_as_ris.html.erb
@@ -1,0 +1,1 @@
+<%= link_to t('blacklight.tools.export_as_ris'), solr_document_url(@document.id, format: :ris), class: 'nav-link' %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -28,3 +28,4 @@ en:
       librarian_view: 'Staff View'
       print: 'Print'
       direct_link_url_text: 'Direct Link URL'
+      export_as_ris: 'Export as RIS'

--- a/spec/system/bookmarks_page_spec.rb
+++ b/spec/system/bookmarks_page_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Bookmarks page', type: :system do
+  let(:user) { User.create(uid: "janeq") }
+
+  it 'loads page without error once user signed in' do
+    sign_in(user)
+    visit bookmarks_path
+
+    expect(page).to have_css('h1.page-heading.bookmarks.show-header', text: 'Bookmarks')
+  end
+end


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: changes the delivery method to partial load.
- app/helpers/tools_sidebar_helper.rb: removes helper method ending with `_path`, which was confusing the rails system when attempting to load the tools menu in Bookmarks `index`.
- app/views/catalog/_export_as_ris.html.erb: creates a partial that executes the same command as the previous helper method.
- config/locales/blacklight.en.yml: localizes the header for the Tools option.
- spec/*: ensures that the Bookmarks page loads normally.

<img width="1207" alt="Screen Shot 2021-07-09 at 8 57 27 AM" src="https://user-images.githubusercontent.com/18330149/125081885-8a007700-e094-11eb-93d7-da589ff65c27.png">
