### PR TITLE
Changes URI data type and removes addition of label when saving collections

### DIFF
--- a/app/services/update_collection_authority_service.rb
+++ b/app/services/update_collection_authority_service.rb
@@ -9,7 +9,7 @@ class UpdateCollectionAuthorityService
     Qa::LocalAuthorityEntry.delete_all
     collection_auth = Qa::LocalAuthority.find_or_create_by(name: 'collections')
     collections&.each do |col|
-      Qa::LocalAuthorityEntry.create(local_authority: collection_auth, label: col, uri: col)
+      Qa::LocalAuthorityEntry.create(local_authority: collection_auth, uri: col)
     end
   end
 end

--- a/db/migrate/20210726233825_change_uri_data_type_authority_entry.rb
+++ b/db/migrate/20210726233825_change_uri_data_type_authority_entry.rb
@@ -1,0 +1,5 @@
+class ChangeUriDataTypeAuthorityEntry < ActiveRecord::Migration[5.1]
+  def change
+    change_column :qa_local_authority_entries, :uri, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210721211326) do
+ActiveRecord::Schema.define(version: 20210726233825) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.integer "user_id", null: false
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20210721211326) do
   create_table "qa_local_authority_entries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.bigint "local_authority_id"
     t.string "label"
-    t.string "uri"
+    t.text "uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.virtual "lower_label", type: :string, limit: 256, as: "lower(`label`)"


### PR DESCRIPTION
* We don't need to save collection names as a label but only URI. We are saving collection names in URI which is now a text column.