### PR TITLE
Revises header links (#946). 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,7 @@ Metrics/MethodLength:
 
 Metrics/ModuleLength:
     Exclude:
+        - 'app/helpers/catalog_helper.rb'
         - 'app/models/concerns/blacklight/solr/document/marc_export.rb'
         - 'lib/traject/extraction_tools.rb'
         - 'config/prepends/custom_citation_logic.rb'

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -111,4 +111,16 @@ module CatalogHelper
   def service_page_url(doc_id)
     "#{ENV['ALMA_BASE_SANDBOX_URL']}/discovery/openurl?institution=#{ENV['INSTITUTION']}&vid=#{ENV['INSTITUTION']}:services&rft.mms_id=#{doc_id}"
   end
+
+  def databases_url
+    'https://guides.libraries.emory.edu/az.php'
+  end
+
+  def articles_plus_url
+    'https://emory-psb.primo.exlibrisgroup.com/discovery/search?vid=01GALI_EMORY:articles'
+  end
+
+  def my_library_card_url
+    'https://emory-psb.primo.exlibrisgroup.com/discovery/account?vid=01GALI_EMORY:services&section=overview&lang=en'
+  end
 end

--- a/app/views/catalog/_other_resource_card.html.erb
+++ b/app/views/catalog/_other_resource_card.html.erb
@@ -1,0 +1,14 @@
+<div class="border-resources card mb-3">
+  <div class="card-header bg-resources resources-header"></div>
+  <div class="card-body">
+    <div class="lightbulb">
+    <span class="rounded-lightbulb">
+    <%= image_tag("lightbulb.svg", :height => "32", :width => "32") %>
+    </span>
+    </div>
+    <p class="text-other-resources"><%= t('blacklight.other_resources.card_descriptor.search_tool') %></p>
+    <a href=<%= url %><%= ' target="_blank"' if new_page %>>
+    <h3 class="bigtext-other-resources"><%= url_text %></h3>
+    </a>
+  </div>
+</div>

--- a/app/views/catalog/_other_resources_accordions.html.erb
+++ b/app/views/catalog/_other_resources_accordions.html.erb
@@ -22,7 +22,7 @@
     </a>
     <div id="research-guides" class="resource-body collapse">
       <p>Research guides offer research assistance, subject guides, and useful resources created and curated by expert librarians and staff at the Emory Libraries. </p>
-      <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://libraries.emory.edu/tools/research-guides.html">View Research Guides</a>
+      <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://libraries.emory.edu/tools/research-guides.html" target="_blank">View Research Guides</a>
     </div>
     
     <a href="#" class="collapsed panel-anchor" data-toggle="collapse" data-target="#digital-repository">
@@ -35,7 +35,7 @@
     </a>
     <div id="digital-repository" class="resource-body collapse">
         <p>Emory's digital collections support the University's research and teaching needs and are our digital front door to unique cultural heritage and scholarship collections from Emory University. </p>
-        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://digital.library.emory.edu/">View Emory Digital Collections Repository</a>
+        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://digital.library.emory.edu/" target="_blank">View Emory Digital Collections Repository</a>
     </div>
     
     <a href="#" class="collapsed panel-anchor" data-toggle="collapse" data-target="#etd-repository">
@@ -48,7 +48,7 @@
     </a>
     <div id="etd-repository" class="resource-body collapse">
         <p>The Emory Theses and Dissertations (ETD) Repository holds theses and dissertations from the Laney Graduate School, the Rollins School of Public Health, and the Candler School of Theology, as well as undergraduate honors papers from Emory College of Arts and Sciences.</p>
-        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://etd.library.emory.edu/">View Emory These and Dissertations Repository</a>
+        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://etd.library.emory.edu/" target="_blank">View Emory These and Dissertations Repository</a>
     </div>
     
     <a href="#" class="collapsed panel-anchor" data-toggle="collapse" data-target="#openemory">
@@ -61,7 +61,7 @@
     </a>
     <div id="openemory" class="resource-body collapse">
         <p>OpenEmory is an open access repository of Emory faculty works and a service of Emory Libraries and Information Technology.</p>
-        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://libraries.emory.edu/tools/open-emory.html">View OpenEmory Repository</a>
+        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://libraries.emory.edu/tools/open-emory.html" target="_blank">View OpenEmory Repository</a>
     </div>
     <a href="#" class="collapsed panel-anchor" data-toggle="collapse" data-target="#course-reserves">
     <div class="panel-title">
@@ -73,7 +73,7 @@
     </a>
     <div id="course-reserves" class="resource-body collapse">
         <p>Course Reserves are required and recommended course materials made available to students at the request of faculty.</p>
-        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://libraries.emory.edu/materials/course-reserves.html">View Course Reserves</a>
+        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://libraries.emory.edu/materials/course-reserves.html" target="_blank">View Course Reserves</a>
     </div>
     <a href="#" class="collapsed panel-anchor" data-toggle="collapse" data-target="#ill">
     <div class="panel-title">
@@ -85,7 +85,7 @@
     </a>
     <div id="ill" class="resource-body collapse">
         <p>ILLiad is the system for Emory Libraries Interlibrary Loan and Electronic Document Delivery. </p>
-        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://libraries.emory.edu/tools/illiad.html">View InterLibrary Loan</a>
+        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://libraries.emory.edu/tools/illiad.html" target="_blank">View InterLibrary Loan</a>
     </div>
     <a href="#" class="collapsed panel-anchor" data-toggle="collapse" data-target="#finding-aids">
     <div class="panel-title">
@@ -97,7 +97,7 @@
     </a>
     <div id="finding-aids" class="resource-body collapse">
         <p>The EmoryFindingAids database provides centralized access to detailed descriptions of archival and manuscript collections held in various repositories at Emory.</p>
-        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://findingaids.library.emory.edu/">View Finding Aids</a>
+        <a class="btn btn-md btn-primary btn-login rounded-0 mb-2" href="https://findingaids.library.emory.edu/" target="_blank">View Finding Aids</a>
     </div>
   </div>
 </section>

--- a/app/views/catalog/_other_resources_cards.html.erb
+++ b/app/views/catalog/_other_resources_cards.html.erb
@@ -1,55 +1,10 @@
 <div class="row">
-	<div class="col-12 col-centered">
-		<h1 id="other-resources-title">Other Resources</h1>
-		<div class="card-deck">
-		
-		<div class="border-resources card mb-3">
-		  <div class="card-header bg-resources resources-header"></div>
-		  <div class="card-body">
-		  	<div class="lightbulb">
-		  	<span class="rounded-lightbulb">
-		  	<%= image_tag("lightbulb.svg", :height => "32", :width => "32") %>
-		  	</span>
-		  	</div>
-		    <p class="text-other-resources">Search Tool</p>
-		    <a href="https://guides.libraries.emory.edu/az.php">
-		    <h3 class="bigtext-other-resources">Databases@Emory</h3>
-			</a>
-		  </div>
-		</div>
-		
-		
-		<div class="border-resources card mb-3" >
-		  <div class="card-header bg-resources resources-header"></div>
-		  <div class="card-body">
-		  	<div class="lightbulb">
-		  	<span class="rounded-lightbulb">
-		  	<%= image_tag("lightbulb.svg", :height => "32", :width => "32") %>
-		  	</span>
-		  	</div>
-		    <p class="text-other-resources">Search Tool</p>
-		    <a href="#">
-		   <h3 class="bigtext-other-resources">eJournals (A-Z)</h3>
-			</a>
-		  </div>
-		</div>
-		
-		
-		<div class="border-resources card mb-3">
-		  <div class="card-header bg-resources resources-header"></div>
-		  <div class="card-body">
-		  	<div class="lightbulb">
-		  	<span class="rounded-lightbulb">
-		  	<%= image_tag("lightbulb.svg", :height => "32", :width => "32") %>
-		  	</span>
-		  	</div>
-		    <p class="text-other-resources">Search Tool</p>
-		    <a href="#">
-		    <h3 class="bigtext-other-resources">Articles+</h3>
-			</a>
-		  </div>
-		</div>
-		
+  <div class="col-12 col-centered">
+    <h1 id="other-resources-title"><%= t('blacklight.other_resources.title') %></h1>
+    <div class="card-deck">
+	  <%= render 'catalog/other_resource_card', url: databases_url, new_page: true, url_text: t('blacklight.other_resources.url_text.databases') %>
+	  <%= render 'catalog/other_resource_card', url: ejournals_path, new_page: false, url_text: t('blacklight.other_resources.url_text.ejournals') %>
+	  <%= render 'catalog/other_resource_card', url: articles_plus_url, new_page: true, url_text: t('blacklight.other_resources.url_text.articles_plus') %>
 	</div>
-	</div>
+  </div>
 </div>

--- a/app/views/shared/_static_links.html.erb
+++ b/app/views/shared/_static_links.html.erb
@@ -1,9 +1,26 @@
 <ul class="navbar-nav">
   <li class="nav-item<%= " mobile-only" if mobile %>"><%= link_to t('blacklight.header.static_links.home'), root_path, class: "nav-link" %></li>
-  <li class="nav-item<%= " mobile-only" if mobile %>"><%= link_to t('blacklight.header.static_links.articles_plus'), root_path, class: "nav-link" %></li>
-  <li class="nav-item<%= " mobile-only" if mobile %>"><%= link_to t('blacklight.header.static_links.databases'), "https://guides.libraries.emory.edu/az.php", class: "nav-link last" %></li>
+  <li class="nav-item<%= " mobile-only" if mobile %>"><%= link_to t('blacklight.header.static_links.ejournals'), ejournals_path, class: "nav-link" %></li>
+  <li class="nav-item<%= " mobile-only" if mobile %>">
+    <%= link_to(
+          t('blacklight.header.static_links.articles_plus'), articles_plus_url, class: "nav-link", target: '_blank'
+        ) 
+    %>
+  </li>
+  <li class="nav-item<%= " mobile-only" if mobile %>">
+    <%= link_to(
+          t('blacklight.header.static_links.databases'), databases_url, class: "nav-link last", target: '_blank'
+        ) 
+    %>
+  </li>
 </ul>
 <ul class="navbar-nav">
+  <li class="nav-item<%= " mobile-only" if mobile %>">
+    <%= link_to(
+          t('blacklight.header.static_links.my_library_card'), my_library_card_url, class: "nav-link", target: '_blank'
+        )
+    %>
+  </li>
   <%= render_nav_actions do |config, action|%>
     <li class="nav-item<%= " mobile-only" if mobile %>"><%= action %></li>
   <% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -31,9 +31,21 @@ en:
         emory_libraries: 'Emory Libraries'
       static_links:
         about_library_search: 'About Library Search'
+        articles_plus: "Articles +"
         contact: 'Contact'
+        databases: "Databases@Emory"
+        ejournals: 'eJournals A-Z'
         help: 'Help'
         home: 'Home'
+        my_library_card: 'My Library Card'
+    other_resources: 
+      title: 'Other Resources'
+      card_descriptor:
+        search_tool: 'Search Tool'
+      url_text:
+        articles_plus: 'Articles+'
+        databases: 'Databases@Emory'
+        ejournals: 'eJournals (A-Z)'
     search:
       alternate_catalog:
         inside_link: 'results in Articles +'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,8 +74,3 @@ en:
       sort_label: "Sort by"
       search_btn: "Search"
       start_over: "Clear Form"
-  blacklight:
-    header:
-      static_links:
-        articles_plus: "Articles +"
-        databases: "Databases@Emory"

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -34,4 +34,28 @@ RSpec.describe 'front page', type: :system do
       expect(facet_headers).to match_array(['Resource Type', 'Language', 'Library', 'Access'])
     end
   end
+
+  context 'header links' do
+    let(:nav_links) { find_all('.non-collapse-navbar .navbar-nav .nav-link') }
+    let(:link_text_arr) { nav_links.map(&:text) }
+    let(:link_href_arr) { nav_links.map { |nl| nl['href'] } }
+    let(:expected_results_arr) do
+      [
+        { text: "Home", url: "/" },
+        { text: "eJournals A-Z", url: "/ejournals" },
+        { text: "Articles +", url: "https://emory-psb.primo.exlibrisgroup.com/discovery/search?vid=01GALI_EMORY:articles" },
+        { text: "Databases@Emory", url: "https://guides.libraries.emory.edu/az.php" },
+        { text: "My Library Card", url: "https://emory-psb.primo.exlibrisgroup.com/discovery/account?vid=01GALI_EMORY:services&section=overview&lang=en" },
+        { text: "Bookmarks 0", url: "/bookmarks" },
+        { text: "History", url: "/search_history" },
+        { text: "Help", url: "/help" }
+      ]
+    end
+
+    it 'has all the right links' do
+      nav_links.each_with_index do |_hsh, ind|
+        expect(expected_results_arr[ind]).to eq({ text: link_text_arr[ind], url: link_href_arr[ind] })
+      end
+    end
+  end
 end


### PR DESCRIPTION
- .rubocop.yml: allows my additional methods to be added to this module.
- app/helpers/catalog_helper.rb: tucks the urls into helper methods to cut down on repetition.
- app/views/catalog/_other_resource_card.html.erb: creates a partial that allows dynamically created cards.
- app/views/catalog/_other_resources_accordions.html.erb: makes all links in this area open in new tabs/pages.
- app/views/catalog/_other_resources_cards.html.erb: converts the similar card html into render calls.
- app/views/shared/_static_links.html.erb: stubs out new page destinations to the affected links, and converts some into target: blank.
- config/locales/*: adds some text and also transfers others.
- spec/system/front_page_spec.rb: tests for the existence of those links.
<img width="1524" alt="Screen Shot 2021-10-13 at 9 37 14 AM" src="https://user-images.githubusercontent.com/18330149/137143676-1d52aeb7-0e18-4f2b-9738-e3a322af2815.png">


