### PR TITLE
Creates service page link for no physical items but bound with (#1097).

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_results_list.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_results_list.scss
@@ -152,7 +152,7 @@ li.loading-avail-badge span {
 }
 
 .btn.rounded-0.phys-avail-label, .btn.rounded-0.mb-2.online-avail-label { 
-  cursor:    default;
+  cursor:    default !important;
   font-size: $results-button-label-font-size;
   padding:   $results-button-label-padding;
 }
@@ -172,3 +172,5 @@ li.loading-avail-badge span {
   padding: 0 16px;
   margin-top: 11px;
 }
+
+.bound-with-link{ margin-left: -0.25rem;}

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -41,4 +41,8 @@ class SolrDocument
   def more_options
     self['format_ssim']
   end
+
+  def bound_with?
+    self['bound_with_display_ssim'].present?
+  end
 end

--- a/app/views/catalog/availability/_badges.html.erb
+++ b/app/views/catalog/availability/_badges.html.erb
@@ -16,7 +16,8 @@
     <%= phys_label_span('Check Holdings') %>
     <%= tag.span(
           tag.a('LOCATE/REQUEST', href: service_page_link, target: '_blank',
-            class: "btn btn-md rounded-0 btn-outline-primary avail-link-el"),
+            class: "btn btn-md rounded-0 btn-outline-primary avail-link-el",
+            rel: 'noopener noreferrer'),
           class: "phys-avail-button bound-with-link"
         ) %>
   <% else %>

--- a/app/views/catalog/availability/_badges.html.erb
+++ b/app/views/catalog/availability/_badges.html.erb
@@ -11,8 +11,18 @@
       </span>
     <% end %>
   <% end %>
-  <%= tag('br') if availability_present?(doc_avail_values, document) %>
-  <%= render_physical_avail_spans(doc_avail_values, document.id) %>
+  <% if doc_avail_values[:physical_holdings].empty? && document.bound_with? %>
+    <%= tag('br') if doc_avail_values[:online_available] || document.url_fulltext.present? %>
+    <%= phys_label_span('Check Holdings') %>
+    <%= tag.span(
+          tag.a('LOCATE/REQUEST', href: service_page_link, target: '_blank',
+            class: "btn btn-md rounded-0 btn-outline-primary avail-link-el"),
+          class: "phys-avail-button bound-with-link"
+        ) %>
+  <% else %>
+    <%= tag('br') if availability_present?(doc_avail_values, document) %>
+    <%= render_physical_avail_spans(doc_avail_values, document.id) %>
+  <% end %>
 <% else %>
   <span class="btn rounded-0 mb-2 phys-avail-label avail-danger">Unknown</span>
 <% end %>


### PR DESCRIPTION
- app/assets/stylesheets/blacklight_catalog/_results_list.scss: styles badges.
- app/models/solr_document.rb: provides presence of bound with test.
- app/views/catalog/availability/_badges.html.erb: adds logic and html to deliver badge and link.
<img width="1390" alt="Screen Shot 2021-12-06 at 4 09 53 PM" src="https://user-images.githubusercontent.com/18330149/144923075-70f5c471-9e77-44ea-8a9c-fcabfb190dfa.png">

