### PR TITLE
Separates the values for 022ay to make searching easier (#1260).

### DIFF
--- a/lib/marc_indexer.rb
+++ b/lib/marc_indexer.rb
@@ -161,7 +161,7 @@ to_field 'material_type_display_tesim', extract_marc('300abcef'), trim_punctuati
 
 # Various Identification Fields
 to_field "isbn_ssim", extract_isbn
-to_field 'issn_ssim', extract_marc('022ay:800x:810x:811x:830x')
+to_field 'issn_ssim', extract_marc('022a:022y:800x:810x:811x:830x')
 to_field 'lccn_ssim', extract_marc('010a')
 to_field 'oclc_ssim', oclcnum('019a:035a')
 to_field 'other_standard_ids_tesim', extract_other_standard_ids

--- a/spec/fixtures/alma_marc_resource.xml
+++ b/spec/fixtures/alma_marc_resource.xml
@@ -1689,6 +1689,10 @@
           <datafield tag="010" ind1=" " ind2=" ">
             <subfield code="a">93030188</subfield>
           </datafield>
+          <datafield tag="022" ind1=" " ind2=" ">
+            <subfield code="a">123456</subfield>
+            <subfield code="y">7891011</subfield>
+          </datafield>
           <datafield tag="035" ind1=" " ind2=" ">
             <subfield code="a">(Aleph)002391657EMU01</subfield>
           </datafield>

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -403,4 +403,11 @@ RSpec.describe 'Indexing fields with custom logic' do
     it('maps the 966a fields') { expect(solr_doc['holdings_note_tesim']).to eq(['Hey, look! Holding notes, bustah!']) }
     it('returns nil when no 966a fields') { expect(solr_doc2['holdings_note_tesim']).to be_nil }
   end
+
+  describe 'issn_ssim field' do
+    it 'returns two separate values when 022 a and y populated' do
+      expect(solr_doc10['issn_ssim']).to match_array ['123456', '7891011']
+      expect(solr_doc10['issn_ssim']).not_to match_array ['123456 7891011']
+    end
+  end
 end


### PR DESCRIPTION
- lib/marc_indexer.rb: ensures that 022a and 022y are separate values in the Solr mapping. 
- spec/fixtures/alma_marc_resource.xml: adds a 022 datafield to test against.
- spec/models/marc_indexing_spec.rb: verifies that the separate subfields come through as more than one value.

