### PR TITLE
Revises the show page's sidebar options (#1233).

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -66,8 +66,10 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial(:export_as_ris, partial: 'export_as_ris')
     config.add_show_tools_partial(:print, partial: 'print')
     config.add_show_tools_partial(:direct_link, partial: 'direct_link')
-    config.add_show_tools_partial(:help, partial: 'help')
-    config.add_show_tools_partial(:feedback, partial: 'feedback')
+    config.add_show_tools_partial(:search_tips, partial: 'search_tips')
+    config.add_show_tools_partial(:ask_librarian, partial: 'ask_librarian')
+    config.add_show_tools_partial(:report_problem, partial: 'report_problem')
+    config.add_show_tools_partial(:harmful_language, partial: 'harmful_language')
     config.add_show_tools_partial(:librarian_view, label: 'Staff View', if: :render_librarian_view_control?, define_method: false)
 
     config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark', if: :render_bookmarks_control?)

--- a/app/helpers/tools_sidebar_helper.rb
+++ b/app/helpers/tools_sidebar_helper.rb
@@ -4,13 +4,14 @@ module ToolsSidebarHelper
     link_to(t('blacklight.tools.print'), '#', onclick: 'javascript:print()', class: 'nav-link')
   end
 
-  def render_help_in_toolbar
-    link_to(t('blacklight.tools.help'), 'https://search.libraries.emory.edu/help', class: 'nav-link', target: "_blank", rel: 'noopener noreferrer')
+  def render_generic_link_in_toolbar(link_text:, link_href:)
+    link_to(link_text, link_href, class: 'nav-link', target: "_blank", rel: 'noopener noreferrer')
   end
 
-  def render_feedback_in_toolbar(url)
-    link_to(t('blacklight.tools.feedback'),
-              "https://emory.libwizard.com/f/blacklight?refer_url=#{url}",
-              class: 'nav-link', target: "_blank", rel: 'noopener noreferrer')
+  def render_link_to_libwizard_in_toolbar(text:, form_name:, url:)
+    render_generic_link_in_toolbar(
+      link_text: text,
+      link_href: "https://emory.libwizard.com/f/#{form_name}?refer_url=#{url}"
+    )
   end
 end

--- a/app/views/catalog/_ask_librarian.html.erb
+++ b/app/views/catalog/_ask_librarian.html.erb
@@ -1,0 +1,3 @@
+<%= render_generic_link_in_toolbar(
+      link_text: t('blacklight.tools.ask_librarian'), 
+      link_href: 'https://emory.libanswers.com/') %>

--- a/app/views/catalog/_feedback.html.erb
+++ b/app/views/catalog/_feedback.html.erb
@@ -1,1 +1,0 @@
-<%= render_feedback_in_toolbar(request.original_url) %>

--- a/app/views/catalog/_harmful_language.html.erb
+++ b/app/views/catalog/_harmful_language.html.erb
@@ -1,0 +1,4 @@
+<%= render_link_to_libwizard_in_toolbar(
+      text: t('blacklight.tools.harmful_language'), 
+      form_name: 'harmful_language_catalog', 
+      url: request.original_url) %>

--- a/app/views/catalog/_help.html.erb
+++ b/app/views/catalog/_help.html.erb
@@ -1,1 +1,0 @@
-<%= render_help_in_toolbar %>

--- a/app/views/catalog/_report_problem.html.erb
+++ b/app/views/catalog/_report_problem.html.erb
@@ -1,0 +1,4 @@
+<%= render_link_to_libwizard_in_toolbar(
+      text: t('blacklight.tools.report_problem'), 
+      form_name: 'blacklight', 
+      url: request.original_url) %>

--- a/app/views/catalog/_search_tips.html.erb
+++ b/app/views/catalog/_search_tips.html.erb
@@ -1,0 +1,3 @@
+<%= render_generic_link_in_toolbar(
+      link_text: t('blacklight.tools.search_tips'), 
+      link_href: 'https://guides.libraries.emory.edu/LibrarySearchUserGuide') %>

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -1,0 +1,37 @@
+<%# Overrides partial of same name from blacklight (7.4.1) %>
+<%# Breaks up the tool options into separate card groups. %>
+<% tools_specific_keys = [:bookmark, :citation, :export_as_ris, :print, :direct_link, :librarian_view] %>
+
+<% if show_doc_actions? %>
+  <div class="card show-tools">
+    <div class="card-header">
+      <h2 class="mb-0 h6"><%= t('blacklight.tools.title') %></h2>
+    </div>
+
+    <ul class="list-group list-group-flush">
+      <%= render_show_doc_actions @document do |config, inner| %>
+        <% if tools_specific_keys.include?(config.key) %>
+          <li class="list-group-item <%= config.key %>">
+            <%= inner %>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+
+  <div class="card show-tools">
+    <div class="card-header">
+      <h2 class="mb-0 h6"><%= t('blacklight_catalog.sidebar.help.title') %></h2>
+    </div>
+
+    <ul class="list-group list-group-flush">
+      <%= render_show_doc_actions @document do |config, inner| %>
+        <% if !tools_specific_keys.include?(config.key) %>
+          <li class="list-group-item <%= config.key %>">
+            <%= inner %>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -49,9 +49,11 @@ en:
     tools:
       citation_warning: 'These citations are automatically generated and may not always be correct. Remember to check your citations for accuracy before including them in your work.'
       direct_link: 'Direct Link'
-      feedback: 'Feedback'
-      help: 'Help'
+      report_problem: 'Report a Problem'
+      search_tips: 'Search Tips'
       librarian_view: 'Staff View'
       print: 'Print'
       direct_link_url_text: 'Direct Link URL'
       export_as_ris: 'Export as RIS'
+      ask_librarian: 'Ask a Librarian'
+      harmful_language: 'Harmful Language'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,10 +85,14 @@ en:
       find_it_header: "Where to find it"
       url_fulltext_field: "Full Text Access"
       find_more_info: "Find more information about "
-      more_options: "More Options"
+      more_options: "More Search Options"
   blacklight_advanced_search:
     form:
       search_btn: "Search"
       sort_label: "Sort by"
       start_over: "Clear Form"
       title: "Advanced Search"
+  blacklight_catalog:
+    sidebar:
+      help:
+        title: "Help"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -124,7 +124,10 @@ RSpec.describe CatalogController, type: :controller do
 
   describe 'tool menu items' do
     let(:tool_menu_items) { controller.blacklight_config.view_config(:show).document_actions.keys }
-    let(:expected_tool_menu_items) { [:bookmark, :citation, :direct_link, :export_as_ris, :feedback, :help, :librarian_view, :print] }
+    let(:expected_tool_menu_items) do
+      [:ask_librarian, :bookmark, :citation, :direct_link, :export_as_ris, :harmful_language,
+       :librarian_view, :print, :report_problem, :search_tips]
+    end
 
     it { expect(tool_menu_items).to contain_exactly(*expected_tool_menu_items) }
   end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -155,7 +155,9 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
 
     context 'Tools Menu Sidebar' do
       let(:expected_tools_links_text) do
-        ["Bookmark Item", "Cite", "Print", "Direct Link", "Help", "Feedback", "Staff View"]
+        ["Bookmark Item", "Cite", "Export as RIS", "Print", "Direct Link", "Staff View",
+         "Search Tips", "Ask a Librarian", "Report a Problem", "Harmful Language",
+         "Find more information about Books"]
       end
 
       it 'shows the correct links' do
@@ -211,10 +213,10 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
         end
       end
 
-      context 'Feedback' do
+      context 'Report a Problem' do
         it 'links to the right LibWizard form' do
-          element = find('li.list-group-item.feedback a.nav-link')
-          expect(element.text).to eq('Feedback')
+          element = find('li.list-group-item.report_problem a.nav-link')
+          expect(element.text).to eq('Report a Problem')
           expect(element['href']).to include(
             'https://emory.libwizard.com/f/blacklight?refer_url=http', '/catalog/123'
           )
@@ -321,11 +323,11 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
       end
     end
 
-    context 'More Options card' do
+    context 'More Search Options card' do
       it 'shows the section when format_ssim populated' do
         visit solr_document_path(id)
 
-        expect(page.body).to have_css('h2', text: 'More Options')
+        expect(page.body).to have_css('h2', text: 'More Search Options')
         expect(page).to have_link('Find more information about Books')
       end
 


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: Renames and adds links to sidebar.
- app/helpers/tools_sidebar_helper.rb: reworks the helpers that deliver the links.
- app/views/catalog/_show_tools.html.erb: adds a new card group to create the `Help` section.
- app/views/catalog/_*: creates or renames the partials that deliver the links.
- config/locales/*: updates or implements the text needed for the changes.
- spec/*: revises the expectations for the tests.
<img width="373" alt="Screen Shot 2022-03-29 at 3 20 20 PM" src="https://user-images.githubusercontent.com/18330149/160690702-66251cdb-0863-455d-b27a-dd91c746af53.png">

