### PR TITLE
Add OAI Validation Rule model

### DIFF
--- a/app/models/oai_validation/deactivated_portfolios_rule.rb
+++ b/app/models/oai_validation/deactivated_portfolios_rule.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class OaiValidation::DeactivatedPortfoliosRule < OaiValidation::Rule
+  def description
+    "Remove all records listed under deactivated portfolios."
+  end
+
+  def record_ids
+    deactivated_portfolios = pull_deactivated_portfolios(document)
+    pull_ids_from_category_array(deactivated_portfolios, 'Deactivated Portfolio', [])
+  end
+
+  def apply
+    deactivated_portfolios = pull_deactivated_portfolios(document)
+    deactivated_portfolios_ids = pull_ids_from_category_array(deactivated_portfolios, 'Deactivated Portfolio', [])
+    deactivated_portfolios.each(&:remove)
+    deactivated_portfolios_ids
+  end
+end

--- a/app/models/oai_validation/deactivated_portfolios_rule.rb
+++ b/app/models/oai_validation/deactivated_portfolios_rule.rb
@@ -10,14 +10,27 @@ class OaiValidation::DeactivatedPortfoliosRule < OaiValidation::Rule
   end
 
   def record_ids
-    deactivated_portfolios = pull_deactivated_portfolios(document)
-    pull_ids_from_category_array(deactivated_portfolios)
+    deactivated_portfolios = pull_deactivated_portfolios
+    deactivated_portfolios.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text }
   end
 
   def apply
-    deactivated_portfolios = pull_deactivated_portfolios(document)
-    deactivated_portfolios_ids = pull_ids_from_category_array(deactivated_portfolios)
+    deactivated_portfolios = pull_deactivated_portfolios
+    deactivated_portfolios_ids = deactivated_portfolios.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text }
     deactivated_portfolios.each(&:remove)
     deactivated_portfolios_ids
+  end
+
+  private
+
+  def pull_deactivated_portfolios
+    document.xpath('//marc:record', MARC_URL).select do |d|
+      nine_nine_eight_count = get_998_count(d)
+      eight_five_sixes = d.xpath("marc:datafield[@tag='856']", MARC_URL).present?
+      physical = document_contain_physical?(d)
+      deactivate_portfolios_count = get_deact_port_count(d)
+
+      !physical && deactivate_portfolios_count.positive? && !eight_five_sixes && nine_nine_eight_count == deactivate_portfolios_count
+    end
   end
 end

--- a/app/models/oai_validation/deactivated_portfolios_rule.rb
+++ b/app/models/oai_validation/deactivated_portfolios_rule.rb
@@ -1,18 +1,22 @@
 # frozen_string_literal: true
 
 class OaiValidation::DeactivatedPortfoliosRule < OaiValidation::Rule
+  def name
+    "Deactivated Portfolios"
+  end
+
   def description
     "Remove all records listed under deactivated portfolios."
   end
 
   def record_ids
     deactivated_portfolios = pull_deactivated_portfolios(document)
-    pull_ids_from_category_array(deactivated_portfolios, 'Deactivated Portfolio', [])
+    pull_ids_from_category_array(deactivated_portfolios)
   end
 
   def apply
     deactivated_portfolios = pull_deactivated_portfolios(document)
-    deactivated_portfolios_ids = pull_ids_from_category_array(deactivated_portfolios, 'Deactivated Portfolio', [])
+    deactivated_portfolios_ids = pull_ids_from_category_array(deactivated_portfolios)
     deactivated_portfolios.each(&:remove)
     deactivated_portfolios_ids
   end

--- a/app/models/oai_validation/deleted_records_rule.rb
+++ b/app/models/oai_validation/deleted_records_rule.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class OaiValidation::DeletedRecordsRule < OaiValidation::Rule
+  def description
+    "Remove all records that were deleted."
+  end
+
+  def record_ids
+    deleted_records = document.xpath("/oai:OAI-PMH/oai:#{xml_type}/oai:record[oai:header/@status='deleted']", OAI_URL)
+    pull_deleted_ids(deleted_records)
+  end
+
+  def apply
+    deleted_records = document.xpath("/oai:OAI-PMH/oai:#{xml_type}/oai:record[oai:header/@status='deleted']", OAI_URL)
+    deleted_ids = pull_deleted_ids(deleted_records, logger)
+    deleted_records.remove
+    deleted_ids
+  end
+end

--- a/app/models/oai_validation/deleted_records_rule.rb
+++ b/app/models/oai_validation/deleted_records_rule.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class OaiValidation::DeletedRecordsRule < OaiValidation::Rule
+  def name
+    "Deleted"
+  end
+
   def description
     "Remove all records that were deleted."
   end
@@ -12,7 +16,7 @@ class OaiValidation::DeletedRecordsRule < OaiValidation::Rule
 
   def apply
     deleted_records = document.xpath("/oai:OAI-PMH/oai:#{xml_type}/oai:record[oai:header/@status='deleted']", OAI_URL)
-    deleted_ids = pull_deleted_ids(deleted_records, logger)
+    deleted_ids = pull_deleted_ids(deleted_records)
     deleted_records.remove
     deleted_ids
   end

--- a/app/models/oai_validation/deleted_records_rule.rb
+++ b/app/models/oai_validation/deleted_records_rule.rb
@@ -11,12 +11,12 @@ class OaiValidation::DeletedRecordsRule < OaiValidation::Rule
 
   def record_ids
     deleted_records = document.xpath("/oai:OAI-PMH/oai:#{xml_type}/oai:record[oai:header/@status='deleted']", OAI_URL)
-    pull_deleted_ids(deleted_records)
+    deleted_records.map { |n| n.at('header/identifier').text.split(':').last }
   end
 
   def apply
     deleted_records = document.xpath("/oai:OAI-PMH/oai:#{xml_type}/oai:record[oai:header/@status='deleted']", OAI_URL)
-    deleted_ids = pull_deleted_ids(deleted_records)
+    deleted_ids = deleted_records.map { |n| n.at('header/identifier').text.split(':').last }
     deleted_records.remove
     deleted_ids
   end

--- a/app/models/oai_validation/lost_stolen_records_rule.rb
+++ b/app/models/oai_validation/lost_stolen_records_rule.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class OaiValidation::LostStolenRecordsRule < OaiValidation::Rule
+  def description
+    "Remove all records that were lost or stolen."
+  end
+
+  def record_ids
+    lost_stolen_records = pull_lost_stolen_records(document)
+    pull_ids_from_category_array(lost_stolen_records, 'Lost/Stolen', [])
+  end
+
+  def apply
+    lost_stolen_records = pull_lost_stolen_records(document)
+    lost_stolen_ids = pull_ids_from_category_array(lost_stolen_records, 'Lost/Stolen', [])
+    lost_stolen_records.each(&:remove)
+    lost_stolen_ids
+  end
+end

--- a/app/models/oai_validation/lost_stolen_records_rule.rb
+++ b/app/models/oai_validation/lost_stolen_records_rule.rb
@@ -1,18 +1,22 @@
 # frozen_string_literal: true
 
 class OaiValidation::LostStolenRecordsRule < OaiValidation::Rule
+  def name
+    "Lost/Stolen"
+  end
+
   def description
     "Remove all records that were lost or stolen."
   end
 
   def record_ids
     lost_stolen_records = pull_lost_stolen_records(document)
-    pull_ids_from_category_array(lost_stolen_records, 'Lost/Stolen', [])
+    pull_ids_from_category_array(lost_stolen_records)
   end
 
   def apply
     lost_stolen_records = pull_lost_stolen_records(document)
-    lost_stolen_ids = pull_ids_from_category_array(lost_stolen_records, 'Lost/Stolen', [])
+    lost_stolen_ids = pull_ids_from_category_array(lost_stolen_records)
     lost_stolen_records.each(&:remove)
     lost_stolen_ids
   end

--- a/app/models/oai_validation/lost_stolen_records_rule.rb
+++ b/app/models/oai_validation/lost_stolen_records_rule.rb
@@ -10,14 +10,26 @@ class OaiValidation::LostStolenRecordsRule < OaiValidation::Rule
   end
 
   def record_ids
-    lost_stolen_records = pull_lost_stolen_records(document)
-    pull_ids_from_category_array(lost_stolen_records)
+    lost_stolen_records = pull_lost_stolen_records
+    lost_stolen_records.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text }
   end
 
   def apply
-    lost_stolen_records = pull_lost_stolen_records(document)
-    lost_stolen_ids = pull_ids_from_category_array(lost_stolen_records)
+    lost_stolen_records = pull_lost_stolen_records
+    lost_stolen_ids = lost_stolen_records.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text }
     lost_stolen_records.each(&:remove)
     lost_stolen_ids
+  end
+
+  private
+
+  def pull_lost_stolen_records
+    document.xpath('//marc:record', MARC_URL).select do |d|
+      hol852_count = d.xpath("marc:datafield[@tag='HOL852']", MARC_URL).size
+      holsp_count = d.xpath(
+        "marc:datafield[@tag='HOLSP']//marc:subfield[@code='a'][text()='true']", MARC_URL
+      ).size
+      hol852_count.positive? && hol852_count <= holsp_count
+    end
   end
 end

--- a/app/models/oai_validation/rule.rb
+++ b/app/models/oai_validation/rule.rb
@@ -24,8 +24,14 @@ class OaiValidation::Rule
     @xml_type = xml_type
   end
 
+  # Name of the validation rule
+  # @return [String] name of the rule
+  def name
+    raise "Method #name has not been implemented for this rule"
+  end
+
   # Description of the validation rule
-  # @return [Boolean] true if record is valid
+  # @return [String] description of the rule
   def description
     raise "Method #description has not been implemented for this rule"
   end

--- a/app/models/oai_validation/rule.rb
+++ b/app/models/oai_validation/rule.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'oai_processing/oai_processing_toolset'
+
+class OaiValidation::Rule
+  include OaiProcessingToolset
+  MARC_URL = OaiProcessingToolset.const_get(:MARC_URL).freeze
+  OAI_URL = OaiProcessingToolset.const_get(:OAI_URL).freeze
+
+  attr_reader :document, :xml_type, :logger
+
+  def self.all_rules(document:, xml_type:)
+    [
+      OaiValidation::DeletedRecordsRule.new(document: document, xml_type: xml_type),
+      OaiValidation::SuppressedRecordsRule.new(document: document, xml_type: xml_type),
+      OaiValidation::LostStolenRecordsRule.new(document: document, xml_type: xml_type),
+      OaiValidation::DeactivatedPortfoliosRule.new(document: document, xml_type: xml_type),
+      OaiValidation::TemporaryLocatedRecordsRule.new(document: document, xml_type: xml_type)
+    ]
+  end
+
+  def initialize(document:, xml_type:)
+    @document = document
+    @xml_type = xml_type
+  end
+
+  # Description of the validation rule
+  # @return [Boolean] true if record is valid
+  def description
+    raise "Method #description has not been implemented for this rule"
+  end
+
+  # Return array of all records affected by this rule
+  # @return [Array<Int>] IDs of records affected
+  def record_ids
+    raise "Method #record_ids has not been implemented for this rule"
+  end
+
+  # Apply requirements of the rule
+  # @return [Array<Int>] IDs of records affected
+  def apply
+    raise "Method #apply has not been implemented for this rule"
+  end
+end

--- a/app/models/oai_validation/rule.rb
+++ b/app/models/oai_validation/rule.rb
@@ -6,6 +6,8 @@ class OaiValidation::Rule
   include OaiProcessingToolset
   MARC_URL = OaiProcessingToolset.const_get(:MARC_URL).freeze
   OAI_URL = OaiProcessingToolset.const_get(:OAI_URL).freeze
+  ALL_LIB_LOCATIONS = OaiProcessingToolset.const_get(:ALL_LIB_LOCATIONS).freeze
+  LIB_LOC_PAIRS = OaiProcessingToolset.const_get(:LIB_LOC_PAIRS).freeze
 
   attr_reader :document, :xml_type, :logger
 

--- a/app/models/oai_validation/suppressed_records_rule.rb
+++ b/app/models/oai_validation/suppressed_records_rule.rb
@@ -11,12 +11,12 @@ class OaiValidation::SuppressedRecordsRule < OaiValidation::Rule
 
   def record_ids
     suppressed_records = document.xpath("//marc:record[substring(marc:leader, 6, 1)='d']", MARC_URL) # gets all records with `d` in the 6th (actual) position of leader string
-    pull_ids_from_category_array(suppressed_records)
+    suppressed_records.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text }
   end
 
   def apply
     suppressed_records = document.xpath("//marc:record[substring(marc:leader, 6, 1)='d']", MARC_URL) # gets all records with `d` in the 6th (actual) position of leader string
-    suppressed_record_ids = pull_ids_from_category_array(suppressed_records)
+    suppressed_record_ids = suppressed_records.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text }
     suppressed_records.remove
     suppressed_record_ids
   end

--- a/app/models/oai_validation/suppressed_records_rule.rb
+++ b/app/models/oai_validation/suppressed_records_rule.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class OaiValidation::SuppressedRecordsRule < OaiValidation::Rule
+  def description
+    "Remove all records that were suppressed."
+  end
+
+  def record_ids
+    suppressed_records = document.xpath("//marc:record[substring(marc:leader, 6, 1)='d']", MARC_URL) # gets all records with `d` in the 6th (actual) position of leader string
+    pull_ids_from_category_array(suppressed_records, 'Suppressed', [])
+  end
+
+  def apply
+    suppressed_records = document.xpath("//marc:record[substring(marc:leader, 6, 1)='d']", MARC_URL) # gets all records with `d` in the 6th (actual) position of leader string
+    suppressed_record_ids = pull_ids_from_category_array(suppressed_records, 'Suppressed', [])
+    suppressed_records.remove
+    suppressed_record_ids
+  end
+end

--- a/app/models/oai_validation/suppressed_records_rule.rb
+++ b/app/models/oai_validation/suppressed_records_rule.rb
@@ -1,18 +1,22 @@
 # frozen_string_literal: true
 
 class OaiValidation::SuppressedRecordsRule < OaiValidation::Rule
+  def name
+    "Suppressed"
+  end
+
   def description
     "Remove all records that were suppressed."
   end
 
   def record_ids
     suppressed_records = document.xpath("//marc:record[substring(marc:leader, 6, 1)='d']", MARC_URL) # gets all records with `d` in the 6th (actual) position of leader string
-    pull_ids_from_category_array(suppressed_records, 'Suppressed', [])
+    pull_ids_from_category_array(suppressed_records)
   end
 
   def apply
     suppressed_records = document.xpath("//marc:record[substring(marc:leader, 6, 1)='d']", MARC_URL) # gets all records with `d` in the 6th (actual) position of leader string
-    suppressed_record_ids = pull_ids_from_category_array(suppressed_records, 'Suppressed', [])
+    suppressed_record_ids = pull_ids_from_category_array(suppressed_records)
     suppressed_records.remove
     suppressed_record_ids
   end

--- a/app/models/oai_validation/temporary_located_records_rule.rb
+++ b/app/models/oai_validation/temporary_located_records_rule.rb
@@ -1,18 +1,22 @@
 # frozen_string_literal: true
 
 class OaiValidation::TemporaryLocatedRecordsRule < OaiValidation::Rule
+  def name
+    "Temporarily Located"
+  end
+
   def description
     "Remove all records that were temporarily located."
   end
 
   def record_ids
     temporarily_located_records = pull_temp_location_records(document)
-    pull_ids_from_category_array(temporarily_located_records, 'Temporarily Located', [])
+    pull_ids_from_category_array(temporarily_located_records)
   end
 
   def apply
     temporarily_located_records = pull_temp_location_records(document)
-    temporarily_located_record_ids = pull_ids_from_category_array(temporarily_located_records, 'Temporarily Located', [])
+    temporarily_located_record_ids = pull_ids_from_category_array(temporarily_located_records)
     temporarily_located_records.each(&:remove)
     temporarily_located_record_ids
   end

--- a/app/models/oai_validation/temporary_located_records_rule.rb
+++ b/app/models/oai_validation/temporary_located_records_rule.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class OaiValidation::TemporaryLocatedRecordsRule < OaiValidation::Rule
+  def description
+    "Remove all records that were temporarily located."
+  end
+
+  def record_ids
+    temporarily_located_records = pull_temp_location_records(document)
+    pull_ids_from_category_array(temporarily_located_records, 'Temporarily Located', [])
+  end
+
+  def apply
+    temporarily_located_records = pull_temp_location_records(document)
+    temporarily_located_record_ids = pull_ids_from_category_array(temporarily_located_records, 'Temporarily Located', [])
+    temporarily_located_records.each(&:remove)
+    temporarily_located_record_ids
+  end
+end

--- a/app/models/oai_validation/temporary_located_records_rule.rb
+++ b/app/models/oai_validation/temporary_located_records_rule.rb
@@ -10,14 +10,29 @@ class OaiValidation::TemporaryLocatedRecordsRule < OaiValidation::Rule
   end
 
   def record_ids
-    temporarily_located_records = pull_temp_location_records(document)
-    pull_ids_from_category_array(temporarily_located_records)
+    temporarily_located_records = pull_temp_location_records
+    temporarily_located_records.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text }
   end
 
   def apply
-    temporarily_located_records = pull_temp_location_records(document)
-    temporarily_located_record_ids = pull_ids_from_category_array(temporarily_located_records)
+    temporarily_located_records = pull_temp_location_records
+    temporarily_located_record_ids = temporarily_located_records.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text }
     temporarily_located_records.each(&:remove)
     temporarily_located_record_ids
+  end
+
+  private
+
+  def pull_temp_location_records
+    document.xpath('//marc:record', MARC_URL).select do |d|
+      nine_nine_sevens = d.xpath("marc:datafield[@tag='997']", MARC_URL)
+      temporaries = nine_nine_sevens.select do |i|
+        library = i.xpath("marc:subfield[@code='c']", MARC_URL).text
+        location = i.xpath("marc:subfield[@code='d']", MARC_URL).text
+
+        ALL_LIB_LOCATIONS.include?(location&.upcase) || LIB_LOC_PAIRS.include?([library&.upcase, location&.upcase])
+      end
+      temporaries.size.positive? && nine_nine_sevens.size == temporaries.size
+    end
   end
 end

--- a/app/services/oai_processing/oai_processing_toolset.rb
+++ b/app/services/oai_processing/oai_processing_toolset.rb
@@ -35,9 +35,9 @@ module OaiProcessingToolset
          </xsl:stylesheet>)
   end
 
-  def pull_deleted_ids(deleted_records, logger)
+  def pull_deleted_ids(deleted_records, logger = nil)
     ids = deleted_records.map { |n| n.at('header/identifier').text.split(':').last }
-    logger.info "Deleted IDs: #{ids}"
+    logger.info "Deleted IDs: #{ids}" if logger.present?
     ids
   end
 
@@ -112,9 +112,9 @@ module OaiProcessingToolset
     end
   end
 
-  def pull_ids_from_category_array(cat_array, cat_label, ids_to_remove, logger)
+  def pull_ids_from_category_array(cat_array, cat_label, ids_to_remove, logger = nil)
     ids = cat_array.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text } - ids_to_remove
-    logger.info("#{cat_label} IDs: #{ids}")
+    logger.info("#{cat_label} IDs: #{ids}") if logger.present?
     ids
   end
 end

--- a/app/services/oai_processing/oai_processing_toolset.rb
+++ b/app/services/oai_processing/oai_processing_toolset.rb
@@ -35,10 +35,8 @@ module OaiProcessingToolset
          </xsl:stylesheet>)
   end
 
-  def pull_deleted_ids(deleted_records, logger = nil)
-    ids = deleted_records.map { |n| n.at('header/identifier').text.split(':').last }
-    logger.info "Deleted IDs: #{ids}" if logger.present?
-    ids
+  def pull_deleted_ids(deleted_records)
+    deleted_records.map { |n| n.at('header/identifier').text.split(':').last }
   end
 
   def pull_record_count(document, xml_type, logger)
@@ -112,9 +110,7 @@ module OaiProcessingToolset
     end
   end
 
-  def pull_ids_from_category_array(cat_array, cat_label, ids_to_remove, logger = nil)
-    ids = cat_array.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text } - ids_to_remove
-    logger.info("#{cat_label} IDs: #{ids}") if logger.present?
-    ids
+  def pull_ids_from_category_array(cat_array)
+    cat_array.map { |e| e.at_xpath("marc:controlfield[@tag='001']", MARC_URL).text }
   end
 end

--- a/spec/services/oai_validation_service_spec.rb
+++ b/spec/services/oai_validation_service_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe OaiValidationService, :clean do
       it 'raises an error' do
         stub_request(:get, "https://emory_alma_example.alma.exlibrisgroup.com/view/oai/emory/request?identifier=oai:alma.emory:990000954720302486&metadataPrefix=marc21&verb=GetRecord")
           .to_return(status: 200, body: File.read(fixture_path + '/single_record_deleted.xml'), headers: {})
-        expect { described_class.validate_record!(990_000_954_720_302_486, logger) }.to raise_error(OaiValidationServiceError, "Record #990000954720302486 is listed under deleted records.")
+        expected_error_message = "Record #990000954720302486 violates the following rule: Remove all records that were deleted."
+        expect { described_class.validate_record!(990_000_954_720_302_486, logger) }.to raise_error(OaiValidationServiceError, expected_error_message)
       end
     end
   end


### PR DESCRIPTION
## Changes
- Add new model `OaiValidation::Rule` to represent a generic validation rule and all its methods
- Add a new model that inherits from `OaiValidation::Rule` for each validation rule currently used in the ingest process
- Edit `OaiValidationService` to use the new rules for validation
- Edit `OaiProcessingService` to use the new rules for validation and indexing

## Background

The main aim of this PR is to split current indexing deletion/suppression rules into individual rules, and have the rules be reusable across the app. The newly introduced `OaiValidation::Rule` has to useful methods, `#records_ids` and `#apply`. `#records_ids` returns all record ids affected by the rule in the `document`, and `#apply` applies the requirements of the rule on the document. For example, for `OaiValidation::DeletedRecordsRule`, the `#records_ids` returns all record ids of records that are deleted, and `#apply` removes all deleted records from the `document`.

Moving forward, these changes will allow us to easily add new rules for filtering valid records in the ingest or validation process. We simply need to add a new model for the rule that inherits from `OaiValidation::Rule`, and add that rule to the array of the`#all_rules` class method of `OaiValidation::Rule`. Once the new rule is added, it will be automatically applied in the ingest process.
