### PR TITLE
Refines Bookmark page's cite buton's styling (#775).

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_bookmarks.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_bookmarks.scss
@@ -2,17 +2,24 @@
 
 // Bookmark Clear Button
 a.clear-bookmarks.btn {
-  border-radius: 0;
-  line-height: 1.968;
-  padding: 0.75rem 1rem;
-  border: none;
+  border-radius:  0;
+  line-height:    $bookmarks-button-line-height;
+  padding:        $bookmarks-button-clear-padding;
+  border:         none;
 }
-.cite-bookmarks.btn{
-  font: normal bold 0.6875rem "Open Sans", sans-serif;
-  line-height: 1.968;
-  padding: 0.6875rem 1rem;
-  letter-spacing: 0.05rem;
-  text-transform: uppercase;
+.cite-bookmarks.btn {
+  background-color: $bright-blue;
+  color:            $white;
+  font:             normal bold $font-size-sm "Open Sans", sans-serif;
+  line-height:      $bookmarks-button-line-height;
+  padding:          $bookmarks-button-cite-padding;
+  letter-spacing:   $bookmarks-button-cite-letter-spacing;
+  text-transform:   uppercase;
+
+  &:hover {
+    background-color: $mid-blue;
+    border-color:     $mid-blue;
+  }
 }
 
 @media (max-width: 575px) {
@@ -34,7 +41,7 @@ h2.bookmarks-subheading {
 }
 
 div#sortAndPerPage.sort-pagination.bookmarks > div > div.page-links {
-  padding-left: 1rem;
+  padding-left: $spacer;
 }
 
 // Bookmarks Nav

--- a/app/assets/stylesheets/blacklight_catalog/_variables.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_variables.scss
@@ -201,7 +201,6 @@ $static-not-found-list-margin:          $facet-label-font-size;
 $static-not-found-list-line-h:          1.938rem;
 
 // Advanced Search
-
 $advanced-search-subtitle-font-size:  $font-size-base * 1.5;
 $advanced-search-button-height:       3.125rem;
 $advanced-search-button-padding:      0.875rem 1.5625rem;
@@ -221,4 +220,8 @@ $constraint-container-margin-top:   1.25rem;
 // Pagination/Sort
 $pagination-padding-left-right:   0.3125rem;
 
-
+// Bookmarks
+$bookmarks-button-line-height:          1.968;
+$bookmarks-button-clear-padding:        0.75rem 1rem;
+$bookmarks-button-cite-padding:         0.6875rem 1rem;
+$bookmarks-button-cite-letter-spacing:  0.05rem;


### PR DESCRIPTION
- app/assets/stylesheets/blacklight_catalog/_bookmarks.scss: changes the appearance of the Cite button.
- app/assets/stylesheets/blacklight_catalog/_variables.scss: refactors some of the values of the bookmarks partial into variables.


https://user-images.githubusercontent.com/18330149/126644903-cad49943-c5e3-4c97-ad0e-ce7e4abbd669.mov

