### PR TITLE
creates two-step document (ILLiad) request via API

### DIFF
--- a/app/models/concerns/document_delivery_requestable.rb
+++ b/app/models/concerns/document_delivery_requestable.rb
@@ -11,9 +11,17 @@ module DocumentDeliveryRequestable
           { user_group: user.user_group, library_code: hol[:library][:value], location_code: hol[:location][:value], item_code: i[:type_code] }
         )
       end
-      { library: hol[:library][:label], location: hol[:location][:label], urls: eligible_items.map { |i| document_delivery_url(hol, i) } } if eligible_items.present?
+      if eligible_items.present?
+        { library: hol[:library][:label], location: hol[:location][:label], call_number: hol[:call_number], descriptions: eligible_items.map { |i| i[:description] },
+          urls: eligible_items.map { |i| document_delivery_url(hol, i) } }
+      end
     end&.compact
     links
+  end
+
+  def item_descriptions(item)
+    descriptions = []
+    descriptions << item[:description]
   end
 
   def document_delivery_url(holding, item)
@@ -61,7 +69,18 @@ module DocumentDeliveryRequestable
     check_for_one_step
   end
 
+  def two_step_doc_delivery?(phys_holdings, user = nil)
+    links = doc_delivery_links(phys_holdings, user)
+    check_for_two_step = links.empty? ? false : (links.count > 1 || links.first[:urls].size > 1)
+    @two_step_links = links if check_for_two_step
+    check_for_two_step
+  end
+
   def one_step_link
     @one_step_link
+  end
+
+  def two_step_links
+    @two_step_links
   end
 end

--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -17,6 +17,10 @@
           <% if document.one_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
             <%= link_to "Request Article or Chapter", document.one_step_link, class: "dropdown-item" %>
           <% end %>
+          <% if document.two_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
+            <%= link_to "Request Article or Chapter", "#", class: "dropdown-item", data: {toggle: "modal", target: "#two-step-illiad"} %>
+           
+          <% end %>
           <% if document.special_collections_requestable?(current_or_guest_user) %>
             <%= link_to "Request from Special Collections", document.special_collections_url, class: "dropdown-item" %>
           <% end %>
@@ -91,6 +95,9 @@
                 </tbody>
               </table>
             </div>
+            <% if document.two_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
+              <%= render 'two_step_illiad_modal', document: document, physical_holdings: physical_holdings %>
+            <% end %>
           <% end %>
           <% if document.online_holdings %>
             <table class="table">
@@ -113,3 +120,5 @@
           <!-- TODO: Change the link below to the production url for Alma if we continue to use this -->
           <%= link_to("Services page", "#{ENV["ALMA_BASE_SANDBOX_URL"]}/discovery/openurl?institution=#{ENV["INSTITUTION"]}&vid=#{ENV["INSTITUTION"]}:blacklight&rft.mms_id=#{document.id}", target: "_blank") %>
         </div>
+
+

--- a/app/views/catalog/_two_step_illiad_modal.html.erb
+++ b/app/views/catalog/_two_step_illiad_modal.html.erb
@@ -1,0 +1,22 @@
+<div id="two-step-illiad" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div id="direct-link" class="modal-header">
+                    <h5 class="mb-0">Request Item</h5>
+                    <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </div>
+                  <div class="modal-body">
+                    <% document.two_step_links.each do |holding| %>
+                    <p><%= holding[:library] %> <%= holding[:location] %></p>
+                    <ul>
+                    <% holding[:urls].each.with_index(0) do |item, index| %>
+                    <li class="mt-2"><%= holding[:call_number] %> <%= holding[:descriptions][index] %> <%= link_to "Request", item, class: "btn btn-primary" %></li>
+                    <% end %>
+                  </ul>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
+            </div>


### PR DESCRIPTION
Connected to #688 

- Take me an item-level selection page
- Show the call number and description for each item that is available to me based on circulation policy
- When I selected a unique item, take me to ILLiad
- The link to ILLiad request form should be populated with all the available title metadata

<img width="861" alt="Screen Shot 2021-07-13 at 8 37 31 AM" src="https://user-images.githubusercontent.com/2473408/125466129-890fd208-9bc7-4660-8ce7-fa3a8841cdae.png">
<img width="606" alt="Screen Shot 2021-07-13 at 9 48 01 AM" src="https://user-images.githubusercontent.com/2473408/125473261-7e0bf750-c0ff-48bb-8adc-ccadcfd8c47f.png">
<img width="1126" alt="Screen Shot 2021-07-13 at 8 38 33 AM" src="https://user-images.githubusercontent.com/2473408/125466171-15f1076e-09a6-42a7-87ac-9ac7464a84ac.png">
