### PR TITLE
Attempts to improve collection filter

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class CollectionsController < ApplicationController
+  def search
+    @collection_result = Qa::LocalAuthorityEntry.where("uri LIKE lower(?)", "%#{params[:uri].downcase}%").pluck(:uri) || []
+    render json: { collection_result: @collection_result }
+  end
+end

--- a/app/views/advanced/_advanced_search_facets_as_select.html.erb
+++ b/app/views/advanced/_advanced_search_facets_as_select.html.erb
@@ -36,7 +36,7 @@
       <%= facet_field_label("collection_ssim") %>
     <% end %>
 
-    <div class="col-sm-9">
+    <div class="col-sm-9" id='collection_facet'>
       <%= content_tag(:select,
                       multiple: true,
                       name: "f_inclusive[collection_ssim][]",
@@ -52,6 +52,27 @@
     </div>
   </div>
 <% end %>
+
+<script>
+  $(document).on('keyup', '#collection_facet .bs-searchbox input', function(e){
+    var q = e.target.value;
+    $.ajax({
+      type: "GET",
+      url: "/collections/search",
+      data: {'uri': q},
+      dataType: "json",
+      success: function(data) {
+        var data = data.collection_result;
+        options = [];
+        data.forEach(function(v) {
+          options += '<option value=' + v + '>' + v + '</option>';
+        });
+        $('#collection_ssim').html(options);
+        $('#collection_ssim').selectpicker('refresh');
+      }
+    });
+  });
+</script>
 
 <%# Publication Date is a range input %>
 <% pub_date = facet_configuration_for_field('pub_date_isim') %>

--- a/config/initializers/advanced_controller.rb
+++ b/config/initializers/advanced_controller.rb
@@ -7,6 +7,6 @@ BlacklightAdvancedSearch::AdvancedController.class_eval do
   def index
     @response = get_advanced_search_facets unless request.method == :post
     collection_auth = Qa::LocalAuthority.find_by(name: 'collections')
-    @collection_ssim_facet = Qa::LocalAuthorityEntry.where(local_authority_id: collection_auth)&.pluck(:uri) || []
+    @collection_ssim_facet = Qa::LocalAuthorityEntry.where(local_authority_id: collection_auth).limit(100)&.pluck(:uri) || []
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,4 +53,5 @@ Rails.application.routes.draw do
   match '/404', to: 'errors#not_found', via: :all
   match '/500', to: 'errors#unhandled_exception', via: :all
   match '/422', to: 'errors#unprocessable', via: :all
+  get '/collections/search', to: 'collections#search'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,3 +27,7 @@ env :PATH, ENV['PATH']
 every 30.minutes do
   rake "delete_old_guests_and_associations"
 end
+
+every 1.day, at: '3am' do
+  runner "UpdateCollectionAuthorityService.update_authority_entries"
+end

--- a/lib/tasks/marc_index_ingester.rake
+++ b/lib/tasks/marc_index_ingester.rake
@@ -35,7 +35,4 @@ task marc_index_ingest: [:environment] do
   ingest_logger&.info("Storing 'to' time")
   PropertyBag.set('marc_ingest_time', to_time) unless single_record
   ingest_logger&.info("Ingesting Complete!")
-  ingest_logger&.info("Starting update of collections local authority table")
-  UpdateCollectionAuthorityService.update_authority_entries
-  ingest_logger&.info("Update of collections local authority table complete")
 end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CollectionsController, type: :controller do
+  before do
+    col = Qa::LocalAuthority.find_or_create_by(name: 'collections')
+    Qa::LocalAuthorityEntry.create(local_authority: col, uri: 'Example1')
+    Qa::LocalAuthorityEntry.create(local_authority: col, uri: 'Blacklight1')
+  end
+
+  context '#search' do
+    it 'will return correct result' do
+      get :search, params: { uri: 'ex' }
+      expect(JSON.parse(response.body)["collection_result"]).to eq(['Example1'])
+    end
+  end
+end


### PR DESCRIPTION
* We are trying to improve the collection filter on the advanced search page. We will only be showing the first 100 collection names but will make the entire table searchable by using ajax GET requests.

**app/controllers/collections_controller.rb**: New collections search controller. We are using LIKE sql query.
**app/views/advanced/_advanced_search_facets_as_select.html.erb**: Adds simple ajax call to the collections search controller action
**config/initializers/advanced_controller.rb**: Limits dropdown to only first 100 options
**config/routes.rb**: Updates route for new controller
**config/schedule.rb**: Adds whenever schedule to run service at 3am every night
