### PR TITLE
Removes calling cache when assigning application_name.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -3,6 +3,8 @@
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
 
+  # Overrides Blacklight's method, since it retains the application name in cache,
+  # causing "Blacklight" to persist after changing to production name.
   def application_name
     t('blacklight.application_name',
         default: t('blacklight.application_name', locale: I18n.default_locale))

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -7,6 +7,7 @@ module CatalogHelper
     t('blacklight.application_name',
         default: t('blacklight.application_name', locale: I18n.default_locale))
   end
+
   def generic_solr_value_to_url(value)
     url_arr = build_arr_links_text_split(values_of_field(value))
     return safe_join(url_arr, tag('br')) if url_arr.present?

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -3,6 +3,10 @@
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
 
+  def application_name
+    t('blacklight.application_name',
+        default: t('blacklight.application_name', locale: I18n.default_locale))
+  end
   def generic_solr_value_to_url(value)
     url_arr = build_arr_links_text_split(values_of_field(value))
     return safe_join(url_arr, tag('br')) if url_arr.present?

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -9,7 +9,7 @@
     <!-- Internet Explorer use the highest version available -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title><%= render_page_title %></title>
+    <title><%= @page_title || application_name %></title>
     <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
     <%= favicon_link_tag %>
     <%= stylesheet_link_tag "application", media: "all" %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -9,7 +9,7 @@
     <!-- Internet Explorer use the highest version available -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title><%= @page_title || application_name %></title>
+    <title><%= render_page_title %></title>
     <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
     <%= favicon_link_tag %>
     <%= stylesheet_link_tag "application", media: "all" %>


### PR DESCRIPTION
app/helpers/catalog_helper.rb: overrides the `application_name` method, since it caches previous values.