### PR TITLE
Adds rake task with scheduler for deleting old guests and associations

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -6,6 +6,11 @@ require "capistrano/setup"
 # Include default deployment tasks
 require "capistrano/deploy"
 
+# exec `whenever` every time we deploy so that jobs
+# are added to crontab
+set :whenever_command, "bundle exec whenever"
+require "whenever/capistrano"
+
 # Load the SCM plugin appropriate to your project:
 #
 # require "capistrano/scm/hg"

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'simple_form' # For database authentication page from Devise
 gem 'sqlite3'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'uglifier', '>= 1.3.0'
+gem 'whenever', require: false
 
 group :development, :test do
   gem 'bixby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    chronic (0.10.2)
     coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -474,6 +475,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (0.11.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     xray-rails (0.3.2)
@@ -537,6 +540,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers (~> 3.0)
   webmock
+  whenever
   xray-rails
 
 RUBY VERSION

--- a/app/services/delete_old_guests_service.rb
+++ b/app/services/delete_old_guests_service.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class DeleteOldGuestsService
+  def self.destroy_users
+    User.where(["created_at < ? AND uid LIKE 'guest_%'", 30.minutes.ago]).destroy_all
+  end
+end

--- a/app/services/delete_old_searches_service.rb
+++ b/app/services/delete_old_searches_service.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class DeleteOldSearchesService
+  def self.destroy_searches
+    Search.where(["created_at < ? AND user_id IS NULL", 30.minutes.ago]).destroy_all
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every 30.minutes do
+  rake "delete_old_guests_and_associations"
+end

--- a/lib/tasks/delete_old_guests_and_associations.rake
+++ b/lib/tasks/delete_old_guests_and_associations.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+desc "Delete stale searches for NULL and guest users along with their bookmarks"
+task delete_old_guests_and_associations: [:environment] do
+  DeleteOldGuestsService.destroy_users
+  DeleteOldSearchesService.destroy_searches
+end

--- a/spec/services/delete_old_guests_service_spec.rb
+++ b/spec/services/delete_old_guests_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DeleteOldGuestsService, :clean do
+  around do |example|
+    User.destroy_all
+    Bookmark.destroy_all
+    Bookmark.create!(id: 123, user: User.create(id: 123, guest: true, uid: 'guest_123'))
+    expect(User.find(123).uid).to eq 'guest_123'
+    expect(Bookmark.find(123).user_id).to eq 123
+    example.run
+    User.destroy_all
+    Bookmark.destroy_all
+  end
+
+  it 'deletes guest user created 30 mins ago along with their bookmarks' do
+    User.update(id: 123, created_at: Time.current - 31.minutes)
+    described_class.destroy_users
+    expect(User.find_by_id(123).nil?).to eq true
+    expect(Bookmark.find_by_id(123).nil?).to eq true
+  end
+
+  it 'does not delete guest user created 30 mins ago' do
+    User.update(id: 123, created_at: Time.current - 29.minutes)
+    described_class.destroy_users
+    expect(User.find_by_id(123).nil?).to eq false
+    expect(Bookmark.find_by_id(123).nil?).to eq false
+  end
+end

--- a/spec/services/delete_old_searches_service_spec.rb
+++ b/spec/services/delete_old_searches_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DeleteOldSearchesService, :clean do
+  around do |example|
+    Search.destroy_all
+    Search.create(id: 123, query_params: 'abc', user: nil)
+    expect(Search.find(123).query_params).to eq 'abc'
+    example.run
+    Search.destroy_all
+  end
+
+  it 'deletes all searches without user which are more than 30 mins old' do
+    Search.update(id: 123, created_at: Time.current - 31.minutes)
+    described_class.destroy_searches
+    expect(Search.find_by_id(123)).to eq nil
+  end
+
+  it 'does not delete searches without user which are less than 30 mins old' do
+    Search.update(id: 123, created_at: Time.current - 29.minutes)
+    described_class.destroy_searches
+    expect(Search.find_by_id(123).nil?).to eq false
+  end
+end


### PR DESCRIPTION
* We are adding a rake task with services for deleting old guests and its associations - bookmarks. Searches are also deleted for all null users.
* Rake task is scheduled and added to crontab using whenever.