### PR TITLE
Hides the Request button on the single item view page (#836).

### DIFF
--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -1,9 +1,10 @@
 <% physical_holdings = document.physical_holdings(current_or_guest_user) %>
 <div class="where-to-find-table">
   <div class="row justify-content-between align-items-center">
-    <div class="col-6">
+    <div class="col"> <%# Replace col with col-6 if request-options is restored %>
       <%= tag.h2 t('catalog.show.find_it_header'), class: "section-title find-it-header" %>
     </div>
+    <%#
     <div class="col-6 request-options">
       <div class="btn-group">
         <button class="btn btn-primary rounded-0">Request</button>
@@ -11,23 +12,24 @@
           <span class="sr-only">Toggle Dropdown</span>
         </button>
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-          <% if document.hold_requestable?(current_or_guest_user) %>
-            <%= link_to "Hold request", new_hold_request_path(hold_request: {mms_id: document.id, title: document['title_display_tesim']&.first}), class: "dropdown-item" %>
-          <% end %>
-          <% if document.one_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
-            <%= link_to "Request Article or Chapter", document.one_step_link, class: "dropdown-item" %>
-          <% end %>
-          <% if document.two_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
-            <%= link_to "Request Article or Chapter", "#", class: "dropdown-item", data: {toggle: "modal", target: "#two-step-illiad"} %>
-           
-          <% end %>
-          <% if document.special_collections_requestable?(current_or_guest_user) %>
-            <%= link_to "Request from Special Collections", document.special_collections_url, class: "dropdown-item" %>
-          <% end %>
+    %>
+          <%# if document.hold_requestable?(current_or_guest_user) %>
+            <%#= link_to "Hold request", new_hold_request_path(hold_request: {mms_id: document.id, title: document['title_display_tesim']&.first}), class: "dropdown-item" %>
+          <%# end %>
+          <%# if document.one_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
+            <%#= link_to "Request Article or Chapter", document.one_step_link, class: "dropdown-item" %>
+          <%# end %>
+          <%# if document.two_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
+            <%#= link_to "Request Article or Chapter", "#", class: "dropdown-item", data: {toggle: "modal", target: "#two-step-illiad"} %>
+          <%# end %>
+          <%# if document.special_collections_requestable?(current_or_guest_user) %>
+            <%#= link_to "Request from Special Collections", document.special_collections_url, class: "dropdown-item" %>
+          <%# end %>
+    <%#
         </div>
       </div>
-
     </div>
+    %>
   </div>
 
   <% if document.physical_holdings %>

--- a/spec/system/hold_request_spec.rb
+++ b/spec/system/hold_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Create a request for a holding", type: :system, js: true, alma: 
       .to_return(status: 200, body: File.read(fixture_path + '/alma_item_records/990011434390302486.xml'), headers: {})
   end
 
-  it "has a button to request a hold" do
+  xit "has a button to request a hold" do
     visit solr_document_path(MLA_HANDBOOK[:id])
     sign_in(user)
     within '.where-to-find-table' do

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
       visit solr_document_path(SITTING_FROG[:id])
     end
 
-    it "has a link for special collections requests" do
+    xit "has a link for special collections requests" do
       expect(page).to have_content("Sitting frog : poetry from Naropa Institute")
       within '.where-to-find-table' do
         expect(page).to have_button("Request")
@@ -408,7 +408,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
         visit solr_document_path(MLA_HANDBOOK[:id])
       end
 
-      it "has a button to request a hold" do
+      xit "has a button to request a hold" do
         within '.where-to-find-table' do
           expect(page).to have_button("Request")
           find('.dropdown-toggle').click
@@ -441,7 +441,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
       expect(find_link("Services page")[:target]).to eq("_blank")
     end
 
-    it "disables the hold request link when there are no physical holdings" do
+    xit "disables the hold request link when there are no physical holdings" do
       sign_in(user)
       within '.where-to-find-table' do
         expect(page).to have_button("Request")


### PR DESCRIPTION
- app/views/catalog/_show_request_options.html.erb: comments out Request button code.
- spec/*: exits out of Request button tests.

<img width="892" alt="Screen Shot 2021-08-19 at 9 45 25 AM" src="https://user-images.githubusercontent.com/18330149/130079559-b40309d5-210b-4f9a-a856-be08d012e1c0.png">
