### PR TITLE
Bug: Corrects the values being used as data attributes in the option injection (#808).

### DIFF
--- a/app/views/advanced/_advanced_search_facets_as_select.html.erb
+++ b/app/views/advanced/_advanced_search_facets_as_select.html.erb
@@ -67,7 +67,7 @@
           $('#collection_ssim').selectpicker('refresh');
           options = [];
           data.forEach(function(v) {
-            options += '<option value=' + v + '>' + v + '</option>';
+            options += '<option value="' + v + '">' + v + '</option>';
           });
           $('#collection_ssim').html(options);
           $('#collection_ssim').selectpicker('refresh');


### PR DESCRIPTION
app/views/advanced/_advanced_search_facets_as_select.html.erb: inserts quotes into the JS to stringify the values.

Since this is a quick fix and POs are awaiting this correction, I have forgone Rspec since it was showing signs that it would take until next day to figure it out.
