### PR TITLE
Revises feedback link to open in new tab/window (#1001).

### DIFF
--- a/app/views/static/contact.html.erb
+++ b/app/views/static/contact.html.erb
@@ -1,51 +1,20 @@
 <% @page_title = "#{t('contact')} - #{application_name}" %>
 <% title = I18n.t('contact'); abbr = nil %>
 
-<%= render 'catalog/breadcrumbs', crumb_hashes: [{ curr_page: true, abbr: abbr, link: '/contact', title: title }]
-%>
+<%= render 'catalog/breadcrumbs', crumb_hashes: [{ curr_page: true, abbr: abbr, link: '/contact', title: title }] %>
 <div class="row static-heading-row contact">
-  <%= render 'static/static_heading', 
-              title: title, 
-              subheading: "Contact points for technical assistance and additional information about our Emory Libraries Catalog and Search" 
-%>
+  <%= render 'static/static_heading', title: title, subheading: t('static.contact.subheader') %>
 </div>
 <div class="row static-body contact">
   <div class="col-lg-8 contact-blurbs">
-    <h2 class="static-blurb-header feedback-blurb-header">Send Feedback or Report a Problem</h2>
+    <h2 class="static-blurb-header feedback-blurb-header"><%= t('static.contact.headers.feedback') %></h2>
     <p class="static-blurb-body feedback-blurb">
-        <a href='https://emory.libwizard.com/f/blacklight' class="static-blurb-link">Send feedback to the development team</a>  
-      </p>
+      <a href='https://emory.libwizard.com/f/blacklight' target="_blank" class="static-blurb-link">
+        <%= t('static.contact.links.feedback') %>
+      </a>
+    </p>
 
-      <h2 class="static-blurb-header contacts-blurb-header">Assistance with Emory Libraries Services</h2>
-      <p class="static-blurb-body contacts-blurb">
-        <a href='https://libraries.emory.edu/services/purchase-request/index.html' class="static-blurb-link">Request a purchase</a>
-      </p>
-      <p class="static-blurb-body contacts-blurb">
-        <a href='https://emory.libanswers.com/' class="static-blurb-link">Ask a Librarian</a>
-      </p>
-      <p class="static-blurb-body contacts-blurb">
-        <a href='https://libraries.emory.edu/tools/report-issues-with-ejournals.html' class="static-blurb-link">Ask eJournals</a>
-      </p>
-      <p class="static-blurb-body contacts-blurb">
-        <a href='https://libraries.emory.edu/contact/subject-librarian-directory.html' class="static-blurb-link">Find a subject librarian</a>
-      </p>
-      <p class="static-blurb-body contacts-blurb">
-        <a href='https://libraries.emory.edu/services/access-course-reserves.html' class="static-blurb-link">Access Course Reserves</a>
-      </p>
-      <p class="static-blurb-body contacts-blurb">
-        <a href='https://libraries.emory.edu/services/submit-ill-request.html' class="static-blurb-link">Submit an ILL Request</a>
-      </p>
-          
-            </div>
-            <div class=" col-lg-4">
-              <div class="explore-card contact-explore">
-                <span class="explore-header">Explore</span>
-                <ul class="explore-links">
-                  <li class="explore-link-item"><%= link_to "Emory Libraries Policies", "https://libraries.emory.edu/about/policies/index.html", class: "explore-link" %></li>
-                  <li class="explore-link-item"><%= link_to "Using the Library", "https://libraries.emory.edu/using-the-library/index.html", class: "explore-link" %></li>
-                  <li class="explore-link-item"><%= link_to "Libraries Hours", "https://libraries.emory.edu/hours/index.html", class: "explore-link" %></li>
-                  <li class="explore-link-item"><%= link_to "Contact Library Staff and Departments", "https://libraries.emory.edu/contact/index.html", class: "explore-link" %></li>
-                </ul>
-              </div>
-            </div>
-          </div>
+    <%= render 'static/contact/assistance' %>
+  </div>
+  <%= render 'static/contact/explore_card' %>
+</div>

--- a/app/views/static/contact/_assistance.html.erb
+++ b/app/views/static/contact/_assistance.html.erb
@@ -1,0 +1,7 @@
+<h2 class="static-blurb-header contacts-blurb-header"><%= t('static.contact.headers.assistance') %></h2>
+<%= render 'static/contact/assistance_link', link: 'https://libraries.emory.edu/services/purchase-request/index.html', link_text: t('static.contact.links.purchase') %>
+<%= render 'static/contact/assistance_link', link: 'https://emory.libanswers.com/', link_text: t('static.contact.links.ask_lib') %>
+<%= render 'static/contact/assistance_link', link: 'https://libraries.emory.edu/tools/report-issues-with-ejournals.html', link_text: t('static.contact.links.ask_ejournals') %>
+<%= render 'static/contact/assistance_link', link: 'https://libraries.emory.edu/contact/subject-librarian-directory.html', link_text: t('static.contact.links.find_sub_lib') %>
+<%= render 'static/contact/assistance_link', link: 'https://libraries.emory.edu/services/access-course-reserves.html', link_text: t('static.contact.links.course_reserves') %>
+<%= render 'static/contact/assistance_link', link: 'https://libraries.emory.edu/services/submit-ill-request.html', link_text: t('static.contact.links.ill_request') %>

--- a/app/views/static/contact/_assistance_link.html.erb
+++ b/app/views/static/contact/_assistance_link.html.erb
@@ -1,0 +1,1 @@
+<p class="static-blurb-body contacts-blurb"><%= link_to link_text, link, class: "static-blurb-link" %></p>

--- a/app/views/static/contact/_card_link_li.html.erb
+++ b/app/views/static/contact/_card_link_li.html.erb
@@ -1,0 +1,1 @@
+<li class="explore-link-item"><%= link_to link_text, link, class: "explore-link" %></li>

--- a/app/views/static/contact/_explore_card.html.erb
+++ b/app/views/static/contact/_explore_card.html.erb
@@ -1,0 +1,11 @@
+<div class=" col-lg-4">
+  <div class="explore-card contact-explore">
+    <span class="explore-header"><%= t('static.contact.explore.title') %></span>
+    <ul class="explore-links">
+      <%= render 'static/contact/card_link_li', link_text: t('static.contact.explore.links.policies'), link: "https://libraries.emory.edu/about/policies/index.html" %>
+      <%= render 'static/contact/card_link_li', link_text: t('static.contact.explore.links.using_lib'), link: "https://libraries.emory.edu/using-the-library/index.html" %>
+      <%= render 'static/contact/card_link_li', link_text: t('static.contact.explore.links.lib_hours'), link: "https://libraries.emory.edu/hours/index.html" %>
+      <%= render 'static/contact/card_link_li', link_text: t('static.contact.explore.links.contact_lib_staff'), link: "https://libraries.emory.edu/contact/index.html" %>
+    </ul>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,26 @@ en:
         materials_link_text: "Information about Libraries Materials"
         research_link_text: "Research Guides"
         contact_link_text: "Contact Us"
+    contact:
+      explore:
+        title: "Explore"
+        links:
+          contact_lib_staff: "Contact Library Staff and Departments"
+          lib_hours: "Libraries Hours"
+          policies: "Emory Libraries Policies"
+          using_lib: "Using the Library"
+      headers:
+        assistance: "Assistance with Emory Libraries Services"
+        feedback: "Send Feedback or Report a Problem"
+      links:
+        ask_ejournals: "Ask eJournals"
+        ask_lib: "Ask a Librarian"
+        course_reserves: "Access Course Reserves"
+        feedback: "Send feedback to the development team"
+        find_sub_lib: "Find a subject librarian"
+        ill_request: "Submit an ILL Request"
+        purchase: "Request a purchase"
+      subheader: "Contact points for technical assistance and additional information about our Emory Libraries Catalog and Search"
     not_found:
       header: "404 Error - Page Not Found"
     unhandled_exception:


### PR DESCRIPTION
All: adds target: blank to the link requested, but also refactors the page to point to sections of the page.

No screenshots necessary.