### PR TITLE
Updates the Articles + verbiage (#953).

### DIFF
--- a/app/views/catalog/_alternate_catalog.html.erb
+++ b/app/views/catalog/_alternate_catalog.html.erb
@@ -9,10 +9,14 @@
         <%= image_tag("lightbulb.svg", :height => "32", :width => "32") %>
         </span>
         </div>
-        <p class="text-other-resources">ARTICLES +</p>
-        <h3 class="bigtext-other-resources">Looking for articles?</h3>
+        <p class="text-other-resources"><%= t('blacklight.search.alternate_catalog.title') %></p>
+        <h3 class="bigtext-other-resources"><%= t('blacklight.search.alternate_catalog.question') %></h3>
         <p id="results-p">
-          Your search also found <a href="<%= articles_plus_url_builder(search_state) %>" id="articles-plus-url"><span class="alternate-catalog-count"></span>results in Articles +</a>
+          <%= t('blacklight.search.alternate_catalog.outside_link') %>
+          <a href="<%= articles_plus_url_builder(search_state) %>" id="articles-plus-url">
+            <span class="alternate-catalog-count"></span>
+            <%= t('blacklight.search.alternate_catalog.inside_link') %>
+          </a>
         </p>
       </div>
     </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -35,6 +35,11 @@ en:
         help: 'Help'
         home: 'Home'
     search:
+      alternate_catalog:
+        inside_link: 'results in Articles +'
+        outside_link: 'Search for '
+        question: 'Looking for articles?'
+        title: 'ARTICLES +'
       bookmarks:
         absent: 'Bookmark Item'
       first_char:

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -157,4 +157,12 @@ RSpec.feature 'View Search Results', type: :system, js: false do
       ).to be_truthy
     end
   end
+
+  context 'articles + card', js: true do
+    it 'shows up when value in query' do
+      fill_in 'q', with: '123'
+      click_on 'search'
+      expect(page).to have_content 'Search for results in Articles +'
+    end
+  end
 end


### PR DESCRIPTION
- app/views/catalog/_alternate_catalog.html.erb: localizes the text in this card.
- config/locales/blacklight.en.yml: places updated verbiage in the locales.
- spec/system/view_search_results_spec.rb: tests for the presence of the new text.
<img width="1055" alt="Screen Shot 2021-10-08 at 10 10 53 AM" src="https://user-images.githubusercontent.com/18330149/136572719-9592dcc8-71e2-42e4-9ae6-4b51939ed5cb.png">

