### PR TITLE
Redirects to a blank search results page with overlay when search returns nothing (#1146).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ Metrics/MethodLength:
         - 'lib/traject/extract_publication_date.rb'
         - 'app/controllers/sessions/social_login.rb'
         - 'config/initializers/bookmarks_index_override.rb'
+        - 'config/initializers/catalog_index_override.rb'
 
 Metrics/ModuleLength:
     Exclude:

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,8 +1,8 @@
 <%# Override of Blacklight v7.4.1 partial of same name; %>
- <% if !request.fullpath.include?('/advanced') %>
- <div class="col-12">
-   <h3 class="header-search">Search books, e-books, journals, videos and more</h2>
- </div>
+<% if !request.fullpath.include?('empty=true') && !request.fullpath.include?('/advanced') %>
+  <div class="col-12">
+    <h3 class="header-search">Search books, e-books, journals, videos and more</h2>
+  </div>
   <div class="navbar-search navbar navbar-light mb-12 p-0" role="navigation">
     <div class="<%= container_classes %>">
       <%= render_search_bar  %>
@@ -10,7 +10,19 @@
   </div>
   <div class="col-12">
     <p>For help in searching the Catalog, try our <a href="https://wiki.emory.edu/display/BDL/How-to+articles">Search Tips</a>.<br>
-      For additional assistance, please <a href="https://emory.libanswers.com/">Ask a Librarian</a>.<br>
-      Or <a href="/contact">send us comments or suggestions</a> that may help us improve the catalog.</p>
+    For additional assistance, please <a href="https://emory.libanswers.com/">Ask a Librarian</a>.<br>
+    Or <a href="/contact">send us comments or suggestions</a> that may help us improve the catalog.</p>
   </div>
+<% elsif request.fullpath.include?('empty=true') && !request.fullpath.include?('/advanced') %>
+  <div class="page-links"><span class="page-entries"> No entries found </span></div>
+  <h2>No results found for your search</h2>
+  <div id="documents" class="noresults">
+    <h3>Try modifying your search</h3>
+    <ul>
+      <li>Please also try your search in 
+        <a href="https://emory.primo.exlibrisgroup.com/discovery/search?vid=01GALI_EMORY:articles" target="_blank" rel="noopener noreferrer">Articles + </a>. Please 
+        <a href="https://emory.libanswers.com/" target="_blank" rel="noopener noreferrer">Ask A Librarian</a> if additional assistance is needed.</li>
+    </ul>
+  </div>
+  <%= render('catalog/other_resources/card', url: articles_plus_url, new_page: true, url_text: 'Articles+') %>
 <% end %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -47,8 +47,8 @@
     </div>
 
     <% if request.fullpath == "/" %>
-    <%= render partial: 'catalog/other_resources/cards' %>
-    <%= render partial: 'catalog/other_resources/accordions' %>
+      <%= render partial: 'catalog/other_resources/cards' %>
+      <%= render partial: 'catalog/other_resources/accordions' %>
     <% end %>
 
   </main>

--- a/config/initializers/catalog_index_override.rb
+++ b/config/initializers/catalog_index_override.rb
@@ -9,16 +9,20 @@ CatalogController.class_eval do
     @document_list = @response.documents
     @document_ids = @response.documents&.map(&:id) || []
 
-    respond_to do |format|
-      format.html { store_preferred_view }
-      format.rss  { render layout: false }
-      format.atom { render layout: false }
-      format.json do
-        @presenter = Blacklight::JsonPresenter.new(@response,
-                                                   blacklight_config)
+    if @document_list.empty?
+      redirect_to "/?empty=true&search_term=#{params[:q]}"
+    else
+      respond_to do |format|
+        format.html { store_preferred_view }
+        format.rss  { render layout: false }
+        format.atom { render layout: false }
+        format.json do
+          @presenter = Blacklight::JsonPresenter.new(@response,
+                                                     blacklight_config)
+        end
+        additional_response_formats(format)
+        document_export_formats(format)
       end
-      additional_response_formats(format)
-      document_export_formats(format)
     end
   end
 

--- a/spec/system/ejournals_spec.rb
+++ b/spec/system/ejournals_spec.rb
@@ -45,13 +45,11 @@ RSpec.feature 'eJournals Page', type: :system, js: false do
       fill_in 'title_precise', with: '123'
       click_button("Search")
       expect(page).not_to have_css("The Title of my Work")
-      expect(page).to have_selector('.constraint', count: 3)
     end
 
     it 'click on Letters' do
       click_link('A')
       expect(page).not_to have_css("The Title of my Work")
-      expect(page).to have_selector('.constraint', count: 3)
     end
   end
 end


### PR DESCRIPTION
- .rubocop.yml: skips method length rule for catalog controller override.
- app/views/catalog/_home_text.html.erb: adds overlay html for empty results redirect.
- app/views/layouts/blacklight/base.html.erb: gives proper spacing to the logic wrapped render calls.
- config/initializers/catalog_index_override.rb: redirests to an empty search when documents list is empty.
- spec/system/ejournals_spec.rb: removes expectations for constraint buttons since the redirect won't have them.
<img width="1490" alt="Screen Shot 2021-12-17 at 11 45 22 AM" src="https://user-images.githubusercontent.com/18330149/146583528-86f64550-ae4c-45e2-9c1b-e978e2bc379e.png">

