### PR TITLE
Bug: Title Starts with clears previous facets fix (#890).

### DIFF
--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -19,7 +19,7 @@ module SearchResultsHelper
 
   def first_char_letter_hash(state, letter)
     letter_state = state.dup
-    letter_state['f'] = { 'title_main_first_char_ssim': [letter] }
+    letter_state['f'] = processed_facet(letter_state, letter)
     letter_state
   end
 
@@ -54,5 +54,10 @@ module SearchResultsHelper
 
   def online_modal_link(mms_id)
     tag.a("CONNECT", href: "#", data: { toggle: 'modal', target: "#avail-modal-#{mms_id}" }, class: "btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el")
+  end
+
+  def processed_facet(letter_state, letter)
+    return letter_state['f'].merge('title_main_first_char_ssim': [letter]) if letter_state['f'].present?
+    { 'title_main_first_char_ssim': [letter] }
   end
 end

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -57,6 +57,20 @@ RSpec.feature 'View Search Results', type: :system, js: false do
 
       expect(results).not_to be_empty
     end
+
+    around do |example|
+      Capybara.ignore_hidden_elements = false
+      example.run
+      Capybara.ignore_hidden_elements = true
+    end
+
+    it 'keeps previous facets when character is chosen', js: true do
+      click_on('Collection')
+      click_on('American county histories')
+      expect(page).to have_content 'Remove constraint Collection: American county histories'
+      find('.first-main-char-ol li a.page-link', text: 'T').click
+      expect(page).to have_content 'Remove constraint Collection: American county histories'
+    end
   end
 
   context 'facets' do


### PR DESCRIPTION
- app/helpers/search_results_helper.rb: merges instead of replacing to ensure other facets stay in place.
- app/helpers/search_results_helper.rb: tests to ensure previous facets remain when choosing a Title Starts With letter.

No screenshots necessary.