### PR TITLE
Reduces the results headers' font size (#1085).

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_results_list.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_results_list.scss
@@ -58,7 +58,7 @@ dt.index-field-name {
 .documents-list > .document {
   margin-bottom: $results-document-bottom-margin;
   h3.document-title-heading {
-    font: normal bold $h4-font-size $font-family-sans-serif;
+    font: normal bold $results-h3-font-size $font-family-sans-serif;
   }
 }
 

--- a/app/assets/stylesheets/blacklight_catalog/_variables.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_variables.scss
@@ -201,6 +201,7 @@ $results-drop-menu-min-w: 4.063rem;
 $results-pagination-margin: 0.563rem;
 $results-thumbnail-width: 11.5rem;
 $results-document-bottom-margin: 2rem;
+$results-h3-font-size: 1.2rem;
 $results-vern-title-bottom-marg: 0.5rem;
 $results-vern-title-left-marg: 1.75rem;
 $results-avail-badge-min-width: 8.5rem;


### PR DESCRIPTION
- app/assets/stylesheets/blacklight_catalog/_results_list.scss: swaps to a new variable pointing directly to this value.
- app/assets/stylesheets/blacklight_catalog/_variables.scss: creates variable for the new value.
<img width="1323" alt="Screen Shot 2021-11-23 at 10 14 03 AM" src="https://user-images.githubusercontent.com/18330149/143052419-5f659b0f-20c1-48c7-8264-dda583bc8f59.png">

