### PR TITLE
Updates format verbiage (#884)

### DIFF
--- a/lib/traject/extraction_tools.rb
+++ b/lib/traject/extraction_tools.rb
@@ -168,9 +168,9 @@ module ExtractionTools
   def format_map_ldr_six
     {
       'c' => "Musical Score", 'd' => "Musical Score", 'e' => "Map", 'f' => "Map",
-      'g' => "Video/Visual Material", 'i' => "Sound Recording", 'j' => "Sound Recording",
-      'k' => "Video/Visual Material", 'm' => "Computer File", 'o' => "Video/Visual Material",
-      'p' => "Archival Material/Manuscripts", 'r' => "Video/Visual Material"
+      'g' => "Video or Visual Material", 'i' => "Sound Recording", 'j' => "Sound Recording",
+      'k' => "Video or Visual Material", 'm' => "Computer File", 'o' => "Video or Visual Material",
+      'p' => "Archival Material or Manuscripts", 'r' => "Video or Visual Material"
     }.freeze
   end
 

--- a/spec/fixtures/alma_marc_resource.xml
+++ b/spec/fixtures/alma_marc_resource.xml
@@ -1517,7 +1517,7 @@
       </header>
       <metadata>
         <record xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
-          <leader>01847cam a2200433Ia 4500</leader>
+          <leader>01847cp  a2200433Ia 4500</leader>
           <controlfield tag="005">20160418225355.0</controlfield>
           <controlfield tag="008">100722s1894 kyuae 000 0 eng d</controlfield>
           <controlfield tag="001">990016148150302486</controlfield>
@@ -1679,7 +1679,7 @@
       </header>
       <metadata>
         <record xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
-          <leader>01571cam a2200445 a 4500</leader>
+          <leader>01571ck  a2200445 a 4500</leader>
           <controlfield tag="005">20160418235235.0</controlfield>
           <controlfield tag="008">930729s19930000dcuab    b   f100 0 eng  </controlfield>
           <controlfield tag="001">990023916570302486</controlfield>

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -77,6 +77,14 @@ RSpec.describe 'Indexing fields with custom logic' do
     context 'when leader 6 is e' do
       it('is mapped as a Map') { expect(solr_doc2['format_ssim']).to eq(["Map"]) }
     end
+
+    context 'when leader 6 position is k' do
+      it('is mapped as a Video or Visual Material') { expect(solr_doc10['format_ssim']).to eq(["Video or Visual Material"]) }
+    end
+
+    context 'when leader 6 position is p' do
+      it('is mapped as a Archival Material or Manuscripts') { expect(solr_doc9['format_ssim']).to eq(["Archival Material or Manuscripts"]) }
+    end
   end
 
   describe 'publication_main_dispaly_ssm field' do


### PR DESCRIPTION
- lib/traject/extraction_tools.rb: changes text to desired format.
- spec/fixtures/alma_marc_resource.xml: updates the format of two records to output the new verbiage in new tests.
- spec/models/marc_indexing_spec.rb: tests for new verbiage.