### PR TITLE
BUG FIX: Stop Availability API query on homepage.

### DIFF
--- a/config/initializers/catalog_index_override.rb
+++ b/config/initializers/catalog_index_override.rb
@@ -8,7 +8,7 @@ CatalogController.class_eval do
     (@response, deprecated_document_list) = search_service.search_results
 
     @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_document_list, 'The @document_list instance variable is deprecated; use @response.documents instead.')
-    @documents_availability = AlmaAvailabilityService.new(@response.documents.map(&:id)).availability_of_documents
+    @documents_availability = AlmaAvailabilityService.new(@response.documents.map(&:id)).availability_of_documents unless request.fullpath == '/'
 
     respond_to do |format|
       format.html { store_preferred_view }


### PR DESCRIPTION
config/initializers/catalog_index_override.rb: blocks the availability API request when on homepage.

No screenshots necessary.
