### PR TITLE
Refines RIS output via mapping changes (#811).

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -130,9 +130,8 @@ module Blacklight::Solr::Document::MarcExport
   # Very preliminary implementation of RIS format. Only gives first value of multi-value Solr fields
   def export_as_ris
     ris_format = {
-      "A1" => :author_display_ssim,
       "A2" => :author_addl_ssim,
-      "AU" => :author_display_ssim,
+      "AU" => :author_ssim,
       "CN" => :local_call_number_tesim,
       "CY" => :publisher_location_ssim,
       "DA" => :pub_date_isim,
@@ -144,7 +143,6 @@ module Blacklight::Solr::Document::MarcExport
       "PP" => :publisher_location_ssim,
       "PY" => :pub_date_isim,
       "SN" => :isbn_ssim,
-      "T1" => :title_citation_ssi,
       "TI" => :title_citation_ssi,
       "TT" => :title_translation_tesim,
       "VO" => :other_standard_ids_tesim,

--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -223,7 +223,7 @@ to_field 'publication_main_display_ssim', extract_publication_main_display
 to_field 'published_tesim', extract_published
 to_field 'published_vern_ssim', extract_marc('260a', alternate_script: :only), trim_punctuation
 to_field 'publisher_details_display_ssim', extract_publisher_details_display
-to_field 'publisher_location_ssim', extract_marc("260a:264a:008[15-17]"), trim_punctuation
+to_field 'publisher_location_ssim', extract_marc("260a:264a"), trim_punctuation
 to_field 'publisher_number_tesim', extract_marc('028ab')
 
 # Library of Congress Fields


### PR DESCRIPTION
- app/models/concerns/blacklight/solr/document/marc_export.rb: removes two mappings marked for deletion and swaps author field to the that doesn't scrape the relator field.
- lib/marc_indexer.rb: excises geocode from the `publisher_location_ssim` field.