### PR TITLE
Adds Check Holdings as an availability indicator (#1051).

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_colors.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_colors.scss
@@ -26,6 +26,7 @@ $red: #b82216;
 $light-red: #eabdb9;
 $orange: #ab750c;
 $yellow: #f6e4c1;
+$alt-yellow: #fcecc7;
 $green: #28a745;
 $light-green: #e0f6da;
 

--- a/app/assets/stylesheets/blacklight_catalog/_results_list.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_results_list.scss
@@ -84,6 +84,10 @@ dt.index-field-name {
   background-color: $light-red;
 }
 
+.phys-avail-label.avail-unknown {
+  background-color: $alt-yellow;
+}
+
 .avail-link-el, .phys-avail-label, .online-avail-label {
   min-width: $results-avail-badge-min-width;
 }

--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -42,20 +42,21 @@ module SearchResultsHelper
 
   def render_physical_avail_spans(avail_values, service_page_link)
     return unless avail_values[:physical_exists]
-    label = phys_label_span(avail_values)
-    service_page_anchor = serv_page_anch(avail_values, service_page_link)
+    status = get_phys_avail_status(avail_values)
+    label = phys_label_span(status)
+    service_page_anchor = serv_page_anch(status, service_page_link)
     dt = tag.span(service_page_anchor, class: "phys-avail-button")
 
     safe_join([label, dt])
   end
 
-  def phys_label_span(avail_values)
-    tag.span("#{'Not ' unless avail_values[:physical_available]}Available",
-      class: "btn rounded-0 mb-2 phys-avail-label avail-#{avail_values[:physical_available] ? 'success' : 'danger'}")
+  def phys_label_span(status)
+    avail_class = get_avail_class(status)
+    tag.span(status, class: "btn rounded-0 mb-2 phys-avail-label #{avail_class}")
   end
 
-  def serv_page_anch(avail_values, service_page_link)
-    tag.a("#{'LOCATE/' if avail_values[:physical_available]}REQUEST",
+  def serv_page_anch(status, service_page_link)
+    tag.a("#{'LOCATE/' unless status == 'Not Available'}REQUEST",
            href: service_page_link, target: '_blank', rel: 'noopener noreferrer',
            class: 'btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el')
   end
@@ -76,5 +77,26 @@ module SearchResultsHelper
   def processed_facet_ejournals(letter_state, letter)
     return letter_state['f'].merge('title_main_first_char_ssim': [letter]) if letter_state['f'].present?
     { 'title_main_first_char_ssim': [letter], 'marc_resource_ssim': ["Online"], 'format_ssim': ["Journal, Newspaper or Serial"] }
+  end
+
+  def get_phys_avail_status(avail_values)
+    if avail_values[:physical_check_holdings]
+      'Check Holdings'
+    elsif avail_values[:physical_available]
+      'Available'
+    else
+      'Not Available'
+    end
+  end
+
+  def get_avail_class(status)
+    case status
+    when "Check Holdings"
+      'avail-unknown'
+    when "Available"
+      'avail-success'
+    else
+      'avail-danger'
+    end
   end
 end

--- a/app/services/alma_availability_service.rb
+++ b/app/services/alma_availability_service.rb
@@ -14,12 +14,12 @@ class AlmaAvailabilityService
     return nil if response.blank?
 
     xml = Nokogiri::XML(response)
-    bib_records = xml.xpath("//bib")
     ret_hsh = {}
-    bib_records.each do |record|
+    xml.xpath("//bib").each do |record|
       ret_hsh[record.xpath('mms_id').text] = {
         physical_exists: record.xpath('record/datafield[@tag="AVA"]').present?,
-        physical_available: physical_any_available?(record),
+        physical_available: physical_any_with?('available', record),
+        physical_check_holdings: physical_any_with?('check_holdings', record),
         online_available: online_any_available?(record)
       }
     end
@@ -44,9 +44,9 @@ class AlmaAvailabilityService
     ENV.fetch('ALMA_BIB_KEY')
   end
 
-  def physical_any_available?(record)
+  def physical_any_with?(field_value, record)
     phys_fields = record.xpath('record/datafield[@tag="AVA"]/subfield[@code="e"]')
-    phys_fields.present? ? phys_fields.any? { |f| f.text.casecmp('available').zero? } : false
+    phys_fields.present? ? phys_fields.any? { |f| f.text.casecmp(field_value).zero? } : false
   end
 
   def online_any_available?(record)

--- a/spec/services/alma_availability_service_spec.rb
+++ b/spec/services/alma_availability_service_spec.rb
@@ -5,9 +5,11 @@ require 'nokogiri'
 RSpec.describe AlmaAvailabilityService, alma: true do
   let(:id) { '990005988630302486' }
   let(:id2) { '990005059530302486' }
+  let(:id3) { '990027507910302486' }
   let(:service) { described_class.new([id]) }
   let(:service2) { described_class.new([id2]) }
   let(:service3) { described_class.new([id, id2]) }
+  let(:service4) { described_class.new([id3]) }
   around do |example|
     orig_url = ENV['ALMA_API_URL']
     orig_key = ENV['ALMA_BIB_KEY']
@@ -21,20 +23,36 @@ RSpec.describe AlmaAvailabilityService, alma: true do
   describe '#availability_of_documents' do
     it 'returns the correct response #1' do
       expect(service.availability_of_documents).to eq(
-        { "990005988630302486" => { online_available: false, physical_available: true, physical_exists: true } }
+        { "990005988630302486" =>
+          { online_available: false, physical_available: true,
+            physical_check_holdings: false, physical_exists: true } }
       )
     end
 
     it 'returns the correct response #2' do
       expect(service2.availability_of_documents).to eq(
-        { "990005059530302486" => { online_available: false, physical_available: true, physical_exists: true } }
+        { "990005059530302486" =>
+          { online_available: false, physical_available: true,
+            physical_check_holdings: false, physical_exists: true } }
       )
     end
 
     it 'returns the correct response #3' do
       expect(service3.availability_of_documents).to eq(
-        { "990005059530302486" => { online_available: false, physical_available: true, physical_exists: true },
-          "990005988630302486" => { online_available: false, physical_available: true, physical_exists: true } }
+        { "990005059530302486" =>
+          { online_available: false, physical_available: true,
+            physical_check_holdings: false, physical_exists: true },
+          "990005988630302486" =>
+          { online_available: false, physical_available: true,
+            physical_check_holdings: false, physical_exists: true } }
+      )
+    end
+
+    it 'returns the correct response #4' do
+      expect(service4.availability_of_documents).to eq(
+        { "990027507910302486" =>
+          { online_available: false, physical_available: true,
+            physical_check_holdings: true, physical_exists: true } }
       )
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -155,5 +155,7 @@ RSpec.configure do |config|
       .to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file.xml'), headers: {})
     stub_request(:get, "http://www.example.com/almaws/v1/bibs?mms_id=990005988630302486&view=full&expand=p_avail,e_avail,d_avail&apikey=fakebibkey123")
       .to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file.xml'), headers: {})
+    stub_request(:get, "http://www.example.com/almaws/v1/bibs?apikey=fakebibkey123&expand=p_avail,e_avail,d_avail&mms_id=990027507910302486&view=full")
+      .to_return(status: 200, body: File.read(fixture_path + '/alma_availability_test_file_10.xml'), headers: {})
   end
 end


### PR DESCRIPTION
- app/assets/*: adds the needed badge color.
- app/helpers/search_results_helper.rb: updates logic to deliver the new badge.
- app/services/alma_availability_service.rb: provides a new hash attribute that points to existing holdings with the `check_holdings` availability status.
- spec/*: adds a test to make sure the AlmaAvailabilityService tests for `check_holdings` correctly.
<img width="1174" alt="Screen Shot 2021-11-29 at 1 08 37 PM" src="https://user-images.githubusercontent.com/18330149/143921978-e2bee81c-a900-4cfb-a05a-ad809c0d6446.png">
<img width="1208" alt="Screen Shot 2021-11-29 at 1 09 06 PM" src="https://user-images.githubusercontent.com/18330149/143921980-a5fbf50e-aafa-4460-ae7b-f268bb0f3a6f.png">


