### PR TITLE
Refines the Contact Us availability badge display logic (#1097).

### DIFF
--- a/app/views/catalog/availability/_badges.html.erb
+++ b/app/views/catalog/availability/_badges.html.erb
@@ -1,4 +1,4 @@
-<% holdings_available = doc_avail_values.present? && (doc_avail_values[:online_available] || document.url_fulltext.present? || doc_avail_values[:physical_holdings].any?) %>
+<% holdings_available = doc_avail_values.present? && (doc_avail_values[:online_available] || document.url_fulltext.present? || doc_avail_values[:physical_holdings].any? || document['bound_with_display_ssim'].present?) %>
 
 <% if holdings_available %>
   <% if doc_avail_values[:online_available] || document.url_fulltext.present? %>


### PR DESCRIPTION
Adds the presence of bound with field as holdings available
<img width="1012" alt="Screen Shot 2021-12-16 at 12 50 58 PM" src="https://user-images.githubusercontent.com/18330149/146423171-8bfa2fb3-c1ab-47d4-a3c9-157547d3afdf.png">
.