### PR TITLE
Adds requested elements to a Record's show XML.

### DIFF
--- a/app/views/catalog/_physical_holding.xml.builder
+++ b/app/views/catalog/_physical_holding.xml.builder
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+xml.physical_holding do
+  xml.call_number ph[:call_number]
+  xml.copy_number ph[:availability][:copies]
+  xml.library ph[:library][:label]
+  xml.location ph[:location][:label]
+  xml.items do
+    ph[:items]&.each do |i|
+      xml.item do
+        xml.barcode i[:barcode]
+        xml.volume_or_issue i[:description]
+        xml.status i[:status]
+      end
+    end
+  end
+end

--- a/app/views/catalog/_supplemental_link.xml.builder
+++ b/app/views/catalog/_supplemental_link.xml.builder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+xml.supplemental_link do
+  link_pieces = supp.split(' text: ')
+  xml.link link_pieces.first
+  xml.label link_pieces.size > 1 ? link_pieces[1] : link_pieces.first
+end

--- a/app/views/catalog/show.xml.builder
+++ b/app/views/catalog/show.xml.builder
@@ -4,21 +4,21 @@ xml.instruct! :xml, version: '1.0'
 xml.document do
   xml.title @document['title_main_display_ssim']&.first
   xml.author @document['author_display_ssim']&.first
+  xml.is_physical_holding @document['marc_resource_ssim']&.include?('At the Library')
+  xml.is_electronic_holding @document['marc_resource_ssim']&.include?('Online')
   xml.edition @document['edition_tsim']&.first
   xml.publisher @document['published_tesim']&.first
   xml.publication_date @document['pub_date_isim']&.first
   xml.isbn @document['isbn_ssim']&.first
   xml.issn @document['issn_ssim']&.first
-  xml.holdings do
+  xml.supplemental_links do
+    @document['url_suppl_ssim']&.each do |supp|
+      xml << render(partial: 'supplemental_link', locals: { supp: supp })
+    end
+  end
+  xml.physical_holdings do
     @document.physical_holdings&.each do |ph|
-      xml.holding do
-        xml.barcodes(ph[:items].map { |i| i[:barcode] }.join('|'), { type: 'multi-value', delim: '|' })
-        xml.volumes_issues(ph[:items].map { |i| i[:description] }.join('|'), { type: 'multi-value', delim: '|' })
-        xml.call_number ph[:call_number]
-        xml.copy_number ph[:availability][:copies]
-        xml.library ph[:library][:label]
-        xml.location ph[:location][:label]
-      end
+      xml << render(partial: 'physical_holding', locals: { ph: ph })
     end
   end
 end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -379,11 +379,15 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
     context 'viewing xml version of document' do
       let(:expected_values_arr) do
         [['//title', 'The Title of my Work'], ['//author', 'George Jenkins'], ['//edition', 'A sample edition'],
+         ['//is_physical_holding', 'false'], ['//is_electronic_holding', 'false'],
          ['//publisher', ''], ['//publication_date', '2015'], ['//isbn', 'SOME MAGICAL NUM .66G'],
-         ['//issn', 'SOME OTHER MAGICAL NUMBER .12Q'], ['//holdings//holding//barcodes', '010001233671'],
-         ['//holdings//holding//volumes_issues', ''], ['//holdings//holding//call_number', 'PT2613 .M45 Z92 2006'],
-         ['//holdings//holding//copy_number', '1'], ['//holdings//holding//library', 'Robert W. Woodruff Library'],
-         ['//holdings//holding//location', 'Book Stacks']]
+         ['//issn', 'SOME OTHER MAGICAL NUMBER .12Q'], ['//supplemental_links//supplemental_link//link', 'http://www.example.com'],
+         ['//supplemental_links//supplemental_link//label', 'http://www.example.com'],
+         ['//physical_holdings//physical_holding//copy_number', '1'], ['//physical_holdings//physical_holding//call_number', 'PT2613 .M45 Z92 2006'],
+         ['//physical_holdings//physical_holding//library', 'Robert W. Woodruff Library'],
+         ['//physical_holdings//physical_holding//location', 'Book Stacks'], ['//physical_holdings//physical_holding//items//item//barcode', '010001233671'],
+         ['//physical_holdings//physical_holding//items/item//volume_or_issue', ''],
+         ['//physical_holdings//physical_holding//items/item//status', 'Item in place']]
       end
 
       it 'displays correct tag/values' do


### PR DESCRIPTION
- app/views/catalog/_physical_holding.xml.builder: throws enumerative code into a partial. Also breaks out items into their own element with associative barcode, vol/issue, and status.
- app/views/catalog/_supplemental_link.xml.builder: a partial created for the requested supplemental links addition.
- app/views/catalog/show.xml.builder: 
  - Adds the holding type boolean elements.
  - Points to the partial above for the supplemental links.
  - Partializes the holdings elements and also renames them since we are now referring to online resources.
- spec/system/view_show_page_spec.rb: Updates the spec to expect the new elements and structure.