### PR TITLE
Boosts select fields in the Keyword option (#1034).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -263,6 +263,10 @@ class CatalogController < ApplicationController
     # urls.  A display label will be automatically calculated from the :key,
     # or can be specified manually to be different.
 
+    keyword_fields = [
+      'title_precise_tesim^100', 'author_tesim^50', 'author_addl_display_tesim^50',
+      'subject_tesim^10', 'text_tesi', 'id', 'local_call_number_tesim', 'other_standard_ids_tesim'
+    ]
     author_fields = [
       'author_tesim', 'author_vern_tesim', 'author_ssort', 'author_addl_display_tesim',
       'note_participant_tesim', 'note_production_tesim'
@@ -295,7 +299,7 @@ class CatalogController < ApplicationController
     config.add_search_field('keyword', label: 'Keyword') do |field|
       field.include_in_advanced_search = false
       field.solr_parameters = {
-        qf: 'text_tesi id local_call_number_tesim other_standard_ids_tesim',
+        qf: keyword_fields.join(' '),
         pf: ''
       }
     end

--- a/spec/system/targeted_field_search_spec.rb
+++ b/spec/system/targeted_field_search_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       'title_added_entry_tesim', 'title_enhanced_tesim', 'subject_tesim', 'title_former_tesim',
       'title_host_item_tesim', 'title_key_tesim', 'title_series_tesim', 'title_translation_tesim',
       'title_varying_tesim', 'text_tesi', 'local_call_number_tesim', 'title_later_tesim',
-      'note_production_tesim', 'note_participant_tesim', 'other_standard_ids_tesim'
+      'note_production_tesim', 'note_participant_tesim', 'other_standard_ids_tesim',
+      'title_precise_tesim'
     ]
   end
 
@@ -66,6 +67,10 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     end
 
     expect(result_titles).to contain_exactly(
+      'Target in title_precise_tesim',
+      'Target in author_tesim',
+      'Target in author_addl_display_tesim',
+      'Target in subject_tesim',
       'Target in text_tesi',
       'Target in id',
       'Target in local_call_number_tesim',


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: creates a array variable for the keyword fields, which has the new fields and their boosting values.
- spec/system/targeted_field_search_spec.rb: updates the expectations for the search results tests.

No screenshots necessary.