### PR TITLE
Removes old links back to Contacts page.

### DIFF
--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -36,7 +36,7 @@
           <ul class="explore-links">
             <li class="explore-link-item"><%= link_to t('static.about.explore.materials_link_text'), "https://libraries.emory.edu/materials/index.html", class: "explore-link" %></li>
             <li class="explore-link-item"><%= link_to t('static.about.explore.research_link_text'), "https://guides.libraries.emory.edu/main", class: "explore-link" %></li>
-            <li class="explore-link-item"><%= link_to t('static.about.explore.contact_link_text'), contact_path, class: "explore-link" %></li>
+            <li class="explore-link-item"><%= link_to t('static.about.explore.contact_link_text'), help_path, class: "explore-link" %></li>
           </ul>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,11 +43,11 @@ en:
         blurb: "Emory Libraries is committed to the principles of universal design and strives to provide equitable services online and in our spaces. We assess and enhance the usability and accessibility of our digital interfaces on an ongoing basis, and use Section 508 of the Rehabilitation Act and current WCAG AA standards as benchmarks. For further information, please use our feedback form or consult Emory’s Department of Accessibility Services."
       help:
         blurb_header: "Questions, Help, and Feedback"
-        blurb: "Please visit our <a href='/contact'>Contact page</a> for more information about Emory Libraries collections, catalog, electronic resources, and access. You can also reach out via our feedback form or visit our project wiki."
+        blurb: "Please visit our <a href='/help'>Help & Contacts page</a> for more information about Emory Libraries collections, catalog, electronic resources, and access. You can also reach out via our feedback form or visit our project wiki."
       explore:
         materials_link_text: "Information about Libraries Materials"
         research_link_text: "Research Guides"
-        contact_link_text: "Contact Us"
+        contact_link_text: "Help & Contacts"
     contact:
       explore:
         title: "Explore"

--- a/spec/system/view_about_page.rb
+++ b/spec/system/view_about_page.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "View the about page", type: :system do
+  it 'has the correct contact links' do
+    visit about_path
+
+    expect(page).to have_css('p.static-blurb-body.help-blurb a', text: 'Help & Contacts page')
+    expect(page).to have_link('Help & Contacts', class: 'explore-link')
+  end
+end


### PR DESCRIPTION
- app/views/static/about.html.erb: now pointing to `/help`.
- config/locales/en.yml: updates text to the Help & Contacts page.
- spec/system/view_about_page.rb: institutes a needed test.
![Screen Shot 2022-07-13 at 9 40 25 AM](https://user-images.githubusercontent.com/18330149/178747746-b07eb776-d684-4663-8f5c-b64056981464.png)

