### PR TITLE
Bug: corrects the formatting of RIS files to comply with Endnote (#755).

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -143,9 +143,9 @@ module Blacklight::Solr::Document::MarcExport
       ris_format[ris_key] = try(:[], solr_field)&.first
     end
     # TODO: crosswalk formats with allowed Type values for RIS
-    text = "TY - GEN\n"
+    text = "TY  - GEN\n"
     ris_format.each do |ris_key, value|
-      text += "#{ris_key} - #{value}\n"
+      text += "#{ris_key}  - #{value}\n"
     end
     text
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -25,8 +25,9 @@ RSpec.describe SolrDocument do
     solr.commit
   end
 
+  let(:solr_doc) { described_class.find(TEST_ITEM[:id]) }
+
   context "with an alias for an identifier" do
-    let(:solr_doc) { described_class.find(TEST_ITEM[:id]) }
     it "has an alias for identifier and mms_id" do
       expect(solr_doc.id).to eq(TEST_ITEM[:id])
       expect(solr_doc.mms_id).to eq(TEST_ITEM[:id])
@@ -34,8 +35,6 @@ RSpec.describe SolrDocument do
   end
 
   context "with a regular test item" do
-    let(:solr_doc) { described_class.find(TEST_ITEM[:id]) }
-
     context '#combined_author_display_vern' do
       it 'combines together author_display_ssim and author_vern_ssim' do
         expect(solr_doc.combined_author_display_vern).to eq ['George Jenkins', 'G. Jenkins']


### PR DESCRIPTION
- app/models/concerns/blacklight/solr/document/marc_export.rb: adds needed extra space before the dash.
- spec/models/solr_document_spec.rb: refactors repetitive code.