### PR TITLE
Adds other_standards_ids_tesim to Keyword Search (#855).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -292,7 +292,7 @@ class CatalogController < ApplicationController
     config.add_search_field('keyword', label: 'Keyword') do |field|
       field.include_in_advanced_search = false
       field.solr_parameters = {
-        qf: 'text_tesi id local_call_number_tesim',
+        qf: 'text_tesi id local_call_number_tesim other_standard_ids_tesim',
         pf: ''
       }
     end

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       'title_added_entry_tesim', 'title_enhanced_tesim', 'subject_tesim', 'title_former_tesim',
       'title_host_item_tesim', 'title_key_tesim', 'title_series_tesim', 'title_translation_tesim',
       'title_varying_tesim', 'text_tesi', 'local_call_number_tesim', 'title_later_tesim',
-      'note_production_tesim', 'note_participant_tesim'
+      'note_production_tesim', 'note_participant_tesim', 'other_standard_ids_tesim'
     ]
   end
 
@@ -53,7 +53,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     expect(result_titles).to contain_exactly(
       'Target in text_tesi',
       'Target in id',
-      'Target in local_call_number_tesim'
+      'Target in local_call_number_tesim',
+      'Target in other_standard_ids_tesim'
     )
   end
 


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: inserts `other_standards_ids_tesim` into the keyword search list.
- spec/system/targeted_field_search_spec.rb: checks that the keyword search is finding results from that field.

No screenshots necessary.
