### PR TITLE
Skips the service page for online links.

### DIFF
--- a/app/helpers/exterior_links_helper.rb
+++ b/app/helpers/exterior_links_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 module ExteriorLinksHelper
-  def service_page_url(doc_id)
-    "#{ENV['ALMA_BASE_URL']}/discovery/openurl?institution=#{ENV['INSTITUTION']}&vid=#{ENV['INSTITUTION']}:services&rft.mms_id=#{doc_id}"
+  def service_page_url(doc_id, online: false)
+    "#{ENV['ALMA_BASE_URL']}/discovery/openurl?institution=#{ENV['INSTITUTION']}&" \
+      "vid=#{ENV['INSTITUTION']}:services#{online ? '&u.ignore_date_coverage=true&force_direct=true' : ''}" \
+      "&rft.mms_id=#{doc_id}"
   end
 
   def databases_url
@@ -14,7 +16,8 @@ module ExteriorLinksHelper
 
   def articles_plus_url_builder(search_state)
     state_query = search_state.to_h['q']
-    "https://emory.primo.exlibrisgroup.com/discovery/search?vid=01GALI_EMORY:articles&query=any,contains,#{state_query}&lang=en"
+    "https://emory.primo.exlibrisgroup.com/discovery/search?vid=01GALI_EMORY:articles" \
+      "&query=any,contains,#{state_query}&lang=en"
   end
 
   def my_library_card_url

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,6 +1,5 @@
 <%# Override of Blacklight v7.4.1 partial of same name; inserts vernacular title helper before the dl L#4 %>
 <% doc_presenter = index_presenter(document) %>
-<% service_page_link = service_page_url(document.id) %>
 <%# default partial to display solr document fields in catalog index view -%>
 <%= vern_title_search_results_populator(document) %>
 <dl class="document-metadata dl-invert row">

--- a/app/views/catalog/availability/_badges.html.erb
+++ b/app/views/catalog/availability/_badges.html.erb
@@ -8,7 +8,7 @@
       <%= render 'shared/document_url_fulltext_modal', document: document %>
     <% else %>
       <span class="online-avail-button">
-        <%= link_to('CONNECT', service_page_link, 
+        <%= link_to('CONNECT', service_page_url(document.id, online: true), 
               target: "_blank", class: "btn btn-md rounded-0 mb-2 btn-outline-primary avail-online-link-el") %>
       </span>
     <% end %>


### PR DESCRIPTION
- app/helpers/exterior_links_helper.rb: changes the method to dynamically add force direct command when needed and refactors another method.
- app/views/catalog/_index.html.erb: removes an unused variable.
- app/views/catalog/availability/_badges.html.erb: makes online badge button force directed.

No visual changes, no screenshots.