### PR TITLE
Changes the placeholder text in the Search bar (#837).

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -37,6 +37,9 @@ en:
     search:
       bookmarks:
         absent: 'Bookmark Item'
+      form:
+        search:
+          placeholder: 'Search the Library Catalog'
       librarian_view: 
         title: 'Staff View'
     tools:

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     visit root_path
   end
 
+  it('has the right placeholder text') { expect(find('input[placeholder="Search the Library Catalog"]')).to be_truthy }
+
   it 'has the right options' do
     options = find_all('select.custom-select.search-field > option').map(&:text)
 


### PR DESCRIPTION
- config/locales/blacklight.en.yml: overrides blacklight localization.
- spec/system/targeted_field_search_spec.rb: tests for the right verbiage.

<img width="839" alt="Screen Shot 2021-08-19 at 9 02 25 AM" src="https://user-images.githubusercontent.com/18330149/130073057-953f25e5-71be-4849-ac0e-e22a18c31ad1.png">