### PR TITLE
Adds banner to homepage announcing beta (#1059).

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_navbar.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_navbar.scss
@@ -190,3 +190,8 @@ a.nav-link.last {
   font-size: .5rem;
   vertical-align: text-bottom;
 }
+
+.beta-banner.alert.alert-warning {
+  margin-left: -15px;
+  margin-right: -15px;
+}

--- a/app/views/shared/_beta_banner.html.erb
+++ b/app/views/shared/_beta_banner.html.erb
@@ -1,0 +1,5 @@
+<div class='beta-banner alert alert-warning'>
+  Welcome to the beta version of Library Search. Questions or concerns about the product can be sent to 
+  <a href="mailto:librarysearch@emory.edu">librarysearch@emory.edu</a>. The production launch is scheduled for January 6, 2022. Until then, you can use Library Search or 
+  <a href="http://discovere.emory.edu/primo_library/libweb/action/search.do">discovere.emory.edu</a> to search and find items from the catalog and Articles Plus.
+</div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -9,6 +9,7 @@
           <%= render 'shared/static_links', mobile: false %>
         </div>
       </div>
+      <%= render 'shared/beta_banner' if request.fullpath == "/" %>
       <div class="row justify-content-between branding-row header-main">
         <div class="branding-header">
           <div class="branding-header logo">


### PR DESCRIPTION
- app/assets/stylesheets/blacklight_catalog/_navbar.scss: styling for banner.
- app/views/shared/_beta_banner.html.erb: banner html.
- app/views/shared/_header_navbar.html.erb: render call to banner.
<img width="2743" alt="Screen Shot 2021-11-19 at 12 13 01 PM" src="https://user-images.githubusercontent.com/18330149/142667100-c6289f81-9bbc-41ad-8e3f-b89be47ed5df.png">

