### PR TITLE
Ignores the Google Analytics param coming from Drupal (#1255).

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,7 @@ Metrics/MethodLength:
         - 'lib/traject/extract_url_fulltext.rb'
         - 'app/controllers/sessions/social_login.rb'
         - 'config/initializers/bookmarks_index_override.rb'
+        - 'config/initializers/catalog_index_override.rb'
 
 Metrics/ModuleLength:
     Exclude:

--- a/app/views/catalog/_facet_group.html.erb
+++ b/app/views/catalog/_facet_group.html.erb
@@ -1,6 +1,6 @@
 <% # Override of BlacklLight 7.4.1 -%>
 <% # main container for facets/limits menu -%>
-<% page_specific_field_names = request.fullpath == '/' ? blacklight_config.homepage_facet_fields : facet_field_names(groupname) - blacklight_config.suppressed_facet_fields %>
+<% page_specific_field_names = @homepage ? blacklight_config.homepage_facet_fields : facet_field_names(groupname) - blacklight_config.suppressed_facet_fields %>
 <% if has_facet_values? facet_field_names(groupname), @response %>
 <div id="facets<%= "-#{groupname}" unless groupname.nil? %>" class="facets sidenav facets-toggleable-md <%= "facet-home" if request.fullpath == "/" %>">
 

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -3,7 +3,7 @@
   Changes the name of the link to Advanced Search on line 36.
 %>
 <%= form_tag search_action_url, 
-      method: :get, class: "search-query-form#{request.fullpath == "/" ? '-home' : ''}", role: 'search' do %>
+      method: :get, class: "search-query-form#{@homepage ? '-home' : ''}", role: 'search' do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <% if search_fields.length > 1 %>
     <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
@@ -40,7 +40,7 @@
   </div>
 <% end %>
 
-<div <% if request.fullpath == "/" %>class="col-12" <% end %>>
+<div <% if @homepage %>class="col-12" <% end %>>
   <%= link_to('Advanced Search', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), 
-        class: "advanced_search#{request.fullpath == "/" ? '_home' : ''}") %>
+        class: "advanced_search#{@homepage ? '_home' : ''}") %>
 </div>

--- a/app/views/catalog/_title_starts_with_index.html.erb
+++ b/app/views/catalog/_title_starts_with_index.html.erb
@@ -1,7 +1,7 @@
 <% state = first_char_search_state(search_state) %>
 <% active_letter = first_char_active_letter(state) %>
 
-<% if request.url.include?('?') && !request.url.include?('/advance') && !request.url.include?('/bookmarks') %>
+<% if request.url.include?('?') && !request.url.include?('/advance') && !request.url.include?('/bookmarks') && !@homepage %>
   <nav class="alpha-filter first-main-char-nav">
     <ol class="first-main-char-ol">
       <li class="page-item first-main-char-descriptor"><%= t('blacklight.search.first_char.label') %></li>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -41,12 +41,12 @@
 
     <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
 
-    <div class="row <%= "content-row" if request.fullpath == "/" %>">
+    <div class="row <%= "content-row" if @homepage %>">
 
       <%= content_for?(:content) ? yield(:content) : yield %>
     </div>
 
-    <% if request.fullpath == "/" %>
+    <% if @homepage %>
     <%= render partial: 'catalog/other_resources/cards' %>
     <%= render partial: 'catalog/other_resources/accordions' %>
     <% end %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -41,14 +41,14 @@
           <%= render 'shared/user_util_links' %>
         </div>
       </div>
-      <% if request.fullpath == "/" %>
+      <% if @homepage %>
         <%= render 'catalog/hero_image' %>
       <% end %>
     </div>
   </div>
 </nav>
 
-<% if !request.fullpath.include?('/advanced') && request.fullpath != "/" && !request.fullpath.include?('/ejournals') %>
+<% if !request.fullpath.include?('/advanced') && !@homepage && !request.fullpath.include?('/ejournals') %>
   <div class="navbar-search navbar navbar-light bg-light mb-3" role="navigation">
     <div class="<%= container_classes %>">
       <%= render_search_bar  %>

--- a/config/initializers/catalog_index_override.rb
+++ b/config/initializers/catalog_index_override.rb
@@ -8,6 +8,7 @@ CatalogController.class_eval do
     @response = homepage? ? fetch_cached_search_results : fetch_live_search_results
     @document_list = @response.documents
     @document_ids = @response.documents&.map(&:id) || []
+    @homepage = homepage?
 
     respond_to do |format|
       format.html { store_preferred_view }
@@ -42,7 +43,7 @@ CatalogController.class_eval do
   end
 
   def homepage?
-    query_params = params.keys - ['action', 'controller']
+    query_params = params.keys - ['_ga', 'action', 'controller']
     query_params.empty?
   end
 end

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -3,58 +3,60 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'front page', type: :system do
-  before do
-    delete_all_documents_from_solr
-    build_solr_docs(TEST_ITEM)
-    visit root_path
-  end
-
-  around do |example|
-    orig_key = ENV['ALMA_BIB_KEY']
-    ENV['ALMA_BIB_KEY'] = "some_fake_key"
-    example.run
-    ENV['ALMA_BIB_KEY'] = orig_key
-  end
-
-  it 'has expected text' do
-    expect(page).to have_css('h3.header-search', text: 'Search books, e-books, journals, videos and more')
-  end
-
-  it('does not have the Title Starts With nav') { expect(page).not_to have_css('.first-main-char-ol') }
-
-  context 'facets' do
-    let(:facet_buttons) { find_all('h3.card-header.p-0.facet-field-heading button') }
-    let(:facet_headers) { facet_buttons.map(&:text) }
-
-    it 'has the right number of facets' do
-      expect(facet_buttons.size).to eq 4
+  ['/', '/?_ga=2.254463560.1947920273.1649182547-1700922359.1649079393'].each do |dest|
+    before do
+      delete_all_documents_from_solr
+      build_solr_docs(TEST_ITEM)
+      visit dest
     end
 
-    it 'has the right headers' do
-      expect(facet_headers).to match_array(['Resource Type', 'Language', 'Library', 'Access'])
-    end
-  end
-
-  context 'header links' do
-    let(:nav_links) { find_all('.non-collapse-navbar .navbar-nav .nav-link') }
-    let(:link_text_arr) { nav_links.map(&:text) }
-    let(:link_href_arr) { nav_links.map { |nl| nl['href'] } }
-    let(:expected_results_arr) do
-      [
-        { text: "Home", url: "/" },
-        { text: "eJournals A-Z", url: "/ejournals" },
-        { text: "Articles +", url: "https://emory.primo.exlibrisgroup.com/discovery/search?vid=01GALI_EMORY:articles" },
-        { text: "Databases@Emory", url: "https://guides.libraries.emory.edu/az.php" },
-        { text: "My Library Card", url: "https://emory.primo.exlibrisgroup.com/discovery/account?vid=01GALI_EMORY:services&section=overview&lang=en" },
-        { text: "Bookmarks 0", url: "/bookmarks" },
-        { text: "History", url: "/search_history" },
-        { text: "Help", url: "/help" }
-      ]
+    around do |example|
+      orig_key = ENV['ALMA_BIB_KEY']
+      ENV['ALMA_BIB_KEY'] = "some_fake_key"
+      example.run
+      ENV['ALMA_BIB_KEY'] = orig_key
     end
 
-    it 'has all the right links' do
-      nav_links.each_with_index do |_hsh, ind|
-        expect(expected_results_arr[ind]).to eq({ text: link_text_arr[ind], url: link_href_arr[ind] })
+    it 'has expected text' do
+      expect(page).to have_css('h3.header-search', text: 'Search books, e-books, journals, videos and more')
+    end
+
+    it('does not have the Title Starts With nav') { expect(page).not_to have_css('.first-main-char-ol') }
+
+    context 'facets' do
+      let(:facet_buttons) { find_all('h3.card-header.p-0.facet-field-heading button') }
+      let(:facet_headers) { facet_buttons.map(&:text) }
+
+      it 'has the right number of facets' do
+        expect(facet_buttons.size).to eq 4
+      end
+
+      it 'has the right headers' do
+        expect(facet_headers).to match_array(['Resource Type', 'Language', 'Library', 'Access'])
+      end
+    end
+
+    context 'header links' do
+      let(:nav_links) { find_all('.non-collapse-navbar .navbar-nav .nav-link') }
+      let(:link_text_arr) { nav_links.map(&:text) }
+      let(:link_href_arr) { nav_links.map { |nl| nl['href'] } }
+      let(:expected_results_arr) do
+        [
+          { text: "Home", url: "/" },
+          { text: "eJournals A-Z", url: "/ejournals" },
+          { text: "Articles +", url: "https://emory.primo.exlibrisgroup.com/discovery/search?vid=01GALI_EMORY:articles" },
+          { text: "Databases@Emory", url: "https://guides.libraries.emory.edu/az.php" },
+          { text: "My Library Card", url: "https://emory.primo.exlibrisgroup.com/discovery/account?vid=01GALI_EMORY:services&section=overview&lang=en" },
+          { text: "Bookmarks 0", url: "/bookmarks" },
+          { text: "History", url: "/search_history" },
+          { text: "Help", url: "/help" }
+        ]
+      end
+
+      it 'has all the right links' do
+        nav_links.each_with_index do |_hsh, ind|
+          expect(expected_results_arr[ind]).to eq({ text: link_text_arr[ind], url: link_href_arr[ind] })
+        end
       end
     end
   end


### PR DESCRIPTION
- .rubocop.yml: excludes the override of CatalogController's index method.
- app/views/*: uses newly created instance variable to feed homepage verification.
- config/initializers/catalog_index_override.rb: updates excluded params with `_ga` and provides that test result to the view.
- spec/system/front_page_spec.rb: makes sure visiting `/?_ga=2.254463560.1947920273.1649182547-1700922359.1649079393` produces the same results as the homepage.
<img width="1153" alt="Screen Shot 2022-04-06 at 2 30 10 PM" src="https://user-images.githubusercontent.com/18330149/162044171-2f70be8e-9312-4cf9-9ef9-9bf558f0d831.png">
<img width="1179" alt="Screen Shot 2022-04-06 at 2 30 38 PM" src="https://user-images.githubusercontent.com/18330149/162044183-0b3693b1-53ec-49ea-a139-9d38ea26e7bf.png">
<img width="1162" alt="Screen Shot 2022-04-06 at 2 31 25 PM" src="https://user-images.githubusercontent.com/18330149/162044184-61c5b7f9-81a8-41df-8cdf-1679cabfff37.png">

