### PR TITLE
Integrates Google Analytics into the catalog (#667). 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ yarn.lock
 
 # Ignore JMeter logs.
 *jmeter.log
+.ruby-version

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -22,13 +22,29 @@
 
 <script type="text/javascript">
   [...document.querySelectorAll('.facet-select')].forEach(function(item) {
-    item.addEventListener('mouseover', function() {
+    item.addEventListener('click', function() {
       var facetParent = item.parentElement.parentElement.parentElement.parentElement.parentElement.id;
-      console.log(facetParent);
+      
+      gtag('event', facetParent, {
+        'event_category': 'facet_clicked',
+        'event_label': item.text
+      });
     });
   });
 
-  document.querySelector('.submit.btn.btn-secondary').addEventListener('mouseover', function() {
-    
+  document.querySelector('.submit.btn.btn-secondary').addEventListener('click', function() {
+    gtag('event', 'publication_date_range_facet', {
+      'event_category': 'facet_clicked',
+      'event_label': 'publication_date_range_applied'
+    });
+  });
+
+  [...document.querySelectorAll('.btn.btn-block.p-2.text-left.collapse-toggle.collapsed')].forEach(function(item) {
+    item.addEventListener('click', function() {
+      gtag('event', item.innerText, {
+        'event_category': 'facet_viewed',
+        'event_label': item.innerText
+      });
+    });
   });
 </script>

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -19,3 +19,16 @@
   </div>
 </div>
 <% end %>
+
+<script type="text/javascript">
+  [...document.querySelectorAll('.facet-select')].forEach(function(item) {
+    item.addEventListener('mouseover', function() {
+      var facetParent = item.parentElement.parentElement.parentElement.parentElement.parentElement.id;
+      console.log(facetParent);
+    });
+  });
+
+  document.querySelector('.submit.btn.btn-secondary').addEventListener('mouseover', function() {
+    
+  });
+</script>

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -21,7 +21,7 @@
 <% end %>
 
 <script type="text/javascript">
-  [...document.querySelectorAll('.facet-select')].forEach(function(item) {
+  document.querySelectorAll('.facet-select').forEach(function(item) {
     item.addEventListener('click', function() {
       var facetParent = item.parentElement.parentElement.parentElement.parentElement.parentElement.id;
       
@@ -39,7 +39,7 @@
     });
   });
 
-  [...document.querySelectorAll('.btn.btn-block.p-2.text-left.collapse-toggle.collapsed')].forEach(function(item) {
+  document.querySelectorAll('.btn.btn-block.p-2.text-left.collapse-toggle.collapsed').forEach(function(item) {
     item.addEventListener('click', function() {
       gtag('event', item.innerText, {
         'event_category': 'facet_viewed',

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -15,3 +15,15 @@
 <%= render('catalog/show_tools/metadata_block', 
       document: document, presenter: DescriptionSummaryPresenter, title: t('catalog.show.description_summary')) %>
 <%= render 'catalog/show_tools/metadata_block', document: document, presenter: AddlIdsPresenter, title: t('catalog.show.addl_ids') %>
+
+<script type="text/javascript">
+  gtag('event', '<%= document['library_ssim']&.first %>', {
+    'event_category': 'library_view',
+    'event_label': '<%= document['title_main_display_ssim'].first %>'
+  });
+
+  gtag('event', '<%= document['format_ssim']&.first %>', {
+    'event_category': 'library_view',
+    'event_label': '<%= document['title_main_display_ssim'].first %>'
+  });
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GA_TRACKING_CODE'] %>"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '<%= ENV['GA_TRACKING_CODE'] %>');
+    </script> 
     <title>Library Search - Emory Libraries</title>
     <%= favicon_link_tag %>
     <%= csrf_meta_tags %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -2,6 +2,14 @@
 <!DOCTYPE html>
 <%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
   <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GA_TRACKING_CODE'] %>"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '<%= ENV['GA_TRACKING_CODE'] %>');
+    </script> 
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -27,3 +27,4 @@ SOLR_URL=
 
 # provide a comma-separated list of network IDs of LTDS users who can perform administrative tasks
 LTDS_ADMIN_NET_ID_LIST=
+GA_TRACKING_CODE=your_google_analytics_code


### PR DESCRIPTION
- .gitignore: ruby version seems to be generating in the app now, so I'll avoid sending it to github.
- app/views/catalog/_facet_group.html.erb: institutes Google tagging that (the first two) reports when a facet limiter is enforced, and also reports when a facet collapsible is clicked.
- app/views/catalog/_show.html.erb: tags the document's library and format.
- app/views/layouts/*: mimics Lux' setup that places the script in both base and application's erbs.
- dotenv.sample: calls out needed new ENV.

Behind the scenes, no screenshots needed.