### PR TITLE
BUG FIX: full_index option ignores the resumption token (#980).

### DIFF
--- a/app/services/oai_query_string_service.rb
+++ b/app/services/oai_query_string_service.rb
@@ -5,7 +5,7 @@ class OaiQueryStringService
     from_time = process_from_time(full_index, logger)
     processed_to_time = process_to_time(to_time, full_index, logger)
     # check where to resume harvesting from
-    saved_resumption_token = PropertyBag.get('marc_ingest_resumption_token')
+    saved_resumption_token = process_resumption_token(full_index)
 
     process_string(saved_resumption_token, oai_set, from_time, processed_to_time, single_record)
   end
@@ -29,5 +29,10 @@ class OaiQueryStringService
     return "?verb=GetRecord&identifier=oai:alma.#{ENV['INSTITUTION']}:#{oai_set}&metadataPrefix=marc21" if single_record
     # start a fresh set harvest
     "?verb=ListRecords&set=#{oai_set}&metadataPrefix=marc21#{to_time}#{from_time}"
+  end
+
+  def self.process_resumption_token(full_index)
+    return nil if full_index
+    PropertyBag.get('marc_ingest_resumption_token')
   end
 end

--- a/spec/services/oai_query_string_service_spec.rb
+++ b/spec/services/oai_query_string_service_spec.rb
@@ -61,8 +61,20 @@ RSpec.describe OaiQueryStringService, :clean do
     end
   end
 
+  context '#process_resumption_token' do
+    it 'returns token when full_index is false' do
+      allow(PropertyBag).to receive(:get).with('marc_ingest_resumption_token').and_return('Hello!')
+      expect(described_class.process_resumption_token(false)).to eq("Hello!")
+    end
+
+    it 'returns nil when full_index is true' do
+      expect(described_class.process_resumption_token(true)).to be_nil
+    end
+  end
+
   def check_other_methods_called
     expect(described_class).to respond_to(:process_from_time).with(2).argument
     expect(described_class).to respond_to(:process_string).with(5).argument
+    expect(described_class).to respond_to(:process_resumption_token).with(1).argument
   end
 end


### PR DESCRIPTION
- app/services/oai_query_string_service.rb: brings logic into delivering the resumption token.
- spec/services/oai_query_string_service_spec.rb: ensures that resumption token is only delivered when full_index isn't chosen.

No screenshots necessary.