### PR TITLE
Revise marc 856 mappings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,8 @@ Metrics/CyclomaticComplexity:
         - 'app/models/marc_indexer.rb'
         - 'app/services/oai_processing_single_service.rb'
         - 'lib/traject/extract_publication_date.rb'
+        - 'lib/traject/extract_url_fulltext.rb'
+        - 'lib/traject/extract_url_suppl.rb'
 
 Metrics/MethodLength:
     Exclude:
@@ -47,6 +49,7 @@ Metrics/MethodLength:
         - 'app/services/oai_processing_service.rb'
         - 'app/services/oai_processing_single_service.rb'
         - 'lib/traject/extract_publication_date.rb'
+        - 'lib/traject/extract_url_fulltext.rb'
         - 'app/controllers/sessions/social_login.rb'
         - 'config/initializers/bookmarks_index_override.rb'
 

--- a/lib/traject/extract_url_fulltext.rb
+++ b/lib/traject/extract_url_fulltext.rb
@@ -8,7 +8,15 @@ module ExtractUrlFulltext
       rec.fields('856').each do |f|
         case f.indicator2
         when '0', '1'
-          accumulate_urls(f, acc)
+          base_url = f.find { |field| field.code == 'u' }&.value
+          next unless base_url
+
+          url = parse_url(base_url)
+          exclude_links_to = ["table of contents", "table of contents only", "publisher description", "cover image", "contributor biographical information"]
+          label = [f['y'], f['3'], f['z']].compact.first
+          next if label.present? && exclude_links_to.include?(label.downcase)
+
+          acc << { url: url, label: label }.to_json if url.present?
         when '2'
           # do nothing
         else

--- a/lib/traject/extract_url_suppl.rb
+++ b/lib/traject/extract_url_suppl.rb
@@ -5,12 +5,18 @@ extend ExtractionTools
 module ExtractUrlSuppl
   def extract_url_suppl
     lambda do |rec, acc|
-      url_fields = rec.fields('856').select { |f| f.indicator2 == '2' || f.indicator2.blank? }
+      url_fields = rec.fields('856').select { |f| ['0', '1', '2'].include?(f.indicator2) || f.indicator2.blank? }
       url_fields.each do |uf|
         next if uf['u'].blank?
         build_str = uf['u']
-        pulled_text = [uf['y'], uf['3'], uf['z']].compact
-        build_str += " text: #{marc21.trim_punctuation(pulled_text.first)}" if pulled_text.present?
+        pulled_text = [uf['y'], uf['3'], uf['z']].compact.first
+
+        if ['0', '1'].include?(uf.indicator2)
+          include_links_to = ["table of contents", "table of contents only", "publisher description", "cover image", "contributor biographical information"]
+          next if pulled_text.nil? || include_links_to.exclude?(pulled_text.downcase)
+        end
+
+        build_str += " text: #{marc21.trim_punctuation(pulled_text)}" if pulled_text.present?
         acc << build_str
       end
     end

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -180,8 +180,7 @@ RSpec.describe 'Indexing fields with custom logic' do
     end
     context "when 856 3 and z are present and ind2 is equal to 1" do
       it 'has value of 856 3 since it has higher precedence than z' do
-        expect(solr_doc['url_fulltext_ssm']).to eq(["{\"url\":\"http://purl.access.gpo.gov/GPO/LPS54510\",\"label\":\"Subfield code 3\"}",
-                                                    "{\"url\":\"http://catdir.loc.gov/catdir/toc/casalini15/3065159.pdf\",\"label\":\"Table of contents only\"}"])
+        expect(solr_doc['url_fulltext_ssm']).to eq(["{\"url\":\"http://purl.access.gpo.gov/GPO/LPS54510\",\"label\":\"Subfield code 3\"}"])
       end
     end
 
@@ -260,7 +259,10 @@ RSpec.describe 'Indexing fields with custom logic' do
     context "when 856 indicator2 == 2 and either y, 3, or z are present" do
       it 'has value of 856u and text = 3 since it has higher precedence than z' do
         expect(solr_doc['url_suppl_ssim']).to eq(
-          ["http://excerpts.contentreserve.com/FormatType-425/3450-1/791128-HarryPotterAndTheSorcerersStone.mp3 text: This is the right code"]
+          [
+            "http://excerpts.contentreserve.com/FormatType-425/3450-1/791128-HarryPotterAndTheSorcerersStone.mp3 text: This is the right code",
+            "http://catdir.loc.gov/catdir/toc/casalini15/3065159.pdf text: Table of contents only"
+          ]
         )
       end
 


### PR DESCRIPTION
Refer to the requirements below:

Revise mappings for the following:

`url_fulltext_ssm`: Include the current logic, but **exclude** the following:

If `ind2=0 or 1` and exactly matches one of these strings in `$3`, `$y,` or `$z`:

```
Table of contents
Table of contents only
Publisher description
Cover image
Contributor biographical information
```

`url_suppl_ssim`: Include the current logic, plus **include** 856s with `ind2=0 or 1` that contain exact matches on the strings listed previously.

```
Table of contents
Table of contents only
Publisher description
Cover image
Contributor biographical information
```

Note: we don't want to use a "contains" type logic here because sometimes a phrase like "table of contents" may be part of a longer phrase such as "Full text including table of contents".