### PR TITLE
Factors in logic that shows temporarily located items.

### DIFF
--- a/app/models/concerns/statusable.rb
+++ b/app/models/concerns/statusable.rb
@@ -83,7 +83,7 @@ module Statusable
   end
 
   def items_by_holding_record(holding_id, user = nil)
-    items_record(user).xpath("//holding_id[text()='#{holding_id}']/parent::holding_data/following-sibling::item_data")
+    items_record(user).xpath("//holding_id[text()='#{holding_id}']/parent::holding_data")
   end
 
   def record_response
@@ -178,21 +178,24 @@ module Statusable
   def items_by_holding_values(holding_id, user = nil)
     items_by_holding_record(holding_id, user).map do |node|
       {
-        pid: node.xpath("pid")&.inner_text,
-        barcode: node.xpath("barcode")&.inner_text,
-        type: node.xpath("physical_material_type").attr("desc")&.value,
-        type_code: node.xpath("physical_material_type")&.text,
+        pid: node.xpath("following-sibling::item_data/pid")&.inner_text,
+        barcode: node.xpath("following-sibling::item_data/barcode")&.inner_text,
+        type: node.xpath("following-sibling::item_data/physical_material_type").attr("desc")&.value,
+        type_code: node.xpath("following-sibling::item_data/physical_material_type")&.text,
         policy: item_policy(node, user),
-        description: node.xpath("description")&.inner_text,
-        status: node.xpath('base_status').attr("desc")&.value
+        description: node.xpath("following-sibling::item_data/description")&.inner_text,
+        status: node.xpath('following-sibling::item_data/base_status').attr("desc")&.value,
+        temporarily_located: node.xpath('in_temp_location')&.inner_text,
+        temp_library: node.xpath('temp_library').attr('desc')&.value,
+        temp_location: node.xpath('temp_location').attr('desc')&.value
       }
     end
   end
 
   def item_policy(node, _user)
-    policy_desc = node.xpath('policy').attr("desc")&.value
-    policy_id = node.xpath('policy')&.inner_text
-    due_date_policy = node.xpath('due_date_policy')&.inner_text
+    policy_desc = node.xpath('following-sibling::item_data/policy').attr("desc")&.value
+    policy_id = node.xpath('following-sibling::item_data/policy')&.inner_text
+    due_date_policy = node.xpath('following-sibling::item_data/due_date_policy')&.inner_text
     { policy_desc: policy_desc, policy_id: policy_id, due_date_policy: due_date_policy }
   end
 

--- a/app/views/catalog/_physical_holding.xml.builder
+++ b/app/views/catalog/_physical_holding.xml.builder
@@ -3,7 +3,6 @@
 if ph[:items].size.positive?
   xml.physical_holding do
     xml.call_number ph[:call_number]
-    xml.copy_number ph[:availability][:copies]
     xml.items do
       ph[:items]&.each do |i|
         xml.item do

--- a/app/views/catalog/_physical_holding.xml.builder
+++ b/app/views/catalog/_physical_holding.xml.builder
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-xml.physical_holding do
-  xml.call_number ph[:call_number]
-  xml.copy_number ph[:availability][:copies]
-  xml.library ph[:library][:label]
-  xml.location ph[:location][:label]
-  xml.items do
-    ph[:items]&.each do |i|
-      xml.item do
-        xml.barcode i[:barcode]
-        xml.volume_or_issue i[:description]
-        xml.status i[:status]
+if ph[:items].size.positive?
+  xml.physical_holding do
+    xml.call_number ph[:call_number]
+    xml.copy_number ph[:availability][:copies]
+    xml.items do
+      ph[:items]&.each do |i|
+        xml.item do
+          xml.library ActiveModel::Type::Boolean.new.cast(i[:temporarily_located]) ? i[:temp_library] : ph[:library][:label]
+          xml.location ActiveModel::Type::Boolean.new.cast(i[:temporarily_located]) ? i[:temp_location] : ph[:location][:label]
+          xml.barcode i[:barcode]
+          xml.volume_or_issue i[:description]
+          xml.status i[:status]
+        end
       end
     end
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -174,17 +174,27 @@ RSpec.describe SolrDocument do
 
       it "can get the due_date_policy based on the user" do
         expect(solr_doc.items_query(user)).to eq "/holdings/ALL/items?limit=100&offset=0&expand=due_date_policy&user_id=janeq&order_by=chron_i&apikey="
-        expect(solr_doc.physical_holdings(user).first[:items].last).to eq({ barcode: "010002752069", type: "Bound Issue", pid: "23236301160002486",
-                                                                            policy: { policy_desc: "30 Day Loan Storage", policy_id: "17", due_date_policy: "28 Days Loan" },
-                                                                            description: "v.75(2013)", status: "Item in place", type_code: "ISSBD" })
+        expect(solr_doc.physical_holdings(user).first[:items].last).to eq(
+          {
+            barcode: "010002752069", type: "Bound Issue", pid: "23236301160002486",
+            policy: { policy_desc: "30 Day Loan Storage", policy_id: "17", due_date_policy: "28 Days Loan" },
+            description: "v.75(2013)", status: "Item in place", type_code: "ISSBD",
+            temp_library: nil, temp_location: nil, temporarily_located: "false"
+          }
+        )
         expect(solr_doc.hold_requestable?).to eq true
       end
 
       it "can get the due_date_policy for a guest user" do
         expect(solr_doc.items_query).to eq "/holdings/ALL/items?limit=100&offset=0&expand=due_date_policy&user_id=GUEST&order_by=chron_i&apikey="
-        expect(solr_doc.physical_holdings.first[:items].last).to eq({ barcode: "010002752069", type: "Bound Issue", pid: "23236301160002486",
-                                                                      policy: { policy_desc: "30 Day Loan Storage", policy_id: "17", due_date_policy: "Loanable" },
-                                                                      description: "v.75(2013)", status: "Item in place", type_code: "ISSBD" })
+        expect(solr_doc.physical_holdings.first[:items].last).to eq(
+          {
+            barcode: "010002752069", type: "Bound Issue", pid: "23236301160002486",
+            policy: { policy_desc: "30 Day Loan Storage", policy_id: "17", due_date_policy: "Loanable" },
+            description: "v.75(2013)", status: "Item in place", type_code: "ISSBD",
+            temp_library: nil, temp_location: nil, temporarily_located: "false"
+          }
+        )
         expect(solr_doc.hold_requestable?).to eq true
       end
     end

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
          ['//publisher', ''], ['//publication_date', '2015'], ['//isbn', 'SOME MAGICAL NUM .66G'],
          ['//issn', 'SOME OTHER MAGICAL NUMBER .12Q'], ['//supplemental_links//supplemental_link//link', 'http://www.example.com'],
          ['//supplemental_links//supplemental_link//label', 'http://www.example.com'],
-         ['//physical_holdings//physical_holding//copy_number', '1'], ['//physical_holdings//physical_holding//call_number', 'PT2613 .M45 Z92 2006'],
+         ['//physical_holdings//physical_holding//call_number', 'PT2613 .M45 Z92 2006'],
          ['//physical_holdings//physical_holding//library', 'Robert W. Woodruff Library'],
          ['//physical_holdings//physical_holding//location', 'Book Stacks'], ['//physical_holdings//physical_holding//items//item//barcode', '010001233671'],
          ['//physical_holdings//physical_holding//items/item//volume_or_issue', ''],


### PR DESCRIPTION
- app/models/concerns/statusable.rb: widens out the scope of the item value scraping, and adds the temporary details needed.
- app/views/catalog/_physical_holding.xml.builder: removes copy number and adds in item specific library and location with logic to read temporarily located records.
- spec/*: updates expectations for new and removed keys/values.

