### PR TITLE
Bug: Title Starts With doesn't appear when facet chosen from homepage (#892).

### DIFF
--- a/app/views/catalog/_title_starts_with_index.html.erb
+++ b/app/views/catalog/_title_starts_with_index.html.erb
@@ -1,6 +1,6 @@
 <% state = first_char_search_state(search_state) %>
 <% active_letter = first_char_active_letter(state) %>
-<% if state['q'] || state['search_field'] == 'advanced' %>
+<% if request.url.include?('?') && !request.url.include?('/advance') %>
   <nav class="alpha-filter first-main-char-nav">
     <ol class="first-main-char-ol">
       <li class="page-item first-main-char-descriptor"><%= t('blacklight.search.first_char.label') %></li>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -28,7 +28,8 @@
 
   <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
     <%= content_for(:container_header) %>
-    <%= render 'catalog/title_starts_with_index' unless current_page?('/advanced') %>
+    <%#byebug%>
+    <%= render 'catalog/title_starts_with_index' %>
 
     <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
 

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -28,7 +28,7 @@
 
   <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
     <%= content_for(:container_header) %>
-    <%#byebug%>
+
     <%= render 'catalog/title_starts_with_index' %>
 
     <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -57,6 +57,17 @@ RSpec.feature 'View Search Results', type: :system, js: false do
 
       expect(results).not_to be_empty
     end
+
+    context 'when choosing a fact from the homepage', js: true do
+      it 'brings you to the search results page with the Title Starts With section' do
+        visit root_path
+        click_on('Language')
+        click_on('English')
+
+        ('A'..'Z').each { |letter| expect(page).to have_link(letter, class: 'page-link') }
+        expect(page).to have_link('All', class: "page-link")
+      end
+    end
   end
 
   context 'facets' do


### PR DESCRIPTION
- app/views/catalog/_title_starts_with_index.html.erb: corrects the limiter for when this partial is delivered.
- app/views/layouts/blacklight/base.html.erb: removes limiter from render call since it's not needed.
- spec/system/view_search_results_spec.rb: tests for correct behavior.

No screenshots necessary.