### PR TITLE
Eliminates non-filing words from the First Char solr field processing (#813).

### DIFF
--- a/lib/traject/extract_title_main_first_char.rb
+++ b/lib/traject/extract_title_main_first_char.rb
@@ -5,8 +5,8 @@ extend ExtractionTools
 module ExtractTitleMainFirstChar
   def extract_title_main_first_char
     lambda do |rec, acc|
-      titles = marc21.extract_marc_from(rec, '245abfgknps', alternate_script: false)
-      titles.each { |t| acc << t.match(/(\w|\p{L})/)[0].upcase } if titles.present?
+      title = Traject::Macros::Marc21Semantics.get_sortable_title(rec)
+      acc << title.match(/(\w|\p{L})/)[0].upcase if title.present?
     end
   end
 end


### PR DESCRIPTION
lib/traject/extract_title_main_first_char.rb: utilizes Marc21's built in processing to eliminate non-filing words from titles, giving this field the true first character.

<img width="1200" alt="Screen Shot 2021-08-12 at 8 38 10 AM" src="https://user-images.githubusercontent.com/18330149/129198044-b8a63959-1f1a-46ce-aa78-5000c5165d9c.png">
