### PR TITLE
Replaces Author limiter label with more appropriate verbiage (#1134).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -82,6 +82,7 @@ class CatalogController < ApplicationController
     # When users venture away from the homepage, the full list of facets will
     # be available to them. Any field listed below will appear on the homepage facets.
     config.homepage_facet_fields = ['marc_resource_ssim', 'library_ssim', 'format_ssim', 'language_ssim']
+    config.suppressed_facet_fields = ['title_main_first_char_ssim', 'author_display_ssim']
     config.truncate_field_values = [
       'table_of_contents_tesim', 'summary_tesim', 'note_publication_tesim', 'note_publication_dates_tesim',
       'note_language_tesim', 'note_accessibility_tesim', 'note_production_tesim', 'material_type_display_tesim',
@@ -129,6 +130,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_geo_ssim', label: 'Region', limit: 5, index_range: true
     config.add_facet_field 'subject_era_ssim', label: 'Era', limit: 5, index_range: [*(0..2), *('A'..'Z')]
     config.add_facet_field 'genre_ssim', label: 'Genre', limit: 5, index_range: true
+    config.add_facet_field 'author_display_ssim', label: 'Author', limit: 5
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -1,6 +1,6 @@
 <% # Override of BlacklLight 7.4.1 -%>
 <% # main container for facets/limits menu -%>
-<% page_specific_field_names = request.fullpath == '/' ? blacklight_config.homepage_facet_fields : facet_field_names(groupname) - ["title_main_first_char_ssim"] %>
+<% page_specific_field_names = request.fullpath == '/' ? blacklight_config.homepage_facet_fields : facet_field_names(groupname) - blacklight_config.suppressed_facet_fields %>
 <% if has_facet_values? facet_field_names(groupname), @response %>
 <div id="facets<%= "-#{groupname}" unless groupname.nil? %>" class="facets sidenav facets-toggleable-md <%= "facet-home" if request.fullpath == "/" %>">
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -59,9 +59,10 @@ RSpec.describe CatalogController, type: :controller do
     let(:expected_facet_fields) do
       ["author_ssim", "format_ssim", "language_ssim", "marc_resource_ssim",
        "subject_era_ssim", "subject_geo_ssim", "subject_ssim", "library_ssim",
-       "collection_ssim", "genre_ssim", "pub_date_isim", "lc_1letter_ssim", "title_main_first_char_ssim"]
+       "collection_ssim", "genre_ssim", "pub_date_isim", "lc_1letter_ssim", "title_main_first_char_ssim", "author_display_ssim"]
     end
     let(:homepage_facet_fields) { controller.blacklight_config.homepage_facet_fields }
+    let(:suppressed_facet_fields) { controller.blacklight_config.suppressed_facet_fields }
 
     context 'homepage facet fields' do
       it do
@@ -69,6 +70,10 @@ RSpec.describe CatalogController, type: :controller do
           ['marc_resource_ssim', 'library_ssim', 'format_ssim', 'language_ssim']
         )
       end
+    end
+
+    context 'suppressed facet fields' do
+      it { expect(suppressed_facet_fields).to eq(['title_main_first_char_ssim', 'author_display_ssim']) }
     end
 
     it { expect(facet_fields).to contain_exactly(*expected_facet_fields) }

--- a/spec/system/view_search_results_spec.rb
+++ b/spec/system/view_search_results_spec.rb
@@ -94,6 +94,16 @@ RSpec.feature 'View Search Results', type: :system, js: false do
          'Publication/Creation Date']
       )
     end
+
+    context 'when author facet link clicked' do
+      it 'lists the right limiter text' do
+        find('.blacklight-author_display_ssim.col-md-9 a', text: 'George Jenkins').click
+
+        expect(page).to have_css('span.filter-name', text: 'Author')
+        expect(page).not_to have_css('span.filter-name', text: 'Author Display Ssim')
+        expect(page).to have_css('span.filter-value[title="George Jenkins"]')
+      end
+    end
   end
 
   context 'A-Z facet navigation' do


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: creates a config variable containing solr fields that shouldn't be displayed in facet group, and adds facet field `author_display_ssim` to tweak the label.
- app/views/catalog/_facet_group.html.erb: points the suppressed fields array to the config variable for ease of future suppression.
- spec/*: sets expectations for new field suppression.
<img width="1424" alt="Screen Shot 2021-12-14 at 10 23 14 AM" src="https://user-images.githubusercontent.com/18330149/146027148-6082bb20-4958-425f-87f8-23fa0d2358ef.png">

