### PR TITLE
Process a single record index regardless of presence of resumption token.

### DIFF
--- a/app/services/oai_query_string_service.rb
+++ b/app/services/oai_query_string_service.rb
@@ -24,7 +24,7 @@ class OaiQueryStringService
 
   def self.process_string(saved_resumption_token, oai_set, from_time, to_time, single_record)
     # resume from last harvested
-    return "?verb=ListRecords&resumptionToken=#{saved_resumption_token}" if saved_resumption_token.present?
+    return "?verb=ListRecords&resumptionToken=#{saved_resumption_token}" if saved_resumption_token.present? && !single_record
     # start a single record harvest
     return "?verb=GetRecord&identifier=oai:alma.#{ENV['INSTITUTION']}:#{oai_set}&metadataPrefix=marc21" if single_record
     # start a fresh set harvest

--- a/spec/services/oai_query_string_service_spec.rb
+++ b/spec/services/oai_query_string_service_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe OaiQueryStringService, :clean do
       check_other_methods_called
       expect(qs).to eq("?verb=ListRecords&resumptionToken=Hello!")
     end
+
+    it 'returns the right string when resumption token present but single_record true' do
+      PropertyBag.set('marc_ingest_resumption_token', 'Hello!')
+      qs = described_class.process_query_string(oai_set, full_index, to_time, true, logger)
+
+      check_other_methods_called
+      expect(qs).not_to eq("?verb=ListRecords&resumptionToken=Hello!")
+      expect(qs).to eq(
+        "?verb=GetRecord&identifier=oai:alma.#{institution}:#{oai_set}&metadataPrefix=marc21"
+      )
+    end
   end
 
   context '#process_from_time' do


### PR DESCRIPTION
- app/services/oai_query_string_service.rb: adds blocker to resumption token query if single_record is present.
- spec/services/oai_query_string_service_spec.rb: checks for right results.
