### PR TITLE
Corrects the logic to deliver citations on the Bookmark page (#742).

### DIFF
--- a/app/views/bookmarks/_clear_bookmarks_widget.html.erb
+++ b/app/views/bookmarks/_clear_bookmarks_widget.html.erb
@@ -1,13 +1,8 @@
 <%= link_to "<span class='short-clear'>Clear</span><span class='long-clear'>#{t('blacklight.bookmarks.clear.action_title')}</span>".html_safe, 
               clear_bookmarks_path, 
-              :method => :delete, 
-              :data => { :confirm => t('blacklight.bookmarks.clear.action_confirm') }, 
-              :class => 'clear-bookmarks btn btn-danger' 
-%>
-<%= link_to 'Cite', "#", class: 'cite-bookmarks btn btn-outline-primary rounded-0' %>
-
-<%#= render_show_doc_actions document_list, document: nil, document_list: @response.documents, url_opts: Blacklight::Parameters.sanitize(params.to_unsafe_h) do |config, inner| %>
-  <%# if inner.include?("Cite") %>
-      <%#= inner %>
-  <%# end %>
-<%# end %>
+              class: 'clear-bookmarks btn btn-danger',
+              data: { confirm: t('blacklight.bookmarks.clear.action_confirm') },
+              method: :delete %>
+<%= link_to t('blacklight.bookmarks.cite'), citation_bookmarks_path, 
+              class: 'cite-bookmarks btn btn-outline-primary rounded-0',
+              data: { "blacklight-modal": "trigger" } %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -12,6 +12,7 @@ en:
     bookmarks:
       add:
         button: 'Bookmark Item'
+      cite: 'Cite'
     citation:
       mla: 'MLA (8th Edition)'
       apa: 'APA (7th Edition)'


### PR DESCRIPTION
- app/views/bookmarks/_clear_bookmarks_widget.html.erb: adds needed elements to the Cite link.
- config/locales/blacklight.en.yml: localizes the link text.

<img width="1145" alt="Screen Shot 2021-07-21 at 3 15 47 PM" src="https://user-images.githubusercontent.com/18330149/126546693-bbc5a5ee-feb4-4ca2-938c-573a9193f191.png">
