### PR TITLE
Removes punctuation from Title and Author sort fields (#814).

### DIFF
--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -38,6 +38,8 @@ require 'traject/extract_format_string'
 require 'traject/extract_isbn'
 require 'traject/extract_other_standard_ids'
 require 'traject/extract_call_number'
+require 'traject/extract_emory_sortable_author'
+require 'traject/extract_emory_sortable_title'
 require 'traject/extract_library'
 require 'traject/extract_marc_resource'
 require 'traject/extract_publication_main_display.rb'
@@ -64,6 +66,8 @@ extend ExtractFormatString
 extend ExtractIsbn
 extend ExtractOtherStandardIds
 extend ExtractCallNumber
+extend ExtractEmorySortableAuthor
+extend ExtractEmorySortableTitle
 extend ExtractLibrary
 extend ExtractMarcResource
 extend ExtractPublicationMainDisplay
@@ -189,7 +193,7 @@ to_field 'title_main_display_ssim', extract_marc('245abfgknps', alternate_script
 to_field 'title_main_first_char_ssim', extract_title_main_first_char
 to_field 'title_series_ssim', extract_marc(title_series_str(ATOG))
 to_field 'title_series_tesim', extract_marc(title_series_str(ATOG))
-to_field 'title_ssort', marc_sortable_title
+to_field 'title_ssort', extract_emory_sortable_title
 to_field 'title_translation_tesim', extract_marc("242#{ATOZ}")
 to_field 'title_uniform_ssim', extract_marc("130adfklmnoprs:240#{ATOG}knps")
 to_field 'title_varying_tesim', extract_marc("246#{ATOG}inp")
@@ -199,7 +203,7 @@ to_field 'author_addl_display_tesim', extract_author_addl_display
 to_field 'author_addl_ssim', extract_marc("700abcdgqt:710abcdgn:711acdegnqe", alternate_script: false), trim_punctuation
 to_field 'author_display_ssim', extract_author_display
 # JSTOR isn't an author. Try to not use it as one
-to_field 'author_ssort', marc_sortable_author
+to_field 'author_ssort', extract_emory_sortable_author
 to_field 'author_ssim', extract_marc("100abcdq:110abd:111acd:700abcdq:710abd:711acd"), trim_punctuation
 to_field 'author_ssm', extract_marc("100abcdq:110#{ATOZ}:111#{ATOZ}", alternate_script: false)
 to_field 'author_tesim', extract_marc("100abcegqu:110abcdegnu:111acdegjnqu")

--- a/lib/traject/extract_emory_sortable_author.rb
+++ b/lib/traject/extract_emory_sortable_author.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'traject/extraction_tools'
+extend ExtractionTools
+
+module ExtractEmorySortableAuthor
+  def extract_emory_sortable_author
+    lambda do |record, accumulator|
+      st = marc_semantics.get_sortable_author(record)
+      accumulator << remove_punct_from_string(st) if st
+    end
+  end
+end

--- a/lib/traject/extract_emory_sortable_title.rb
+++ b/lib/traject/extract_emory_sortable_title.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'traject/extraction_tools'
+extend ExtractionTools
+
+module ExtractEmorySortableTitle
+  def extract_emory_sortable_title
+    lambda do |record, accumulator|
+      st = marc_semantics.get_sortable_title(record)
+      accumulator << remove_punct_from_string(st) if st
+    end
+  end
+end

--- a/lib/traject/extract_title_main_first_char.rb
+++ b/lib/traject/extract_title_main_first_char.rb
@@ -5,7 +5,7 @@ extend ExtractionTools
 module ExtractTitleMainFirstChar
   def extract_title_main_first_char
     lambda do |rec, acc|
-      title = Traject::Macros::Marc21Semantics.get_sortable_title(rec)
+      title = marc_semantics.get_sortable_title(rec)
       acc << title.match(/(\w|\p{L})/)[0].upcase if title.present?
     end
   end

--- a/lib/traject/extraction_tools.rb
+++ b/lib/traject/extraction_tools.rb
@@ -5,6 +5,14 @@ module ExtractionTools
     Traject::Macros::Marc21
   end
 
+  def marc_semantics
+    Traject::Macros::Marc21Semantics
+  end
+
+  def remove_punct_from_string(str)
+    str.gsub(/[[:punct:]]/, "")
+  end
+
   def extract_join_remove(record, field_num_tag)
     marc21.extract_marc_from(record, field_num_tag).join(' ').remove(" :", "[", "]")
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SessionsController, type: :controller do
       expect(response).to redirect_to(root_path)
       expect(flash[:error]).to be(nil)
       expect(session[:alma_id]).to eq('bukowski1')
-      expect(User.first.uid).to eq('bukowski1')
+      expect(User.last.uid).to eq('bukowski1')
     end
   end
 end

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -360,4 +360,24 @@ RSpec.describe 'Indexing fields with custom logic' do
   describe 'author_vern_ssim field' do
     it('has correct value for vernacular author') { expect(solr_doc['author_vern_ssim']).to eq(['Yackety Smackety']) }
   end
+
+  describe 'title_ssort field' do
+    it 'has a string with no puctuation' do
+      match_results = [solr_doc, solr_doc2, solr_doc3, solr_doc4, solr_doc5, solr_doc6,
+                       solr_doc7, solr_doc8, solr_doc9, solr_doc10].map do |d|
+                         d['title_ssort'].match(/[[:punct:]]/)
+                       end
+      expect(match_results.compact).to be_empty
+    end
+  end
+
+  describe 'author_ssort field' do
+    it 'has a string with no puctuation' do
+      match_results = [solr_doc, solr_doc2, solr_doc3, solr_doc4, solr_doc5, solr_doc6,
+                       solr_doc7, solr_doc8, solr_doc9, solr_doc10].map do |d|
+                         d['author_ssort'].match(/[[:punct:]]/)
+                       end
+      expect(match_results.compact).to be_empty
+    end
+  end
 end

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe 'Indexing fields with custom logic' do
     it 'has a string with no puctuation' do
       match_results = [solr_doc, solr_doc2, solr_doc3, solr_doc4, solr_doc5, solr_doc6,
                        solr_doc7, solr_doc8, solr_doc9, solr_doc10].map do |d|
-                         d['title_ssort'].match(/[[:punct:]]/)
+                         d['title_ssort']&.match(/[[:punct:]]/)
                        end
       expect(match_results.compact).to be_empty
     end
@@ -375,7 +375,7 @@ RSpec.describe 'Indexing fields with custom logic' do
     it 'has a string with no puctuation' do
       match_results = [solr_doc, solr_doc2, solr_doc3, solr_doc4, solr_doc5, solr_doc6,
                        solr_doc7, solr_doc8, solr_doc9, solr_doc10].map do |d|
-                         d['author_ssort'].match(/[[:punct:]]/)
+                         d['author_ssort']&.match(/[[:punct:]]/)
                        end
       expect(match_results.compact).to be_empty
     end


### PR DESCRIPTION
- lib/marc_indexer.rb: adds two new customized extraction methods that strip punctuation out of the title/author sorts.
- lib/traject/*: institutes code to extract punctuation.
- lib/traject/extract_title_main_first_char.rb: swaps out long call to module with a new method.
- lib/traject/extraction_tools.rb: inserts two new methods that DRY up the other module's processes.
- spec/*: changes and inserts new expectations.

No screenshots necessary.