### PR TITLE
Restore submitting holds requests using the ALMA API

### DIFF
--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -23,35 +23,33 @@
         <% end %>
       </div>
     <% end %>
-    <%#
-    <div class="col-6 request-options">
-      <div class="btn-group">
-        <button class="btn btn-primary rounded-0">Request</button>
-        <button class="btn btn-primary rounded-0 dropdown-toggle dropdown-toggle-split" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <span class="sr-only">Toggle Dropdown</span>
-        </button>
-        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-    %>
-    <%# if document.hold_requestable?(current_or_guest_user) %>
-    <%#= link_to "Hold request", new_hold_request_path(hold_request: {mms_id: document.id, title: document['title_display_tesim']&.first}), class: "dropdown-item" %>
-    <%# end %>
-    <%# if document.one_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
-    <%#= link_to "Request Article or Chapter", document.one_step_link, class: "dropdown-item" %>
-    <%# end %>
-    <%# if document.two_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
-    <%#= link_to "Request Article or Chapter", "#", class: "dropdown-item", data: {toggle: "modal", target: "#two-step-illiad"} %>
-    <%# end %>
-    <%# if document.special_collections_requestable?(current_or_guest_user) %>
-    <%#= link_to "Request from Special Collections", document.special_collections_url, class: "dropdown-item" %>
-    <%# end %>
-    <%#
+    <% if Flipflop.enable_requesting_using_api? %>
+      <div class="col-6 request-options">
+        <div class="btn-group">
+          <button class="btn btn-primary rounded-0">Request</button>
+          <button class="btn btn-primary rounded-0 dropdown-toggle dropdown-toggle-split" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="sr-only">Toggle Dropdown</span>
+          </button>
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+            <% if document.hold_requestable?(current_or_guest_user) %>
+            <%= link_to "Hold request", new_hold_request_path(hold_request: {mms_id: document.id, title: document['title_display_tesim']&.first}), class: "dropdown-item" %>
+            <% end %>
+            <% if document.one_step_doc_delivery?(@physical_holdings, current_or_guest_user) %>
+            <%= link_to "Request Article or Chapter", document.one_step_link, class: "dropdown-item" %>
+            <% end %>
+            <% if document.two_step_doc_delivery?(@physical_holdings, current_or_guest_user) %>
+            <%= link_to "Request Article or Chapter", "#", class: "dropdown-item", data: {toggle: "modal", target: "#two-step-illiad"} %>
+            <% end %>
+            <% if document.special_collections_requestable?(current_or_guest_user) %>
+            <%= link_to "Request from Special Collections", document.special_collections_url, class: "dropdown-item" %>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
-    %>
+    <% end %>
   </div>
   <% if Flipflop.enable_requesting_using_api? %>
-    <% if document.physical_holdings&.any? %>
+    <% if @physical_holdings&.any? %>
       <div class="table-responsive">
         <table class="table">
           <thead>
@@ -61,7 +59,7 @@
             </tr>
           </thead>
           <tbody>
-            <% document.physical_holdings.each.with_index(1) do |holding, index| %>
+            <% @physical_holdings.each.with_index(1) do |holding, index| %>
               <tr id="physical-holding-<%= index.to_s %>" class="d-flex">
                 <td class="col-sm-4">
                   <%= holding[:library][:label] %>
@@ -113,8 +111,8 @@
           </tbody>
         </table>
       </div>
-      <% if document.two_step_doc_delivery?(document.physical_holdings, current_or_guest_user) %>
-        <%= render 'two_step_illiad_modal', document: document, physical_holdings: document.physical_holdings %>
+      <% if document.two_step_doc_delivery?(@physical_holdings, current_or_guest_user) %>
+        <%= render 'two_step_illiad_modal', document: document, physical_holdings: @physical_holdings %>
       <% end %>
     <% end %>
     <% if document.online_holdings&.any? %>

--- a/config/initializers/catalog_show_override.rb
+++ b/config/initializers/catalog_show_override.rb
@@ -8,6 +8,7 @@ CatalogController.class_eval do
     deprecated_response, @document = search_service.fetch(params[:id])
     @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_response, 'The @response instance variable is deprecated; use @document.response instead.')
     @documents_availability = AlmaAvailabilityService.new([@document.id]).availability_of_documents
+    @physical_holdings = @document.physical_holdings(current_or_guest_user) if Flipflop.enable_requesting_using_api?
     respond_to do |format|
       format.html { @search_context = setup_next_and_previous_documents }
       format.json

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -345,6 +345,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
 
     context 'displaying availability badges show page' do
       before do
+        allow(Flipflop).to receive(:enable_requesting_using_api?).and_return(false)
         delete_all_documents_from_solr
         build_solr_docs(TEST_ITEM.merge(id: '990005988630302486'))
         visit solr_document_path('990005988630302486')


### PR DESCRIPTION
Restore request dropdown that allows users to submit hold requests using the ALMA API, as well as "Request Article or Chapter" and "Request from Special Collections". The feature is still being the feature toggle `enable_requesting_using_api`. This is a feature intended for v2 of the Blacklight catalog project.

![Screen Shot 2021-12-02 at 4 34 01 PM](https://user-images.githubusercontent.com/13107510/144506766-edf8a3a9-ef9a-4451-86c7-93f7cb1d80bd.png)


