### PR TITLE
Refine availability table css

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_results_list.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_results_list.scss
@@ -164,6 +164,17 @@ li.loading-avail-badge span {
   margin-right: 1em;
 }
 
+.availability-table {
+  .table-primary th {
+    border-color: #dee2e6;
+  }
+
+  td {
+    font-size: 0.875rem;
+    text-align: left;
+  }
+}
+
 .btn.rounded-0.phys-avail-label, .btn.rounded-0.mb-2.online-avail-label { 
   cursor:    default !important;
   font-size: $results-button-label-font-size;

--- a/app/views/catalog/availability/_table.html.erb
+++ b/app/views/catalog/availability/_table.html.erb
@@ -1,7 +1,7 @@
 <% if doc_avail_values[:physical_holdings].present? %>
   <span id="avail-<%= document.id %>-toggle" class="collapse">
     <div class="table-responsive-sm">
-      <table class="table table-bordered">
+      <table class="table table-bordered availability-table">
         <thead>
           <tr class="table-primary">
             <th scope="col" class="col-sm-4">Library Location</th>


### PR DESCRIPTION
- [ ] The font size on the table rows is slightly larger than on the wireframe; we want it to be more consistent with the font sizes used in the Availability badge. Suggested revision: make font size 0.875rem.

- [ ] The Availability badge is showing up as centered, but should be left aligned in its column.

- [ ] The table heading borders should be our standard light gray. It is currently showing a mix of blue and gray borders. Please remove the extraneous blue border.

Refer to the screenshots below:

## Document show page

![Screen Shot 2022-01-10 at 11 54 04 AM](https://user-images.githubusercontent.com/13107510/148805758-69d9945d-8d13-4edc-9d28-b94dceb7eafe.png)

## Results page

![Screen Shot 2022-01-10 at 11 54 36 AM](https://user-images.githubusercontent.com/13107510/148805867-50ca5309-f9e0-4c3a-8270-86bcdcbefda8.png)

