### PR TITLE
Reworks Availability Sections (#1096).

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_results_list.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_results_list.scss
@@ -151,7 +151,7 @@ li.loading-avail-badge span {
   margin-right: 1em;
 }
 
-.btn.rounded-0.mb-2.phys-avail-label, .btn.rounded-0.mb-2.online-avail-label { 
+.btn.rounded-0.phys-avail-label, .btn.rounded-0.mb-2.online-avail-label { 
   cursor:    default;
   font-size: $results-button-label-font-size;
   padding:   $results-button-label-padding;
@@ -162,3 +162,13 @@ li.loading-avail-badge span {
 .avail-label { margin-top: $results-avail-label-maring-top; }
 
 .avail-label, .avail-dd { padding-top: map-get($spacers, 3);}
+
+.service-page-link { width: 100% }
+
+.show-all-avail-checkbox {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 16px;
+  margin-top: 11px;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -143,7 +143,6 @@ class CatalogController < ApplicationController
       helper_method: :multiple_values_new_line)
     config.add_index_field 'format_ssim', label: 'Type'
     config.add_index_field 'edition_tsim', label: 'Edition', helper_method: :multiple_values_new_line
-    config.add_index_field 'local_call_number_tesim', label: 'Call Number', helper_method: :multiple_sorted_values_new_line
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -154,7 +153,6 @@ class CatalogController < ApplicationController
       helper_method: :multiple_values_new_line)
     config.add_show_field 'format_ssim', label: 'Type', helper_method: :multiple_values_new_line
     config.add_show_field 'edition_tsim', label: 'Edition', helper_method: :multiple_values_new_line
-    config.add_show_field 'local_call_number_tesim', label: 'Call Number', helper_method: :multiple_sorted_values_new_line
     #   Where to find it section
     config.add_show_field 'url_fulltext_ssm', label: 'Full Text Access', helper_method: :multiple_values_new_line
     #   Additional/Related Title Information Section

--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+module AvailabilityHelper
+  def render_physical_avail_spans(avail_values, mms_id)
+    return if avail_values[:physical_holdings].blank?
+    status = get_phys_avail_status(avail_values)
+    label = phys_label_span(status)
+    table_toggle_anchor = table_toggle_anch(mms_id)
+    dt = tag.span(table_toggle_anchor, class: "phys-avail-button")
+
+    safe_join([label, dt])
+  end
+
+  def phys_label_span(status)
+    avail_class = get_avail_class(status)
+    tag.span(status, class: "btn rounded-0 phys-avail-label #{avail_class}")
+  end
+
+  def table_toggle_anch(mms_id)
+    tag.a('LOCATE',
+            href: "#avail-#{mms_id}-toggle",
+            data: { toggle: "collapse" },
+            class: "btn btn-md rounded-0 btn-outline-primary avail-link-el")
+  end
+
+  def get_phys_avail_status(avail_values)
+    avail_num = avail_count(avail_values)
+    if avail_num.size > 1
+      '1+ Available'
+    elsif avail_num.size == 1
+      'Available'
+    elsif show_check_holdings?(avail_values, avail_num)
+      'Check Holdings'
+    else
+      'Not Available'
+    end
+  end
+
+  def get_avail_class(status)
+    case status
+    when "Check Holdings"
+      'avail-unknown'
+    when "Available", "1+ Available"
+      'avail-success'
+    else
+      'avail-danger'
+    end
+  end
+
+  def avail_count(avail_values)
+    avail_values[:physical_holdings].select { |ph| ph[:status] == 'available' }
+  end
+
+  def show_check_holdings?(avail_values, avail_num)
+    avail_num.size.zero? &&  avail_values[:physical_holdings].any? { |ph| ph[:status] == 'check_holdings' }
+  end
+
+  def raw_status_to_label(status)
+    case status
+    when 'available'
+      "Available"
+    when 'unavailable'
+      "Not Available"
+    when 'check_holdings'
+      "Check Holdings"
+    else
+      "Not Available"
+    end
+  end
+
+  def render_online_link_span(mms_id)
+    tag.span(online_modal_link(mms_id), class: "online-avail-button")
+  end
+
+  def online_modal_link(mms_id)
+    tag.a("CONNECT", href: "#", data: { toggle: 'modal', target: "#avail-modal-#{mms_id}" }, class: "btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el")
+  end
+end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -58,7 +58,7 @@ module CatalogHelper
   end
 
   def availability_present?(doc_avail_values, document)
-    doc_avail_values[:physical_exists] &&
+    doc_avail_values[:physical_holdings].present? &&
       (doc_avail_values[:online_available] || document.url_fulltext.present?)
   end
 

--- a/app/helpers/search_results_helper.rb
+++ b/app/helpers/search_results_helper.rb
@@ -40,35 +40,6 @@ module SearchResultsHelper
     state
   end
 
-  def render_physical_avail_spans(avail_values, service_page_link)
-    return unless avail_values[:physical_exists]
-    status = get_phys_avail_status(avail_values)
-    label = phys_label_span(status)
-    service_page_anchor = serv_page_anch(status, service_page_link)
-    dt = tag.span(service_page_anchor, class: "phys-avail-button")
-
-    safe_join([label, dt])
-  end
-
-  def phys_label_span(status)
-    avail_class = get_avail_class(status)
-    tag.span(status, class: "btn rounded-0 mb-2 phys-avail-label #{avail_class}")
-  end
-
-  def serv_page_anch(status, service_page_link)
-    tag.a("#{'LOCATE/' unless status == 'Not Available'}REQUEST",
-           href: service_page_link, target: '_blank', rel: 'noopener noreferrer',
-           class: 'btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el')
-  end
-
-  def render_online_link_span(mms_id)
-    tag.span(online_modal_link(mms_id), class: "online-avail-button")
-  end
-
-  def online_modal_link(mms_id)
-    tag.a("CONNECT", href: "#", data: { toggle: 'modal', target: "#avail-modal-#{mms_id}" }, class: "btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el")
-  end
-
   def processed_facet(letter_state, letter)
     return letter_state['f'].merge('title_main_first_char_ssim': [letter]) if letter_state['f'].present?
     { 'title_main_first_char_ssim': [letter] }
@@ -77,26 +48,5 @@ module SearchResultsHelper
   def processed_facet_ejournals(letter_state, letter)
     return letter_state['f'].merge('title_main_first_char_ssim': [letter]) if letter_state['f'].present?
     { 'title_main_first_char_ssim': [letter], 'marc_resource_ssim': ["Online"], 'format_ssim': ["Journal, Newspaper or Serial"] }
-  end
-
-  def get_phys_avail_status(avail_values)
-    if avail_values[:physical_check_holdings]
-      'Check Holdings'
-    elsif avail_values[:physical_available]
-      'Available'
-    else
-      'Not Available'
-    end
-  end
-
-  def get_avail_class(status)
-    case status
-    when "Check Holdings"
-      'avail-unknown'
-    when "Available"
-      'avail-success'
-    else
-      'avail-danger'
-    end
   end
 end

--- a/app/views/catalog/_availability_indicator.html.erb
+++ b/app/views/catalog/_availability_indicator.html.erb
@@ -1,22 +1,13 @@
 <% service_page_link = service_page_url(document.id) %>
 
 <dd class="avail-dd col-md-9" id="availability-indicator-<%= document.id %>">
-    <% if doc_avail_values.present? %>
-      <%= render_physical_avail_spans(doc_avail_values, service_page_link) %>
-      <%= tag('br') if availability_present?(doc_avail_values, document) %>
-      <% if doc_avail_values[:online_available] || document.url_fulltext.present? %>
-        <%= tag.span('Online', class: "btn rounded-0 mb-2 online-avail-label avail-default") %>
-        <% if !doc_avail_values[:online_available] %>
-          <%= render_online_link_span(document.id) %>
-          <%= render 'shared/document_url_fulltext_modal', document: document %>
-        <% else %>
-          <span class="online-avail-button">
-            <%= link_to('CONNECT', service_page_link, 
-                  target: "_blank", class: "btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el") %>
-          </span>
-        <% end %>
-      <% end %>
-    <% else %>
-      <span class="btn rounded-0 mb-2 phys-avail-label avail-danger">Unknown</span>
-    <% end %>
+  <%= render 'catalog/availability/badges', 
+        document: document, 
+        doc_avail_values: doc_avail_values, 
+        service_page_link: service_page_link %>
+  <%= render 'catalog/availability/table', 
+        document: document, 
+        doc_avail_values: doc_avail_values, 
+        service_page_link: service_page_link %>
 </dd>
+

--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -8,19 +8,14 @@
     </div>
     <% if !Flipflop.enable_requesting_using_api? && doc_avail_values.present? %>
       <div class="col-12">
-        <%= render_physical_avail_spans(doc_avail_values, service_page_link) %>
-        <%= tag('br') if availability_present?(doc_avail_values, document) %>
-        <% if doc_avail_values[:online_available] || document.url_fulltext.present? %>
-          <span class="btn rounded-0 mb-2 online-avail-label avail-default">Online</span>
-          <% if !doc_avail_values[:online_available] %>
-            <%= render_online_link_span(document.id) %>
-            <%= render 'shared/document_url_fulltext_modal', document: document %>
-          <% else %>
-            <span class="online-avail-button">
-              <%= link_to "CONNECT", service_page_link, target: "_blank", class: "btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el" %>
-            </span>
-          <% end %>
-        <% end %>
+        <%= render 'catalog/availability/badges', 
+              document: document, 
+              doc_avail_values: doc_avail_values, 
+              service_page_link: service_page_link %>
+        <%= render 'catalog/availability/table', 
+              document: document, 
+              doc_avail_values: doc_avail_values, 
+              service_page_link: service_page_link %>
       </div>
     <% end %>
     <% if Flipflop.enable_requesting_using_api? %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,0 +1,15 @@
+<%# Overrides partial of same name from blacklight (7.4.1) %>
+<%#
+  Inserts a checkbox to collapse/expand all availability for page.
+%>
+<div id="sortAndPerPage" class="sort-pagination clearfix">
+  <%= render partial: "paginate_compact", object: @response if show_pagination? %>
+  <% if @document_ids.present? %>
+    <div class="show-all-avail-checkbox">
+        <label data-toggle="collapse" data-target="<%= safe_join(@document_ids.map { |id| "#avail-#{id}-toggle" }, ',') %>">
+            <input type="checkbox"/> Show Locations
+        </label>
+    </div>
+  <% end %>
+  <%= render_results_collection_tools wrapping_class: "search-widgets float-md-right" %>
+</div>

--- a/app/views/catalog/availability/_badges.html.erb
+++ b/app/views/catalog/availability/_badges.html.erb
@@ -1,0 +1,18 @@
+<% if doc_avail_values.present? %>
+  <% if doc_avail_values[:online_available] || document.url_fulltext.present? %>
+    <%= tag.span('Online', class: "btn rounded-0 mb-2 online-avail-label avail-default") %>
+    <% if !doc_avail_values[:online_available] %>
+      <%= render_online_link_span(document.id) %>
+      <%= render 'shared/document_url_fulltext_modal', document: document %>
+    <% else %>
+      <span class="online-avail-button">
+        <%= link_to('CONNECT', service_page_link, 
+              target: "_blank", class: "btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el") %>
+      </span>
+    <% end %>
+  <% end %>
+  <%= tag('br') if availability_present?(doc_avail_values, document) %>
+  <%= render_physical_avail_spans(doc_avail_values, document.id) %>
+<% else %>
+  <span class="btn rounded-0 mb-2 phys-avail-label avail-danger">Unknown</span>
+<% end %>

--- a/app/views/catalog/availability/_table.html.erb
+++ b/app/views/catalog/availability/_table.html.erb
@@ -1,0 +1,30 @@
+<span id="avail-<%= document.id %>-toggle" class="collapse">
+  <div class="table-responsive-sm">
+    <table class="table table-bordered">
+      <thead>
+        <tr class="table-primary">
+          <th scope="col" class="col-sm-6">Library Location</th>
+          <th scope="col" class="col-sm-3">Call Number</th>
+          <th scope="col" class="col-sm-3">Availability</th>
+        </tr>
+      </thead>
+      <% doc_avail_values[:physical_holdings].each do |ph| %>
+        <tr>
+          <td class="col-sm-6">
+            <%= ph[:lib_location].present? ? "#{ph[:library]}: #{ph[:lib_location]}" : ph[:library] %>
+          </td>
+          <td class="col-sm-3"><%= ph[:call_number] %></td>
+          <td class="col-sm-3"><%= phys_label_span(raw_status_to_label(ph[:status])) %></td>
+        </tr>
+      <% end %>
+      <tr>
+        <td colspan='3'>
+          <span class="service-page-button">
+            <%= link_to('LOCATE/REQUEST THIS ITEM >>', service_page_link, 
+              target: "_blank", class: "btn btn-md rounded-0 mb-2 btn-primary service-page-link") %>
+          </span>
+        </td>
+      </tr>
+    </table>
+  </div>
+</span>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe CatalogController, type: :controller do
         .index_fields.keys
     end
     let(:expected_index_fields) do
-      [
-        'author_display_ssim', 'format_ssim', 'publication_main_display_ssim', 'edition_tsim',
-        'local_call_number_tesim'
-      ]
+      ['author_display_ssim', 'format_ssim', 'publication_main_display_ssim', 'edition_tsim']
     end
     let(:field_title) { controller.blacklight_config.index.title_field }
 
@@ -31,7 +28,7 @@ RSpec.describe CatalogController, type: :controller do
     end
     let(:expected_show_fields) do
       ['author_display_ssim', 'language_ssim', 'isbn_ssim', 'id', 'title_addl_tesim',
-       'title_varying_tesim', 'edition_tsim', 'local_call_number_tesim', 'material_type_display_tesim',
+       'title_varying_tesim', 'edition_tsim', 'material_type_display_tesim',
        'note_general_tsim', 'publication_main_display_ssim', 'format_ssim', 'title_abbr_tesim',
        'title_added_entry_tesim', 'title_series_ssim', 'title_translation_tesim', 'author_addl_display_tesim',
        'genre_ssim', 'subject_display_ssim', 'url_suppl_ssim', 'issn_ssim', 'oclc_ssim',

--- a/spec/services/alma_availability_service_spec.rb
+++ b/spec/services/alma_availability_service_spec.rb
@@ -24,35 +24,56 @@ RSpec.describe AlmaAvailabilityService, alma: true do
     it 'returns the correct response #1' do
       expect(service.availability_of_documents).to eq(
         { "990005988630302486" =>
-          { online_available: false, physical_available: true,
-            physical_check_holdings: false, physical_exists: true } }
+          { online_available: false, physical_holdings: [
+            { call_number: "PT2613 .M45 Z92 2006", lib_location: "",
+              library: "Library Service Center", status: "available" }
+          ] } }
       )
     end
 
     it 'returns the correct response #2' do
       expect(service2.availability_of_documents).to eq(
         { "990005059530302486" =>
-          { online_available: false, physical_available: true,
-            physical_check_holdings: false, physical_exists: true } }
+          { online_available: false, physical_holdings: [
+            { call_number: "PS3505 .R43 H4 1976 DANOWSKI", lib_location: "Locked Stacks",
+              library: "Stuart A. Rose Manuscript, Archives, and Rare Book Library",
+              status: "available" },
+            { call_number: "PS3505 .R43 H4 1976 EDELSTEIN", lib_location: "Locked Stacks",
+              library: "Stuart A. Rose Manuscript, Archives, and Rare Book Library", status: "available" }
+          ] } }
       )
     end
 
     it 'returns the correct response #3' do
       expect(service3.availability_of_documents).to eq(
         { "990005059530302486" =>
-          { online_available: false, physical_available: true,
-            physical_check_holdings: false, physical_exists: true },
+          { online_available: false, physical_holdings: [
+            { call_number: "PS3505 .R43 H4 1976 DANOWSKI", lib_location: "Locked Stacks",
+              library: "Stuart A. Rose Manuscript, Archives, and Rare Book Library",
+              status: "available" },
+            { call_number: "PS3505 .R43 H4 1976 EDELSTEIN", lib_location: "Locked Stacks",
+              library: "Stuart A. Rose Manuscript, Archives, and Rare Book Library",
+              status: "available" }
+          ] },
           "990005988630302486" =>
-          { online_available: false, physical_available: true,
-            physical_check_holdings: false, physical_exists: true } }
+          { online_available: false, physical_holdings: [
+            { call_number: "PT2613 .M45 Z92 2006", lib_location: "",
+              library: "Library Service Center", status: "available" }
+          ] } }
       )
     end
 
     it 'returns the correct response #4' do
       expect(service4.availability_of_documents).to eq(
         { "990027507910302486" =>
-          { online_available: false, physical_available: true,
-            physical_check_holdings: true, physical_exists: true } }
+          { online_available: false, physical_holdings: [
+            { call_number: "JA1 .R4", lib_location: "", library: "Library Service Center",
+              status: "available" },
+            { call_number: "JA1 .R4", lib_location: "Book Stacks", library: "Robert W. Woodruff Library",
+              status: "available" },
+            { call_number: "JA1 .R4", lib_location: "Current Periodicals", library: "Robert W. Woodruff Library",
+              status: "check_holdings" }
+          ] } }
       )
     end
   end

--- a/spec/system/bookmarks_page_spec.rb
+++ b/spec/system/bookmarks_page_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe 'Bookmarks page', type: :system, js: true do
+RSpec.describe 'Bookmarks page', :clean, type: :system, js: true do
   before do
     delete_all_documents_from_solr
     build_solr_docs([TEST_ITEM])
@@ -29,6 +29,7 @@ RSpec.describe 'Bookmarks page', type: :system, js: true do
       visit root_path
       click_on 'search'
       find('input#toggle-bookmark_123').set(true)
+      sleep 5
       visit bookmarks_path
 
       expect(page).to have_link('Export as RIS', href: '/export_multiple_ris/123')

--- a/spec/system/bookmarks_page_spec.rb
+++ b/spec/system/bookmarks_page_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe 'Bookmarks page', :clean, type: :system, js: true do
       visit root_path
       click_on 'search'
       find('input#toggle-bookmark_123').set(true)
-      sleep 5
       visit bookmarks_path
 
       expect(page).to have_link('Export as RIS', href: '/export_multiple_ris/123')

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -26,13 +26,13 @@ RSpec.feature 'View Search Results', type: :system, js: false do
     end
 
     it 'has the right metadata labels' do
-      ['Author/Creator:', 'Type:', 'Publication/Creation:', 'Edition:', 'Call Number:'].each do |label|
+      ['Author/Creator:', 'Type:', 'Publication/Creation:', 'Edition:'].each do |label|
         expect(page).to have_content(label)
       end
     end
 
     it 'has the right values' do
-      ['George Jenkins', 'Book', 'A dummy publication', 'A sample edition', 'MST .3000'].each do |value|
+      ['George Jenkins', 'Book', 'A dummy publication', 'A sample edition'].each do |value|
         expect(page).to have_content(value)
       end
     end
@@ -137,7 +137,9 @@ RSpec.feature 'View Search Results', type: :system, js: false do
       orig_key = ENV['ALMA_BIB_KEY']
       ENV['ALMA_API_URL'] = 'http://www.example.com'
       ENV['ALMA_BIB_KEY'] = "fakebibkey123"
+      Capybara.ignore_hidden_elements = false
       example.run
+      Capybara.ignore_hidden_elements = true
       ENV['ALMA_API_URL'] = api_url
       ENV['ALMA_BIB_KEY'] = orig_key
     end
@@ -146,13 +148,17 @@ RSpec.feature 'View Search Results', type: :system, js: false do
       expect(page).to have_selector(:id, 'availability-indicator-990005988630302486')
 
       within('#availability-indicator-990005988630302486') do
-        expect(page).to have_xpath('//span[1]', text: 'Available', class: 'btn rounded-0 mb-2 phys-avail-label avail-success')
-        expect(page).to have_xpath('//span[2]/a', text: 'LOCATE/REQUEST', class: 'btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el')
-        expect(page).to have_xpath('//span[3]', text: 'Online', class: 'btn rounded-0 mb-2 online-avail-label avail-default')
+        expect(page).to have_xpath('//span[1]', text: 'Online', class: 'btn rounded-0 mb-2 online-avail-label avail-default')
+        expect(page).to have_css('span', text: 'Available')
+        expect(page).to have_xpath('//span[4]/a', text: 'LOCATE', class: 'btn btn-md rounded-0 btn-outline-primary avail-link-el')
         expect(
           find('a.btn.btn-md.rounded-0.mb-2.btn-outline-primary.avail-link-el[data-target="#avail-modal-990005988630302486"]').present?
         ).to be_truthy
       end
+    end
+
+    it 'contains the span holding the table' do
+      expect(page).to have_css('span#avail-990005988630302486-toggle', class: 'collapse')
     end
   end
 

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
     context 'displaying metadata' do
       let(:expected_labels) do
         [
-          'Author/Creator:', 'Publication/Creation:', 'Type:', 'Edition:', 'Call Number:', 'Full Title:',
+          'Author/Creator:', 'Publication/Creation:', 'Type:', 'Edition:', 'Full Title:',
           'Series Titles:', 'Related/Included Titles:', 'Variant Titles:', 'Abbreviated Titles:',
           'Translated Titles:', 'Additional Author/Creators:', 'Genre:', 'Subjects:',
           'Language:', 'Physical Type/Description:', 'General Note:', 'Related Resources Link:',
@@ -49,7 +49,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
       end
       let(:expected_values) do
         [
-          "George JenkinsG. Jenkins", 'A dummy publication', 'A sample edition', 'MST .3000', 'Book',
+          "George JenkinsG. Jenkins", 'A dummy publication', 'A sample edition', 'Book',
           'More title info', 'The Jenkins Series', 'The Jenkins Story', 'Variant title',
           'Jenk. Story', 'Le Stori de Jenkins', 'Tim Jenkins', 'Genre example', 'Adventure--More Adventures.',
           'English', 'Short summary', '1 online resource (111 pages)', 'General note',
@@ -343,7 +343,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
       end
     end
 
-    context 'displaying availability badges show page' do
+    context 'displaying availability on show page' do
       before do
         allow(Flipflop).to receive(:enable_requesting_using_api?).and_return(false)
         delete_all_documents_from_solr
@@ -352,14 +352,24 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
       end
 
       it 'shows the right badges and links' do
-        find('.phys-avail-label').should have_content('Available')
+        find_all('span.phys-avail-label').first.should have_content('Available')
         find('.online-avail-label').should have_content('Online')
         expect(page).to have_link(
-          'LOCATE/REQUEST', class: 'btn btn-md rounded-0 mb-2 btn-outline-primary avail-link-el'
+          'LOCATE', class: 'btn btn-md rounded-0 btn-outline-primary avail-link-el'
         )
         expect(
           find('a.btn.btn-md.rounded-0.mb-2.btn-outline-primary.avail-link-el[data-target="#avail-modal-990005988630302486"]').present?
         ).to be_truthy
+      end
+
+      around do |example|
+        Capybara.ignore_hidden_elements = false
+        example.run
+        Capybara.ignore_hidden_elements = true
+      end
+
+      it 'contains the span holding the table' do
+        expect(page).to have_css('span#avail-990005988630302486-toggle', class: 'collapse')
       end
     end
   end


### PR DESCRIPTION
- app/assets/stylesheets/blacklight_catalog/_results_list.scss: corrects style of surrounding elements for new table.
- app/controllers/catalog_controller.rb: removes call number display in both show and index.
- app/helpers/availability_helper.rb: institutes another helper module to group methods into a more precise use case.
- app/helpers/catalog_helper.rb: swaps hash test to new key.
- app/helpers/search_results_helper.rb: extracts methods to a more aptly named module.
- app/services/alma_availability_service.rb: refactors class to reduce size of method and includes new logic that iterates over multiple `AVA` fields.
- app/views/catalog/_availability_indicator.html.erb and app/views/catalog/_show_request_options.html.erb: removes repeated html and calls newly created partials.
- app/views/catalog/_sort_and_per_page.html.erb: brings in partial from Blacklight as override so that "show all" checkbox can be live in element.
- app/views/catalog/availability/_badges.html.erb and app/views/catalog/availability/_table.html.erb: creates partials for the reused, modified html that populates the badge/link and collapsible table.
- spec/*: updates spec to new expectations.

https://user-images.githubusercontent.com/18330149/144859807-ab6ccd37-8d34-47fe-88d5-5e114ca3008b.mov



