### PR TITLE
#981 Get alma availability after page load

### DIFF
--- a/app/assets/javascripts/catalog.js
+++ b/app/assets/javascripts/catalog.js
@@ -67,6 +67,21 @@ $(document).ready(function() {
     $(this).prev().children('.panel-title').css('background', 'rgba(231, 234, 241, 0.5)')
   // do something…
   })
+
+  $.ajax({
+    type: "GET",
+    data: {
+      document_ids: $('#search_results_document_ids').val().split(',')
+    },
+    url: "/availability_indicators",
+    dataType: "json",
+    success: function(data) {
+      for (const [key, value] of Object.entries(data)) {
+        $(`#availability-indicator-${key}`).replaceWith(value);
+      }
+    }
+  });
+
   /* end ready */
 });
 

--- a/app/assets/stylesheets/blacklight_catalog/_results_list.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_results_list.scss
@@ -101,6 +101,52 @@ dt.index-field-name {
   }
 }
 
+.loading-avail-block {
+  height: 38px;
+  width: 400px;
+  padding: 0;
+  font-family: "Open Sans", sans-serif;
+  box-sizing: border-box;
+  display: flex;
+}
+
+.loading-avail-block li {
+  box-sizing: border-box;
+  display: inline-block;
+  font-family: "Open Sans", sans-serif;
+  list-style-type: none;
+  width: 138px;
+  height: 38px;
+  text-align: center;
+  margin-right: 0;
+  line-height: 34px;
+}
+
+.loading-avail-badge {
+  font-size: 14px;
+  line-height: 30px;
+}
+
+li.loading-avail-badge {
+  border: 1px solid #E7EAF1;
+  width: 138px;
+  text-transform: uppercase;
+  font-size: 11px;
+  font-weight: bold;
+}
+
+li.loading-avail-badge span {
+  vertical-align: middle;
+}
+
+.loading-avail-message {
+  color: #091C44;
+}
+
+.loading-avail-spinner {
+  margin-right: 1em;
+}
+
 .btn.rounded-0.mb-2.phys-avail-label, .btn.rounded-0.mb-2.online-avail-label { 
   cursor:    default;
   font-size: $results-button-label-font-size;

--- a/app/controllers/availability_indicators_controller.rb
+++ b/app/controllers/availability_indicators_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+class AvailabilityIndicatorsController < ApplicationController
+  include Blacklight::Searchable
+
+  def index
+    availability_data = AlmaAvailabilityService.new(document_ids).availability_of_documents
+    availability_indicators = {}
+    documents = search_service.fetch(document_ids, rows: document_ids.count).first.documents
+    documents.each do |document|
+      availability = availability_data.present? ? availability_data[document.id] : nil
+      indicator = render_to_string('catalog/_availability_indicator', layout: false, locals: { xray: false, document: document, doc_avail_values: availability })
+      availability_indicators[document.id] = indicator
+    end
+    render json: availability_indicators
+  end
+
+  private
+
+  def document_ids
+    availability_indicators_params[:document_ids].first(100).select do |i|
+      i.scan(/\D/).empty?
+    end
+  end
+
+  def availability_indicators_params
+    params.permit(document_ids: [])
+  end
+end

--- a/app/services/alma_availability_service.rb
+++ b/app/services/alma_availability_service.rb
@@ -8,8 +8,11 @@ class AlmaAvailabilityService
   end
 
   def availability_of_documents
-    return if @mms_ids.blank?
+    return nil if @mms_ids.blank?
+
     response = query_availability
+    return nil if response.blank?
+
     xml = Nokogiri::XML(response)
     bib_records = xml.xpath("//bib")
     ret_hsh = {}
@@ -25,6 +28,8 @@ class AlmaAvailabilityService
 
   def query_availability
     RestClient.get "#{api_url}/almaws/v1/bibs?mms_id=#{@mms_ids.join('%2C')}#{query_inst}#{api_key}"
+  rescue
+    nil
   end
 
   def query_inst

--- a/app/views/catalog/_availability_indicator.html.erb
+++ b/app/views/catalog/_availability_indicator.html.erb
@@ -1,0 +1,21 @@
+<% service_page_link = service_page_url(document.id) %>
+
+<dd class="avail-dd col-md-9" id="availability-indicator-<%= document.id %>">
+    <% if doc_avail_values.present? %>
+      <%= render_physical_avail_spans(doc_avail_values, service_page_link) %>
+      <%= tag('br') if doc_avail_values[:physical_exists] && (doc_avail_values[:online_available] || document.url_fulltext.present?) %>
+      <% if doc_avail_values[:online_available] || document.url_fulltext.present? %>
+        <span class="btn rounded-0 mb-2 online-avail-label avail-default">Online</span>
+        <% if !doc_avail_values[:online_available] %>
+          <%= render_online_link_span(document.id) %>
+          <%= render 'catalog/document_url_fulltext_modal', document: document %>
+        <% else %>
+          <span class="online-avail-button">
+            <%= link_to "CONNECT", service_page_link, target: "_blank", class: "btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el" %>
+          </span>
+        <% end %>
+      <% end %>
+    <% else %>
+      <span class="btn rounded-0 mb-2 phys-avail-label avail-danger">Unknown</span>  
+    <% end %>
+</dd>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,31 +1,20 @@
 <%# Override of Blacklight v7.4.1 partial of same name; inserts vernacular title helper before the dl L#4 %>
 <% doc_presenter = index_presenter(document) %>
-<% doc_avail_values = @documents_availability[document.id] if @documents_availability.present? %>
 <% service_page_link = service_page_url(document.id) %>
 <%# default partial to display solr document fields in catalog index view -%>
 <%= vern_title_search_results_populator(document) %>
 <dl class="document-metadata dl-invert row">
-
   <% doc_presenter.fields_to_render.each do |field_name, field| -%>
     <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
     <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
   <% end -%>
-  <dt class="avail-label blacklight-access-availability-<%= document.id %> col-md-3">Access & Availability:</dt>
-  <dd class="avail-dd blacklight-access-availability-<%= document.id %> col-md-9">
-    <% if doc_avail_values.present? %>
-      <%= render_physical_avail_spans(doc_avail_values, service_page_link) %>
-      <%= tag('br') if doc_avail_values[:physical_exists] && (doc_avail_values[:online_available] || document.url_fulltext.present?) %>
-      <% if doc_avail_values[:online_available] || document.url_fulltext.present? %>
-        <span class="btn rounded-0 mb-2 online-avail-label avail-default">Online</span>
-        <% if !doc_avail_values[:online_available] %>
-          <%= render_online_link_span(document.id) %>
-          <%= render 'document_url_fulltext_modal', document: document %>
-        <% else %>
-          <span class="online-avail-button">
-            <%= link_to "CONNECT", service_page_link, target: "_blank", class: "btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el" %>
-          </span>
-        <% end %>
-      <% end %>
-    <% end %>
+  <dt class="avail-label col-md-3">Access & Availability:</dt>
+  <dd class="avail-dd col-md-9" id="availability-indicator-<%= document.id %>">
+    <ul class="loading-avail-block">
+      <li class="loading-avail-badge">
+       <span class="spinner-border spinner-border-sm loading-avail-spinner" role="status"></span>
+       <span class="loading-avail-message">Loading</span>
+      </li>
+    </ul>
   </dd>
 </dl>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -20,6 +20,7 @@
 <%= render 'search_header' %>
 
 <h2 class="sr-only visually-hidden"><%= t('blacklight.search.search_results') %></h2>
+<input type="hidden" id="search_results_document_ids" value="<%= @document_ids.join(',') %>" />
 
 <%- if @response.empty? %>
   <%= render "zero_results" %>

--- a/config/initializers/catalog_index_override.rb
+++ b/config/initializers/catalog_index_override.rb
@@ -6,9 +6,8 @@
 CatalogController.class_eval do
   def index
     (@response, deprecated_document_list) = search_service.search_results
-
     @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_document_list, 'The @document_list instance variable is deprecated; use @response.documents instead.')
-    @documents_availability = AlmaAvailabilityService.new(@response.documents.map(&:id)).availability_of_documents unless request.fullpath == '/'
+    @document_ids = @response&.documents&.map(&:id) || []
 
     respond_to do |format|
       format.html { store_preferred_view }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   end
 
   resources :hold_requests
+  resources :availability_indicators, only: [:index], constraints: ->(request) { request.format == :json }
 
   devise_for :users, controllers: { omniauth_callbacks: "omniauth_callbacks" }, skip: "sessions"
 

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -124,7 +124,7 @@ RSpec.feature 'View Search Results', type: :system, js: false do
     end
   end
 
-  context 'displaying availability badges' do
+  context 'displaying availability badges', js: true do
     before do
       delete_all_documents_from_solr
       build_solr_docs(TEST_ITEM.merge(id: '990005988630302486'))
@@ -143,20 +143,16 @@ RSpec.feature 'View Search Results', type: :system, js: false do
     end
 
     it 'shows the right badges and links' do
-      expect(page).to have_css('dt', class: 'avail-label blacklight-access-availability-990005988630302486 col-md-3')
-      expect(page).to have_css('dd', class: 'avail-dd blacklight-access-availability-990005988630302486 col-md-9')
-      expect(page).to have_css(
-        'span', class: 'btn rounded-0 mb-2 phys-avail-label avail-success', text: 'Available'
-      )
-      expect(page).to have_link(
-        'LOCATE/REQUEST', class: 'btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el'
-      )
-      expect(page).to have_css(
-        'span', class: 'btn rounded-0 mb-2 online-avail-label avail-default', text: 'Online'
-      )
-      expect(
-        find('a.btn.btn-md.rounded-0.mb-2.btn-outline-primary.avail-link-el[data-target="#avail-modal-990005988630302486"]').present?
-      ).to be_truthy
+      expect(page).to have_selector(:id, 'availability-indicator-990005988630302486')
+
+      within('#availability-indicator-990005988630302486') do
+        expect(page).to have_xpath('//span[1]', text: 'Available', class: 'btn rounded-0 mb-2 phys-avail-label avail-success')
+        expect(page).to have_xpath('//span[2]/a', text: 'LOCATE/REQUEST', class: 'btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el')
+        expect(page).to have_xpath('//span[3]', text: 'Online', class: 'btn rounded-0 mb-2 online-avail-label avail-default')
+        expect(
+          find('a.btn.btn-md.rounded-0.mb-2.btn-outline-primary.avail-link-el[data-target="#avail-modal-990005988630302486"]').present?
+        ).to be_truthy
+      end
     end
   end
 


### PR DESCRIPTION
Changes include:

- Remove ALMA availability request from page load
- Add loading indicator on page load for Access & Availability information
- Add `AvailabilityIndicatorsController` which renders views of availability indicators for any documents requested. The controller returns a JSON with key as the document ID and value as the view html in string format.
- Add ajax request to `AvailabilityIndicatorsController` to replace loading indicators with availability indicators after page load

Please refer to the following recording for UI changes in this PR:

https://user-images.githubusercontent.com/13107510/139339745-c5a619d7-e4e9-42df-be5f-3c82846f82fb.mov

