### PR TITLE
Corrects the Capistrano task to load ENVs (#995).

### DIFF
--- a/config/deploy/arch.rb
+++ b/config/deploy/arch.rb
@@ -54,20 +54,19 @@
 #     auth_methods: %w(publickey password)
 #     # password: "please use keys"
 #   }
+set :stage, :ARCH
 
 before 'deploy:check:linked_files', "deploy:copy_secrets"
 before 'deploy:symlink:linked_files', "deploy:copy_secrets"
+before 'deploy:assets:precompile', 'envvars:load'
 namespace :deploy do
   task :copy_secrets do
     on roles("web") do
       upload!("./config/secrets.yml", "#{shared_path}/config/secrets.yml")
     end
   end
-
-  after :starting, 'envvars:load'
 end
 
-set :stage, :ARCH
 set :ec2_region, %w[us-east-1]
 ec2_role %i[web app db],
   user: 'deploy',

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -59,14 +59,13 @@ set :stage, :PROD
 
 before 'deploy:check:linked_files', "deploy:copy_secrets"
 before 'deploy:symlink:linked_files', "deploy:copy_secrets"
+before 'deploy:assets:precompile', 'envvars:load'
 namespace :deploy do
   task :copy_secrets do
     on roles("web") do
       upload!("./config/secrets.yml", "#{shared_path}/config/secrets.yml")
     end
   end
-
-  after :starting, 'envvars:load'
 end
 
 set :ec2_region, %w[us-east-1]

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -59,14 +59,13 @@ set :stage, :TEST
 
 before 'deploy:check:linked_files', "deploy:copy_secrets"
 before 'deploy:symlink:linked_files', "deploy:copy_secrets"
+before 'deploy:assets:precompile', 'envvars:load'
 namespace :deploy do
   task :copy_secrets do
     on roles("web") do
       upload!("./config/secrets.yml", "#{shared_path}/config/secrets.yml")
     end
   end
-
-  after :starting, 'envvars:load'
 end
 
 set :ec2_region, %w[us-east-1]

--- a/lib/capistrano/tasks/envvars.rake
+++ b/lib/capistrano/tasks/envvars.rake
@@ -3,16 +3,8 @@
 namespace :envvars do
   desc 'Load environment variables'
   task :load do
-    # Grab the current value of :default_env
-    environment = fetch(:default_env, {})
-
-    on roles(:app) do
-      # Read in the environment file
-      env_file = "/opt/blacklight-catalog/shared/config/environment_variables.yml"
-      YAML.safe_load(File.open(env_file)).each { |key, value| environment.store(key, value) } if File.exist?(env_file)
-
-      # Finally, update the global :default_env variable again
-      set :default_env, environment
+    on roles("web") do
+      execute "cp -v /opt/blacklight-catalog/shared/config/environment_variables /opt/blacklight-catalog/current/.env.production"
     end
   end
 end


### PR DESCRIPTION
- config/deploy/*: reworks call to task to be inline with other secret loading task.
- lib/capistrano/tasks/envvars.rake: simplifies the loading of ENV to just copying the file in.

No screenshots necessary.