### PR TITLE
Converts the Title Starts With facet to a navigation menu (#851).

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -9,6 +9,7 @@
 @import 'blacklight_catalog/citations';
 @import 'blacklight_catalog/colors';
 @import 'blacklight_catalog/facets';
+@import 'blacklight_catalog/first_main_char_nav';
 @import 'blacklight_catalog/fonts';
 @import 'blacklight_catalog/header';
 @import 'blacklight_catalog/footer';

--- a/app/assets/stylesheets/blacklight_catalog/_first_main_char_nav.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_first_main_char_nav.scss
@@ -1,0 +1,19 @@
+nav.alpha-filter.first-main-char-nav {
+  padding: $title-starts-with-padding;
+  > ol {
+    display: flex;
+    list-style: none;
+    padding-inline-start: 0px;
+    > li.page-item > a.page-link {
+      padding: $title-starts-with-page-link-padding;
+      font-size: $font-size-base;
+      line-height: $title-starts-with-page-link-line-h;
+      margin-left: $title-starts-with-page-link-margin-left;
+    }
+    > li.page-item.first-main-char-descriptor { 
+      font-weight: $font-weight-bold;
+      padding-right: map-get($spacers, 3); 
+      margin: auto;
+    }
+  }
+}

--- a/app/assets/stylesheets/blacklight_catalog/_variables.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_variables.scss
@@ -225,3 +225,9 @@ $bookmarks-button-line-height:          1.968;
 $bookmarks-button-clear-padding:        0.75rem 1rem;
 $bookmarks-button-cite-padding:         0.6875rem 1rem;
 $bookmarks-button-cite-letter-spacing:  0.05rem;
+
+// Title Starts With Nav
+$title-starts-with-padding:               1rem 0;
+$title-starts-with-page-link-padding:     0.25rem 0.75rem;
+$title-starts-with-page-link-line-h:      1.5rem;
+$title-starts-with-page-link-margin-left: -0.063rem;

--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -8,4 +8,23 @@ module SearchResultsHelper
     return safe_join(vern_titles, tag('br')) if vern_titles.present?
     ''
   end
+
+  def first_char_search_state(search_state)
+    search_state.to_h.merge('sort': 'title_ssort asc, pub_date_isim desc')
+  end
+
+  def first_char_active_letter(state)
+    state['f']['title_main_first_char_ssim']&.first if state['f']
+  end
+
+  def first_char_letter_hash(state, letter)
+    letter_state = state.dup
+    letter_state['f'] = { 'title_main_first_char_ssim': [letter] }
+    letter_state
+  end
+
+  def first_char_cleared_hash(state)
+    state['f']&.delete('title_main_first_char_ssim')
+    state
+  end
 end

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -1,6 +1,6 @@
 <% # Override of BlacklLight 7.4.1 -%>
 <% # main container for facets/limits menu -%>
-<% page_specific_field_names = request.fullpath == '/' ? blacklight_config.homepage_facet_fields : facet_field_names(groupname) %>
+<% page_specific_field_names = request.fullpath == '/' ? blacklight_config.homepage_facet_fields : facet_field_names(groupname) - ["title_main_first_char_ssim"] %>
 <% if has_facet_values? facet_field_names(groupname), @response %>
 <div id="facets<%= "-#{groupname}" unless groupname.nil? %>" class="facets sidenav facets-toggleable-md">
 

--- a/app/views/catalog/_title_starts_with_index.html.erb
+++ b/app/views/catalog/_title_starts_with_index.html.erb
@@ -1,0 +1,17 @@
+<% state = first_char_search_state(search_state) %>
+<% active_letter = first_char_active_letter(state) %>
+<% if state['q'] %>
+  <nav class="alpha-filter first-main-char-nav">
+    <ol class="first-main-char-ol">
+      <li class="page-item first-main-char-descriptor"><%= t('blacklight.search.first_char.label') %></li>
+      <% ("A".."Z").each do |letter| %>
+        <li class="page-item <%= 'active' if active_letter == letter %>">
+          <%= link_to(letter, first_char_letter_hash(state, letter), class: 'page-link') %>
+        </li>
+      <% end %>
+      <li class="page-item <%= 'active' if active_letter.blank? %>">
+        <%= link_to t('blacklight.search.facets.all'), first_char_cleared_hash(state), class: 'page-link' %>
+      </li>
+    </ol>
+  </nav>
+<% end %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -28,6 +28,7 @@
 
   <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
     <%= content_for(:container_header) %>
+    <%= render 'catalog/title_starts_with_index' %>
 
     <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
 

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -37,6 +37,8 @@ en:
     search:
       bookmarks:
         absent: 'Bookmark Item'
+      first_char:
+        label: 'Title Starts With'
       form:
         search:
           placeholder: 'Search the Library Catalog'

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'front page', type: :system do
     expect(page).to have_css('h1.jumbotron-heading', text: 'Welcome!')
   end
 
+  it('does not have the Title Starts With nav') { expect(page).not_to have_css('.first-main-char-ol') }
+
   context 'facets' do
     let(:facet_buttons) { find_all('h3.card-header.p-0.facet-field-heading button') }
     let(:facet_headers) { facet_buttons.map(&:text) }

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -29,19 +29,42 @@ RSpec.feature 'View Search Results', type: :system, js: false do
     end
   end
 
+  context 'Title Starts With section' do
+    it('has a label') { expect(page).to have_content('Title Starts With') }
+
+    it 'has links for all letters' do
+      ('A'..'Z').each { |letter| expect(page).to have_link(letter, class: 'page-link') }
+    end
+
+    it 'has a link that clears this facet' do
+      expect(page).to have_link('All', class: "page-link")
+    end
+
+    it 'finds the title and clears facet successfully' do
+      find('.first-main-char-ol li a.page-link', text: 'T').click
+      results = find_all('.documents-list article')
+
+      expect(results).not_to be_empty
+
+      find('.first-main-char-ol li a.page-link', text: 'All').click
+
+      expect(results).not_to be_empty
+    end
+  end
+
   context 'facets' do
     let(:facet_buttons) { find_all('h3.card-header.p-0.facet-field-heading button') }
     let(:facet_headers) { facet_buttons.map(&:text) }
 
     it 'has the right number of facets' do
-      expect(facet_buttons.size).to eq 13
+      expect(facet_buttons.size).to eq 12
     end
 
     it 'has the right headers' do
       expect(facet_headers).to match_array(
         ['Access', 'Author/Creator', 'Collection', 'Era', 'Language', 'Region',
          'Resource Type', 'Subject', 'Genre', 'LC Classification', 'Library',
-         'Publication/Creation Date', 'Title Starts With']
+         'Publication/Creation Date']
       )
     end
   end


### PR DESCRIPTION
- app/assets/stylesheets/*: enforces styling on the new element created.
- app/helpers/search_results_helper.rb: provides the logic needed to create the necessary search lings.
- app/views/catalog/_facet_group.html.erb: removes the facet from the sidebar.
- app/views/catalog/_title_starts_with_index.html.erb: partializes the html that is used to deliver the menu.
- app/views/layouts/blacklight/base.html.erb: inserts the partial in the right place on the search_results page.
- config/locales/blacklight.en.yml: localizes the text used in the partial.
- spec/system/*: tests where this feature should/shouldn't be and it's function.

<img width="1286" alt="Screen Shot 2021-08-27 at 10 34 01 AM" src="https://user-images.githubusercontent.com/18330149/131163374-ada4e050-a687-4d9d-aa41-3aa695f4ef86.png">
