### PR TITLE
Restrict app profiling to development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'omniauth-shibboleth', '~> 1.3'
 gem 'openurl'
 gem 'puma', '~> 3.7'
 gem 'qa'
-gem 'rack-mini-profiler'
 gem 'rails', '~> 5.1.7'
 gem 'rest-client'
 gem 'rsolr', '>= 1.0'
@@ -38,7 +37,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'secure_headers'
 gem 'simple_form' # For database authentication page from Devise
 gem 'sqlite3'
-gem 'stackprof'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'uglifier', '>= 1.3.0'
 gem 'whenever', require: false
@@ -68,8 +66,10 @@ group :development do
   gem 'capistrano-rails', '~> 1.6', require: false
   gem 'capistrano-yarn'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'rack-mini-profiler'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'stackprof'
   gem 'web-console', '>= 3.3.0'
   gem 'xray-rails'
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,6 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  before_action do
-    Rack::MiniProfiler.authorize_request unless ENV['BLACKLIGHT_BASE_URL'] == 'https://search.libraries.emory.edu'
-  end
-
   def guest_uid_authentication_key(key)
     guest_email_authentication_key(key)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,5 @@ module BlacklightCatalog
 
     config.exceptions_app = routes
     config.autoload_paths += %W[#{config.root}/app/loggers lib/traject]
-
-    Rack::MiniProfiler.config.authorization_mode = :allow_authorized
   end
 end


### PR DESCRIPTION
After changes made to speed up the index page, we no longer need app profiling in Test and Arch.