### PR TITLE
Refactor login links view

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -21,10 +21,10 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <% if provider == "Shibboleth" %>
+    <% if provider == :shibboleth %>
       <%= link_to "Emory Users Login", new_user_shib_session_path %><br />
     <% else %>
-      <%= link_to "Emory Users Login", omniauth_authorize_path(resource_name, provider) %><br />
+      <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
     <% end %>
   <% end %>
   <%= link_to "Affiliate login", alma_social_login_url(redirect_to: session[:requested_page]) %>


### PR DESCRIPTION
Fixes #1040

Background: When I first read the if statement that determines what path to assign to a login link, I was confused because both the if and else scenarios labeled the link `Emory Users Login`, meaning for any other provider than `shibboleth`we still name it `Emory Users Login`. Upon further inspection, I figured that the if statement is supposed to set `Emory Users Login` when the provider is `shibboleth`, and name any other login link based on the provider's name. The changes in this PR ensure the if/statement renders the correct label and path for a login link based on the provider.