### PR TITLE
Creates XML template to pass to Ares (#1131).

### DIFF
--- a/app/views/catalog/show.xml.builder
+++ b/app/views/catalog/show.xml.builder
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+xml.instruct! :xml, version: '1.0'
+xml.document do
+  xml.title @document['title_main_display_ssim']&.first
+  xml.author @document['author_display_ssim']&.first
+  xml.edition @document['edition_tsim']&.first
+  xml.publisher @document['published_tesim']&.first
+  xml.publication_date @document['pub_date_isim']&.first
+  xml.isbn @document['isbn_ssim']&.first
+  xml.issn @document['issn_ssim']&.first
+  xml.holdings do
+    @document.physical_holdings&.each do |ph|
+      xml.holding do
+        xml.barcodes(ph[:items].map { |i| i[:barcode] }.join('|'), { type: 'multi-value', delim: '|' })
+        xml.volumes_issues(ph[:items].map { |i| i[:description] }.join('|'), { type: 'multi-value', delim: '|' })
+        xml.call_number ph[:call_number]
+        xml.copy_number ph[:availability][:copies]
+        xml.library ph[:library][:label]
+        xml.location ph[:location][:label]
+      end
+    end
+  end
+end

--- a/config/initializers/catalog_show_override.rb
+++ b/config/initializers/catalog_show_override.rb
@@ -12,6 +12,7 @@ CatalogController.class_eval do
     respond_to do |format|
       format.html { @search_context = setup_next_and_previous_documents }
       format.json
+      format.xml
       additional_export_formats(@document, format)
     end
   end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -375,6 +375,26 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
         expect(page).to have_css('span#avail-990005988630302486-toggle', class: 'collapse')
       end
     end
+
+    context 'viewing xml version of document' do
+      let(:expected_values_arr) do
+        [['//title', 'The Title of my Work'], ['//author', 'George Jenkins'], ['//edition', 'A sample edition'],
+         ['//publisher', ''], ['//publication_date', '2015'], ['//isbn', 'SOME MAGICAL NUM .66G'],
+         ['//issn', 'SOME OTHER MAGICAL NUMBER .12Q'], ['//holdings//holding//barcodes', '010001233671'],
+         ['//holdings//holding//volumes_issues', ''], ['//holdings//holding//call_number', 'PT2613 .M45 Z92 2006'],
+         ['//holdings//holding//copy_number', '1'], ['//holdings//holding//library', 'Robert W. Woodruff Library'],
+         ['//holdings//holding//location', 'Book Stacks']]
+      end
+
+      it 'displays correct tag/values' do
+        visit "/catalog/#{id}.xml"
+        xml = Nokogiri::XML(page.body)
+
+        expected_values_arr.each do |arr|
+          expect(xml.xpath(arr[0]).text).to eq(arr[1])
+        end
+      end
+    end
   end
 
   context 'A special collections item' do


### PR DESCRIPTION
- app/views/catalog/show.xml.builder: stubs out template to build XML document for Ares.
- config/initializers/catalog_show_override.rb: ensures that the .xml extension looks at the builder template.
- spec/system/view_show_page_spec.rb: tests the expectations of the XML.

```
<?xml version="1.0" encoding="UTF-8"?>
<document>
  <title>Arntz-Bulletin; : Dokumentation der Kunst des 20. Jahrhunderts. Bibliographie, Werk-Kataloge ...</title>
  <author/>
  <edition/>
  <publisher>[Distributed in U.S. by Wittenborn, Verlag G. Arntz-Winter]</publisher>
  <publication_date>1968</publication_date>
  <isbn/>
  <issn/>
  <holdings>
    <holding>
      <barcodes type="multi-value" delim="|">010000712412|010000712414</barcodes>
      <volumes_issues type="multi-value" delim="|">V.1|V.2 PT.1-6</volumes_issues>
      <call_number>Z5935 .A762</call_number>
      <copy_number>2</copy_number>
      <library>Library Service Center</library>
      <location/>
    </holding>
  </holdings>
</document>
```
