### PR TITLE
Refactors how holding item information is displayed

### DIFF
--- a/app/views/hold_requests/_form.html.erb
+++ b/app/views/hold_requests/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for @hold_request do |f| %>
   <%= f.input :mms_id, value: @hold_request.mms_id, readonly: true %>
   <%= f.input :pickup_library, collection: @hold_request.pickup_library_options.map { |h| [h[:label], h[:value]] }, required: true, prompt: "--" %>
-  <%= f.input :holding_item_id, collection: @hold_request.items.map { |h| [h[:label], h[:value]] }, required: true, prompt: "--" unless @hold_request.items.empty? %>
+  <%= f.input :holding_item_id, as: :radio_buttons, collection: @hold_request.items.map { |h| [h[:label], h[:value]] }, required: true unless @hold_request.items.empty? %>
   <%= f.input :not_needed_after, as: :date, :input_html => { :value => Date.today} %>
   <%= f.input :comment %>
   <%= f.submit %>

--- a/spec/models/hold_request_spec.rb
+++ b/spec/models/hold_request_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe HoldRequest do
       .to_return(status: 200, body: File.read(fixture_path + '/alma_users/full_user_record.xml'), headers: {})
     stub_request(:get, "http://www.example.com/almaws/v1/bibs/9936984306602486?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail,requests&view=full")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_bib_records/sound_recording.xml'), headers: {})
-    stub_request(:get, "http://www.example.com/almaws/v1/bibs/9936984306602486/holdings/ALL/items?apikey=fakebibkey123&expand=due_date_policy&limit=100&offset=0&order_by=chron_i&user_id=GUEST")
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/9936984306602486/holdings/ALL/items?apikey=fakebibkey123&expand=due_date_policy&limit=100&offset=0&order_by=chron_i&user_id=janeq")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_item_records/9936984306602486.xml'), headers: {})
     # user = User.create(uid: "janeq")
     hr = described_class.new(mms_id: "9936984306602486", user: user)
@@ -157,12 +157,14 @@ RSpec.describe HoldRequest do
 
   describe "#items" do
     it "returns holding_items in an array" do
+      stub_request(:get, "http://www.example.com/almaws/v1/bibs/990011434390302486/holdings/ALL/items?apikey=fakebibkey123&expand=due_date_policy&limit=100&offset=0&order_by=chron_i&user_id=GUEST")
+        .to_return(status: 200, body: File.read(fixture_path + '/alma_item_records/990011434390302486.xml'), headers: {})
       hr = described_class.new(mms_id: "990011434390302486")
       expect(hr.items).to eq [
-        { label: "ML549 .E38 v.30(2013)", value: "23187557240002486" },
-        { label: "ML549 .E38 v.25-29(2010-2012)", value: "23187557230002486" },
-        { label: "ML549 .E38 V.21-24 2003-2006", value: "23187557250002486" },
-        { label: "ML549 .E38 V.18-20 2000-2002", value: "23187557260002486" }
+        { label: "Library: Marian K. Heilbrun Music Media, Location: Book Stacks, ML549 .E38, Description: v.30(2013)", value: "23187557240002486" },
+        { label: "Library: Marian K. Heilbrun Music Media, Location: Book Stacks, ML549 .E38, Description: v.25-29(2010-2012)", value: "23187557230002486" },
+        { label: "Library: Marian K. Heilbrun Music Media, Location: Book Stacks, ML549 .E38, Description: V.21-24 2003-2006", value: "23187557250002486" },
+        { label: "Library: Marian K. Heilbrun Music Media, Location: Book Stacks, ML549 .E38, Description: V.18-20 2000-2002", value: "23187557260002486" }
       ]
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe User do
     end
 
     before do
-      described_class.delete_all
+      described_class.destroy_all
     end
 
     context "shibboleth" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -145,7 +145,5 @@ RSpec.configure do |config|
     ).to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file.xml'), headers: {})
     stub_request(:get, "http://www.example.com/almaws/v1/bibs/990011434390302486?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail,requests&view=full")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_multiple_holdings_item_level.xml'), headers: {})
-    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990011434390302486/holdings/ALL/items?apikey=fakebibkey123&expand=due_date_policy&limit=100&offset=0&order_by=chron_i&user_id=GUEST")
-      .to_return(status: 200, body: File.read(fixture_path + '/alma_item_records/990011434390302486.xml'), headers: {})
   end
 end

--- a/spec/system/hold_request_spec.rb
+++ b/spec/system/hold_request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Create a request for a holding", type: :system, js: true, alma: 
       .to_return(status: 200, body: File.read(fixture_path + '/alma_users/full_user_record.xml'), headers: {})
     stub_request(:post, "http://www.example.com/almaws/v1/users/janeq/requests?user_id_type=all_unique&mms_id=9936550118202486&allow_same_request=false&apikey=fakeuserkey456")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_request_test_file.json'))
-    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990011434390302486/holdings/ALL/items?apikey=fakebibkey123&expand=due_date_policy&user_id=janeq")
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs/990011434390302486/holdings/ALL/items?apikey=fakebibkey123&expand=due_date_policy&user_id=janeq&limit=100&offset=0&order_by=chron_i")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_item_records/990011434390302486.xml'), headers: {})
   end
 
@@ -57,6 +57,6 @@ RSpec.describe "Create a request for a holding", type: :system, js: true, alma: 
   it 'has a dropdown with item level call number and description for unique item level descriptions' do
     sign_in(user)
     visit new_hold_request_path(hold_request: { mms_id: "990011434390302486" })
-    expect(page).to have_select("hold_request_holding_item_id", with_options: ["ML549 .E38 V.21-24 2003-2006"])
+    expect(page).to have_content("Library: Marian K. Heilbrun Music Media, Location: Book Stacks, ML549 .E38, Description: v.30(2013)")
   end
 end


### PR DESCRIPTION
* We are changing from the dropdown menu to radio buttons for displaying item level information. This commit also attempts to reduce the number of API calls made on new hold request form.

![image](https://user-images.githubusercontent.com/17075287/125116668-0f971d80-e0bb-11eb-9bdf-5cda82f34d81.png)
