### PR TITLE
Removes force_direct from OpenURL calls (#1250).

### DIFF
--- a/app/helpers/exterior_links_helper.rb
+++ b/app/helpers/exterior_links_helper.rb
@@ -2,7 +2,7 @@
 module ExteriorLinksHelper
   def service_page_url(doc_id, online: false)
     "#{ENV['ALMA_BASE_URL']}/discovery/openurl?institution=#{ENV['INSTITUTION']}&" \
-      "vid=#{ENV['INSTITUTION']}:services#{online ? '&u.ignore_date_coverage=true&force_direct=true' : ''}" \
+      "vid=#{ENV['INSTITUTION']}:services#{online ? '&u.ignore_date_coverage=true' : ''}" \
       "&rft.mms_id=#{doc_id}"
   end
 

--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -227,6 +227,6 @@ module Statusable
   end
 
   def ave_query
-    "?institution=#{alma_institution}&vid=#{alma_institution}:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid="
+    "?institution=#{alma_institution}&vid=#{alma_institution}:blacklight&u.ignore_date_coverage=true&portfolio_pid="
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe SolrDocument do
         label: "Online resource from A-R Editions"
       }, {
         label: "Online resource from A-R Editions",
-        url: "http://www.example.com/hello/discovery/openurl?institution=SOME_INSTITUTION&vid=SOME_INSTITUTION:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53450970510002486"
+        url: "http://www.example.com/hello/discovery/openurl?institution=SOME_INSTITUTION&vid=SOME_INSTITUTION:blacklight&u.ignore_date_coverage=true&portfolio_pid=53450970510002486"
       }]
     end
 
@@ -220,7 +220,7 @@ RSpec.describe SolrDocument do
         label: "Online resource from Elsevier"
       }, {
         label: "Online resource from Elsevier",
-        url: "http://www.example.com/hello/discovery/openurl?institution=SOME_INSTITUTION&vid=SOME_INSTITUTION:blacklight&u.ignore_date_coverage=true&force_direct=true&portfolio_pid=53445539330002486"
+        url: "http://www.example.com/hello/discovery/openurl?institution=SOME_INSTITUTION&vid=SOME_INSTITUTION:blacklight&u.ignore_date_coverage=true&portfolio_pid=53445539330002486"
       }]
     end
 


### PR DESCRIPTION
- app/helpers/exterior_links_helper.rb and app/models/concerns/statusable.rb: eliminates the option of going directly to the portfolio provider's content, so that the end user may have a choice when multiple options are available.
- spec/models/solr_document_spec.rb: updates the tests' expectations for the produced links.

No screenshots necessary, all backend work with rSpec monitoring.