### PR TITLE
Removes the spellcheck suggestions from blank search result (#1119).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -433,7 +433,7 @@ class CatalogController < ApplicationController
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
-    config.spell_max = 0
+    config.spell_max = -1
 
     # Configuration for autocomplete suggestor
     config.autocomplete_enabled = true

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -114,13 +114,13 @@ RSpec.feature 'View Search Results', type: :system, js: false do
   end
 
   context 'spellcheck suggestions', js: true do
-    it 'shows suggestions only when no results are found' do
+    it 'does not show suggestions when no results are found' do
       # blank search will return our test item in the search results, therefore, no suggestions will be displayed
       expect(page).not_to have_content 'Did you mean'
       fill_in 'q', with: '1234'
       click_on 'search'
       # above search will return no results, therefore, suggestions will be displayed
-      expect(page).to have_content 'Did you mean'
+      expect(page).not_to have_content 'Did you mean'
     end
   end
 


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: sets to negative one, effectively turning off suggestions.
- spec/system/view_search_results_spec.rb: changes expectations to not seeing suggestions.
<img width="1768" alt="Screen Shot 2021-12-09 at 10 31 31 AM" src="https://user-images.githubusercontent.com/18330149/145425981-1be46630-f348-4c37-a290-85f1c64a146d.png">

