### PR TITLE
BUG FIX: updates defining of Marc Resource format text (#968).

### DIFF
--- a/app/helpers/more_options_helper.rb
+++ b/app/helpers/more_options_helper.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
+
 module MoreOptionsHelper
+  formats = ::ExtractionTools::MARC_RESOURCE_FORMATS
   MATERIAL_TYPE_PAGE_LINKS = {
-    'Musical Score': { 'Music and Scores': 'music-scores.html' },
-    'Map': { 'General Materials': 'index.html' },
-    'Video/Visual Material': [
+    formats[:music] => { 'Music and Scores': 'music-scores.html' },
+    formats[:map] => { 'General Materials': 'index.html' },
+    formats[:visual] => [
       { 'Films and Videos': 'film-videos/index.html' }, { 'Images': 'images.html' }
     ],
-    'Sound Recording': { 'Music and Scores': 'music-scores.html' },
-    'Computer File': { 'General Materials': 'index.html' },
-    'Archival Material/Manuscripts': { 'Archives and Special Collections': 'archives-special-collections.html' },
-    'Journal, Newspaper or Serial': [
+    formats[:sound] => { 'Music and Scores': 'music-scores.html' },
+    formats[:file] => { 'General Materials': 'index.html' },
+    formats[:archival] => { 'Archives and Special Collections': 'archives-special-collections.html' },
+    formats[:journal] => [
       { 'Journals and Newspapers': 'journals-newspapers.html' }, { 'Articles': 'articles.html' }
     ],
-    'Book': { 'Books': 'books.html' }
+    formats[:book] => { 'Books': 'books.html' }
   }.with_indifferent_access.freeze
 
   def render_more_options_links(document)

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,6 @@ module BlacklightCatalog
     # -- all .rb files in that directory are automatically loaded.
 
     config.exceptions_app = routes
-    config.autoload_paths += %W[#{config.root}/app/loggers]
+    config.autoload_paths += %W[#{config.root}/app/loggers lib/traject]
   end
 end

--- a/lib/traject/extraction_tools.rb
+++ b/lib/traject/extraction_tools.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 module ExtractionTools
+  MARC_RESOURCE_FORMATS = {
+    "music": "Musical Score",
+    "map": "Map",
+    "visual": "Video or Visual Material",
+    "sound": "Sound Recording",
+    "file": "Computer File",
+    "archival": "Archival Material or Manuscripts",
+    "book": "Book",
+    "journal": "Journal, Newspaper or Serial"
+  }.with_indifferent_access
+
   def marc21
     Traject::Macros::Marc21
   end
@@ -167,19 +178,24 @@ module ExtractionTools
 
   def format_map_ldr_six
     {
-      'c' => "Musical Score", 'd' => "Musical Score", 'e' => "Map", 'f' => "Map",
-      'g' => "Video or Visual Material", 'i' => "Sound Recording", 'j' => "Sound Recording",
-      'k' => "Video or Visual Material", 'm' => "Computer File", 'o' => "Video or Visual Material",
-      'p' => "Archival Material or Manuscripts", 'r' => "Video or Visual Material"
+      'c' => MARC_RESOURCE_FORMATS[:music], 'd' => MARC_RESOURCE_FORMATS[:music],
+      'e' => MARC_RESOURCE_FORMATS[:map], 'f' => MARC_RESOURCE_FORMATS[:map],
+      'g' => MARC_RESOURCE_FORMATS[:visual], 'i' => MARC_RESOURCE_FORMATS[:sound],
+      'j' => MARC_RESOURCE_FORMATS[:sound], 'k' => MARC_RESOURCE_FORMATS[:visual],
+      'm' => MARC_RESOURCE_FORMATS[:file], 'o' => MARC_RESOURCE_FORMATS[:visual],
+      'p' => MARC_RESOURCE_FORMATS[:archival], 'r' => MARC_RESOURCE_FORMATS[:visual]
     }.freeze
   end
 
   def format_map_ldr_six_seven
     {
-      'aa' => "Book", 'ab' => "Journal, Newspaper or Serial", 'ac' => "Book", 'ad' => "Book",
-      'ai' => "Journal, Newspaper or Serial", 'am' => "Book", 'as' => "Journal, Newspaper or Serial",
-      'ta' => "Book", 'tb' => "Journal, Newspaper or Serial", 'tc' => "Book", 'td' => "Book",
-      'ti' => "Journal, Newspaper or Serial", 'tm' => "Book", 'ts' => "Journal, Newspaper or Serial"
+      'aa' => MARC_RESOURCE_FORMATS[:book], 'ab' => MARC_RESOURCE_FORMATS[:journal],
+      'ac' => MARC_RESOURCE_FORMATS[:book], 'ad' => MARC_RESOURCE_FORMATS[:book],
+      'ai' => MARC_RESOURCE_FORMATS[:journal], 'am' => MARC_RESOURCE_FORMATS[:book],
+      'as' => MARC_RESOURCE_FORMATS[:journal], 'ta' => MARC_RESOURCE_FORMATS[:book],
+      'tb' => MARC_RESOURCE_FORMATS[:journal], 'tc' => MARC_RESOURCE_FORMATS[:book],
+      'td' => MARC_RESOURCE_FORMATS[:book], 'ti' => MARC_RESOURCE_FORMATS[:journal],
+      'tm' => MARC_RESOURCE_FORMATS[:book], 'ts' => MARC_RESOURCE_FORMATS[:journal]
     }.freeze
   end
 end

--- a/spec/helpers/more_options_helper_spec.rb
+++ b/spec/helpers/more_options_helper_spec.rb
@@ -14,22 +14,23 @@ RSpec.describe MoreOptionsHelper, type: :helper do
       ]
     )
   end
+  let(:formats) { ::ExtractionTools::MARC_RESOURCE_FORMATS }
   let(:links_hash) do
     {
-      "Musical Score" => { "Music and Scores" => "music-scores.html" },
-      "Map" => { "General Materials" => "index.html" },
-      "Video/Visual Material" => [
+      formats[:music] => { "Music and Scores" => "music-scores.html" },
+      formats[:map] => { "General Materials" => "index.html" },
+      formats[:visual] => [
         { "Films and Videos" => "film-videos/index.html" },
         { "Images" => "images.html" }
       ],
-      "Sound Recording" => { "Music and Scores" => "music-scores.html" },
-      "Computer File" => { "General Materials" => "index.html" },
-      "Archival Material/Manuscripts" => { "Archives and Special Collections" => "archives-special-collections.html" },
-      "Journal, Newspaper or Serial" => [
+      formats[:sound] => { "Music and Scores" => "music-scores.html" },
+      formats[:file] => { "General Materials" => "index.html" },
+      formats[:archival] => { "Archives and Special Collections" => "archives-special-collections.html" },
+      formats[:journal] => [
         { "Journals and Newspapers" => "journals-newspapers.html" },
         { "Articles" => "articles.html" }
       ],
-      "Book" => { "Books" => "books.html" }
+      formats[:book] => { "Books" => "books.html" }
     }
   end
   let(:solr_doc) { SolrDocument.find(TEST_ITEM[:id]) }


### PR DESCRIPTION
- app/helpers/more_options_helper.rb: utilizes the constant created in the indexing method to feed the links hash.
- config/application.rb: loads the traject methods so that `MARC_RESOURCE_FORMATS` is readable elsewhere.
- lib/traject/extraction_tools.rb enforces the defining and pulling of each format's text to one place.
- spec/helpers/more_options_helper_spec.rb: ties tests to the one source of truth.

No screenshots necessary.