### PR TITLE
CSS refinements for availability table

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_results_list.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_results_list.scss
@@ -28,7 +28,7 @@ article.document {
       margin-bottom: 0;
 
       @media (max-width:767px) {
-        margin-bottom: 3px;
+        margin-bottom: 6px;
       }
     }
   }
@@ -176,6 +176,7 @@ li.loading-avail-badge span {
 .availability-table {
   .table-primary th {
     border-color: #dee2e6;
+    font-size: 0.875rem;
 
     @media (max-width:575px) {
       max-width: 33.33%;


### PR DESCRIPTION
- Reduce table headers font size to 0.875rem
- Increase bottom margin of article.document > dl.row > dd to 6px on mobile
![Screen Shot 2022-01-13 at 5 08 20 PM](https://user-images.githubusercontent.com/13107510/149416767-e32b2c4d-6613-421f-9977-31f752603cc7.png)
![Screen Shot 2022-01-13 at 5 08 09 PM](https://user-images.githubusercontent.com/13107510/149416771-0c3a03cf-3321-4cea-8c49-43d54318f862.png)

