### PR TITLE
Fix availability table layout for printing

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_print.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_print.scss
@@ -29,7 +29,7 @@
     display: inline;
     > div > table {
       > thead > tr > th.no-print, > tbody > tr > td.no-print, > tbody > tr.no-print { 
-        display: none;
+        display: none !important;
       }
     }
   }

--- a/app/assets/stylesheets/blacklight_catalog/_results_list.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_results_list.scss
@@ -175,7 +175,8 @@ li.loading-avail-badge span {
 
 .availability-table {
   .table-primary th {
-    border-color: #dee2e6;
+    border: 1px solid #dee2e6;
+    border-bottom-width: 2px;
     font-size: 0.875rem;
 
     @media (max-width:575px) {
@@ -186,6 +187,7 @@ li.loading-avail-badge span {
   td {
     font-size: 0.875rem;
     text-align: left;
+    border: 1px solid #dee2e6;
 
     @media (max-width:575px) {
       max-width: 33.33%;

--- a/app/views/catalog/availability/_table.html.erb
+++ b/app/views/catalog/availability/_table.html.erb
@@ -1,7 +1,7 @@
 <% if doc_avail_values[:physical_holdings].present? %>
   <span id="avail-<%= document.id %>-toggle" class="collapse">
     <div class="table-responsive-sm">
-      <table class="table table-bordered availability-table">
+      <table class="table availability-table">
         <thead>
           <tr class="table-primary">
             <th scope="col" class="col-sm-4">Library Location</th>


### PR DESCRIPTION
Fixes #1216 

This PR addresses the following issue reported by @eporter23:

> @abelemlih looks much better in all the various views, thank you! I am still seeing an outline for the hidden availability column in Safari and Firefox, though it is fine in Chrome

**View**:

![Screen Shot 2022-02-01 at 1 39 33 PM](https://user-images.githubusercontent.com/13107510/152030638-59cd0b57-ca1d-4e87-81d7-80eb6a2fb976.png)

**Print output in Chrome**:
![Screen Shot 2022-02-01 at 1 42 30 PM](https://user-images.githubusercontent.com/13107510/152030726-d9a11a66-9040-4f6b-9960-ab4b660bf52d.png)

**Print output in Firefox**:
![Screen Shot 2022-02-01 at 1 43 24 PM](https://user-images.githubusercontent.com/13107510/152030857-a91a6d7a-6137-44e1-b4b0-df11b9bc8715.png)

**Print output in Safari**:
![Screen Shot 2022-02-01 at 1 44 00 PM](https://user-images.githubusercontent.com/13107510/152030954-175fcedd-81db-4563-bf88-234d298cd96a.png)

