### PR TITLE
Turns main author list into facet hyperlinks (#1020).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ yarn.lock
 
 # Ignore JMeter logs.
 *jmeter.log
+.ruby-version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,7 @@ Metrics/ModuleLength:
         - 'lib/traject/extraction_tools.rb'
         - 'config/prepends/custom_citation_logic.rb'
         - 'app/models/concerns/statusable.rb'
+        - 'app/helpers/catalog_helper.rb'
 
 Metrics/PerceivedComplexity:
     Exclude:

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -18,7 +18,11 @@ module CatalogHelper
   end
 
   def combine_author_vern(value)
-    combined_values = value[:document].combined_author_display_vern
+    combined_values =
+      (multilined_links_to_facet_flexible(values_of_field(value), 'author_display_ssim') +
+        multilined_links_to_facet_flexible(
+          value[:document]['author_vern_ssim'], 'author_vern_ssim'
+        ))&.compact&.uniq
     return safe_join(combined_values, tag('br')) if combined_values.present?
     ''
   end
@@ -103,6 +107,14 @@ module CatalogHelper
     end
     return safe_join(ret_vals, tag('br')) if ret_vals.present?
     ''
+  end
+
+  def multilined_links_to_facet_flexible(values, field_name)
+    ret_vals = values&.map do |v|
+      link_to(v, ("/?f%5B#{field_name}%5D%5B%5D=" + CGI.escape(v))).to_s
+    end
+    return ret_vals if ret_vals.present?
+    []
   end
 
   def build_title_search_links(record_values, record_formats)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,13 +34,6 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
 
-  def combined_author_display_vern
-    ret_array = []
-    self['author_display_ssim'].each { |v| ret_array << v } if self['author_display_ssim'].present?
-    self['author_vern_ssim'].each { |v| ret_array << v } if self['author_vern_ssim'].present?
-    ret_array.uniq
-  end
-
   def url_fulltext
     self['url_fulltext_ssm']
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -35,12 +35,6 @@ RSpec.describe SolrDocument do
   end
 
   context "with a regular test item" do
-    context '#combined_author_display_vern' do
-      it 'combines together author_display_ssim and author_vern_ssim' do
-        expect(solr_doc.combined_author_display_vern).to eq ['George Jenkins', 'G. Jenkins']
-      end
-    end
-
     context '#more_options' do
       it 'pulls the format_ssim value' do
         expect(solr_doc.more_options).to eq solr_doc['format_ssim']

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -93,6 +93,20 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
       end
     end
 
+    context 'displaying author values' do
+      it 'shows a facet link for the author_display_ssim field' do
+        expect(page).to have_link(
+          'George Jenkins', href: '/?f%5Bauthor_display_ssim%5D%5B%5D=George+Jenkins'
+        )
+      end
+
+      it 'shows a facet link for the author_vern_ssim field, when present' do
+        expect(page).to have_link(
+          'G. Jenkins', href: '/?f%5Bauthor_vern_ssim%5D%5B%5D=G.+Jenkins'
+        )
+      end
+    end
+
     context 'displaying vernacular title' do
       it 'has the vernacular title below the main title' do
         expect(find('h1[itemprop="name"]+h2.vernacular_title_1').text).to eq('Title of my Work')


### PR DESCRIPTION
- .*: ignores ruby_version for github and catalog_helpers from rubocop.
- app/helpers/catalog_helper.rb: updates the methods used to populate author values.
- app/models/solr_document.rb: removes the method, since the values aren't needed blindly.
- spec/models/solr_document_spec.rb: deletes test that corresponds to the Solr Document method.
- spec/system/view_show_page_spec.rb: tests for the right links.
<img width="922" alt="Screen Shot 2021-11-15 at 11 30 36 AM" src="https://user-images.githubusercontent.com/18330149/141818651-eb5a5769-8825-41aa-a7bd-ffe656f675f6.png">
<img width="1011" alt="Screen Shot 2021-11-15 at 11 31 03 AM" src="https://user-images.githubusercontent.com/18330149/141818672-28242881-deb7-40de-b12e-27d74f3752a2.png">


