### PR TITLE
Includes field 940 into librarian view (#1115).

### DIFF
--- a/app/views/catalog/_marc_view.html.erb
+++ b/app/views/catalog/_marc_view.html.erb
@@ -1,0 +1,31 @@
+<%# Overwrite of BlacklightMarc 7.0.0 partial of same name. Removes exclusion of 940 field in library view. %>
+<div id="marc_view" class="modal-body">
+  <% fields = document.to_marc.find_all{|f| ('000'..'999') === f.tag }  %>
+  <div class="field"><%= t('blacklight.search.librarian_view.leader', :leader => document.to_marc.leader) %></div>
+  <%- fields.each do |field| -%>
+    <div class="field">
+      <div class="tag_ind">
+        <span class="tag">
+          <%= h(field.tag) %>
+        </span>
+      <%- if field.is_a?(MARC::ControlField) -%>
+        <span class="control_field_values">
+          <%= h(field.value) %>
+        </span>
+      <%- else -%>
+        <div class="ind1">
+          <%= !field.indicator1.blank? ? field.indicator1 : "&nbsp;".html_safe -%>
+        </div>
+        <div class="ind2">
+          <%= !field.indicator2.blank? ? field.indicator2 : "&nbsp;".html_safe -%>
+        </div>
+      </div>
+      <div class="subfields">
+        <%- field.each do |sub| -%>
+        <span class="sub_code"><%= h(sub.code) %>|</span> <%= h(sub.value) %>
+      <%- end -%>
+      <%- end -%>
+      </div>
+    </div>
+  <%- end -%>
+</div>


### PR DESCRIPTION
<img width="1057" alt="Screen Shot 2021-12-08 at 3 47 17 PM" src="https://user-images.githubusercontent.com/18330149/145282006-21754cd9-c954-4cad-bb01-4d3b7d97c494.png">
