### PR TITLE
Refines the logic for deeming a record Online (#1237).

### DIFF
--- a/lib/traject/extract_marc_resource.rb
+++ b/lib/traject/extract_marc_resource.rb
@@ -81,7 +81,7 @@ module ExtractMarcResource
 
   def proof_of_856(record)
     record.fields('856').any? do |f|
-      f.indicator2 == '0' || f.indicator2 == '1' || f.indicator2 != '2' && !notfulltext.match?(fields_z3(f))
+      (f.indicator2 == '0' || f.indicator2 == '1') && (suppl_labels & fields_yz3(f)).empty?
     end
   end
 end

--- a/lib/traject/extraction_tools.rb
+++ b/lib/traject/extraction_tools.rb
@@ -63,12 +63,20 @@ module ExtractionTools
     [field['z'], field['3']].join(' ')
   end
 
+  def fields_yz3(field)
+    [field['y'], field['z'], field['3']].compact&.map(&:downcase)
+  end
+
   def accumulate_field_u(field, accumulator)
     accumulator << field['u'] unless field['u'].nil?
   end
 
   def notfulltext
     /abstract|description|sample text|table of contents|/i
+  end
+
+  def suppl_labels
+    ["table of contents", "table of contents only", "publisher description", "cover image", "contributor biographical information"]
   end
 
   def alpha_pat

--- a/spec/fixtures/alma_marc_resource.xml
+++ b/spec/fixtures/alma_marc_resource.xml
@@ -916,6 +916,10 @@
             <subfield code="0">(uri) http://id.loc.gov/authorities/names/n86714535</subfield>
             <subfield code="0">(uri) http://viaf.org/viaf/sourceID/LC|n86714535</subfield>
           </datafield>
+          <datafield tag="856" ind1="4" ind2="1">
+            <subfield code="3">Table of contents only</subfield>
+            <subfield code="u">http://catdir.loc.gov/catdir/toc/casalini15/3065159.pdf</subfield>
+          </datafield>
           <datafield tag="910" ind1=" " ind2=" ">
             <subfield code="a">RDA ENRICHED</subfield>
           </datafield>
@@ -1212,6 +1216,10 @@
           </datafield>
           <datafield tag="752" ind1=" " ind2=" ">
             <subfield code="a">Yemen.</subfield>
+          </datafield>
+          <datafield tag="856" ind1="4" ind2="1">
+            <subfield code="3">full text, baby!</subfield>
+            <subfield code="u">http://catdir.loc.gov/catdir/toc/casalini15/3065159.pdf</subfield>
           </datafield>
           <datafield tag="910" ind1=" " ind2=" ">
             <subfield code="a">MARS</subfield>

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -32,14 +32,28 @@ RSpec.describe 'Indexing fields with custom logic' do
     end
   end
 
-  describe 'marc_resource_ssim field, when 598a equals "NEW"' do
-    it('is mapped with Recently Acquired') { expect(solr_doc['marc_resource_ssim']).to include('Recently Acquired') }
-  end
+  context 'marc_resource_ssim' do
+    describe 'when 598a equals "NEW"' do
+      it('is mapped with Recently Acquired') { expect(solr_doc['marc_resource_ssim']).to include('Recently Acquired') }
+    end
 
-  describe 'marc_resource_ssim field, when 598a does not exist' do
-    it 'is not mapped with Recently Acquired' do
-      [solr_doc2, solr_doc3, solr_doc4].each do |d|
-        expect(d['marc_resource_ssim']).not_to include('Recently Acquired')
+    describe 'when 598a does not exist' do
+      it 'is not mapped with Recently Acquired' do
+        [solr_doc2, solr_doc3, solr_doc4].each do |d|
+          expect(d['marc_resource_ssim']).not_to include('Recently Acquired')
+        end
+      end
+    end
+
+    describe 'when 856 has supplemental links only' do
+      it 'is not mapped with Online' do
+        expect(solr_doc5['marc_resource_ssim']).not_to include('Online')
+      end
+    end
+
+    describe 'when 856 has a fulltext link' do
+      it 'is mapped with Online' do
+        expect(solr_doc6['marc_resource_ssim']).to include('Online')
       end
     end
   end


### PR DESCRIPTION
- lib/traject/extract_marc_resource.rb: matches the logic to the `url_fulltext` field.
- lib/traject/extraction_tools.rb: provides new methods to include the same fields and test values as the above mentioned field.
- spec/*: adds 856s to records that are not being queried with this field, as well tests for the expected outcomes.

Backend work, no screenshots necessary.