### PR TITLE
Bug: main title first char mapping error.

### DIFF
--- a/lib/traject/extract_title_main_first_char.rb
+++ b/lib/traject/extract_title_main_first_char.rb
@@ -6,7 +6,8 @@ module ExtractTitleMainFirstChar
   def extract_title_main_first_char
     lambda do |rec, acc|
       title = marc_semantics.get_sortable_title(rec)
-      acc << title.match(/(\w|\p{L})/)[0].upcase if title.present?
+      matched_chars = title&.match(/(\w|\p{L})/)
+      acc << matched_chars[0].upcase if matched_chars.present?
     end
   end
 end

--- a/spec/fixtures/alma_marc_resource.xml
+++ b/spec/fixtures/alma_marc_resource.xml
@@ -1730,7 +1730,7 @@
             <subfield code="a">I 19:1570</subfield>
           </datafield>
           <datafield tag="245" ind1="0" ind2="4">
-            <subfield code="a">The Future of energy gases /</subfield>
+            <subfield code="a">/</subfield>
             <subfield code="c">David G. Howell, editor ; associate editors, Katryn Wiese [and others].</subfield>
           </datafield>
           <datafield tag="264" ind1=" " ind2="2">

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -380,4 +380,8 @@ RSpec.describe 'Indexing fields with custom logic' do
       expect(match_results.compact).to be_empty
     end
   end
+
+  describe 'title_main_first_char_ssim field' do
+    it('remains empty if value is just punctuation') { expect(solr_doc10['title_main_first_char_ssim']).to be_nil }
+  end
 end


### PR DESCRIPTION
- lib/traject/extract_title_main_first_char.rb: checks for match before pushing to accumulator.
- spec/fixtures/alma_marc_resource.xml: changes title for testing purposes.
- spec/models/marc_indexing_spec.rb: tests new protective logic.

No screenshots necessary.