### PR TITLE
Add content blocks admin dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 ruby '~> 2.7.4'
 
+gem 'administrate'
 gem 'blacklight', '7.4.1'
 gem 'blacklight-marc', '>= 7.0.0.rc1'
 gem 'blacklight_advanced_search'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,16 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    administrate (0.17.0)
+      actionpack (>= 5.0)
+      actionview (>= 5.0)
+      activerecord (>= 5.0)
+      datetime_picker_rails (~> 0.0.7)
+      jquery-rails (>= 4.0)
+      kaminari (>= 1.0)
+      momentjs-rails (~> 2.8)
+      sassc-rails (~> 2.1)
+      selectize-rails (~> 0.6)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (8.0.0)
@@ -146,6 +156,8 @@ GEM
       tins (~> 1.6)
     crack (0.4.4)
     crass (1.0.6)
+    datetime_picker_rails (0.0.7)
+      momentjs-rails (>= 2.8.1)
     deprecation (1.0.0)
       activesupport
     devise (4.7.3)
@@ -255,6 +267,8 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
+    momentjs-rails (2.29.1.1)
+      railties (>= 3.1)
     multipart-post (2.1.1)
     mysql2 (0.5.3)
     net-scp (3.0.0)
@@ -423,6 +437,7 @@ GEM
       tilt
     scrub_rb (1.0.1)
     secure_headers (6.3.2)
+    selectize-rails (0.12.6)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -519,6 +534,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  administrate
   bixby
   blacklight (= 7.4.1)
   blacklight-marc (>= 7.0.0.rc1)

--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Admin
+  class AdminController < ApplicationController
+    authorize_resource class: :admin
+
+    def index; end
+  end
+end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Admin
+  class ApplicationController < Administrate::ApplicationController
+    before_action :authenticate_admin
+
+    def authenticate_admin
+      can? :manage, :admin
+    end
+
+    def show_action?(action, resource)
+      can? action, resource
+    end
+  end
+end

--- a/app/controllers/admin/content_blocks_controller.rb
+++ b/app/controllers/admin/content_blocks_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Admin
+  class ContentBlocksController < Admin::ApplicationController
+    authorize_resource class: ContentBlock
+
+    def valid_action?(name, resource = resource_class)
+      %w[destroy].exclude?(name.to_s) && super
+    end
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-class AdminController < ApplicationController
-  authorize_resource class: false
-
-  def index; end
-end

--- a/app/dashboards/content_block_dashboard.rb
+++ b/app/dashboards/content_block_dashboard.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require "administrate/base_dashboard"
+
+class ContentBlockDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    reference: Field::String,
+    value: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    reference
+    value
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    reference
+    value
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    reference
+    value
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  def permitted_attributes
+    [:value].map do |attr|
+      attribute_types[attr].permitted_attribute(
+        attr,
+        resource_class: self.class.model
+      )
+    end.uniq
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,9 @@ class Ability
   def initialize(user)
     return unless user&.admin?
 
-    can :index, :admin
+    can :manage, :admin
     can :manage, :flipflop
+    can :read, ContentBlock
+    can :update, ContentBlock
   end
 end

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class ContentBlock < ApplicationRecord
+  validates :reference, presence: true
+  delegate :blank?, to: :value
+
+  def self.homepage_banner
+    ContentBlock.find_by(reference: 'homepage_banner') || ContentBlock.blank(reference: 'homepage_banner')
+  end
+
+  def self.blank(reference:)
+    ContentBlock.new(reference: reference, value: '')
+  end
+end

--- a/app/views/admin/admin/index.html.erb
+++ b/app/views/admin/admin/index.html.erb
@@ -1,2 +1,3 @@
 <h1 class="static-heading">Admin Dashboard</h1>
 <p class="static-blurb-body contacts-blurb"><%= link_to 'Experimental Features Dashboard', '/features', class: "static-blurb-link" %></p>
+<p class="static-blurb-body contacts-blurb"><%= link_to 'Content Blocks Dashboard', '/admin/content_blocks', class: "static-blurb-link" %></p>

--- a/app/views/admin/content_blocks/_form.html.erb
+++ b/app/views/admin/content_blocks/_form.html.erb
@@ -1,0 +1,56 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name, singular: true)
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes(controller.action_name).each do |attribute| -%>
+    <% if attribute.name == 'reference'%>
+      <div class="field-unit field-unit--string field-unit--required" disabled="">
+        <div class="field-unit__label">
+          <label for="content_block_reference">Reference</label>
+        </div>
+        <div class="field-unit__field">
+          <input type="text" value='<%= attribute.data %>' name="content_block[reference]" id="content_block_reference" disabled="">
+        </div>
+    </div>
+    <% else %>
+      <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+        <%= render_field attribute, f: f %>
+      </div>
+    <% end %>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/shared/_beta_banner.html.erb
+++ b/app/views/shared/_beta_banner.html.erb
@@ -1,3 +1,0 @@
-<div class='beta-banner alert alert-warning'>
-  The ILLiad interlibrary loan site will be inaccessible due to maintenance on Tuesday 6/14 from 8am-11am. We appreciate your patience during this time.
-</div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -9,7 +9,7 @@
           <%= render 'shared/static_links', mobile: false %>
         </div>
       </div>
-      <%#= render 'shared/beta_banner' if @homepage %>
+      <%= render 'shared/homepage_banner' unless ContentBlock.homepage_banner.blank? %>
       <div class="row justify-content-between branding-row header-main">
         <div class="branding-header">
           <div class="branding-header logo">

--- a/app/views/shared/_homepage_banner.html.erb
+++ b/app/views/shared/_homepage_banner.html.erb
@@ -1,0 +1,1 @@
+<div class='beta-banner alert alert-warning'><%= ContentBlock.homepage_banner.value %></div>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -3,7 +3,7 @@
   <% if has_user_authentication_provider? %>
     <% if current_user %>
       <% if current_user&.admin? %>
-        <%= link_to t('blacklight.admin'), admin_path, class: 'nav-link' %>
+        <%= link_to t('blacklight.admin'), admin_root_path, class: 'nav-link' %>
       <% end %>
       <li class="nav-item">
         <% if current_user.display_name %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :content_blocks
+
+    root to: "admin#index"
+  end
+
   mount Flipflop::Engine => "/features"
   mount Qa::Engine => '/qa'
 
@@ -56,5 +62,4 @@ Rails.application.routes.draw do
   match '/422', to: 'errors#unprocessable', via: :all
   get '/collections/search', to: 'collections#search'
   get '/ejournals', to: 'static#ejournals'
-  get '/admin', to: 'admin#index'
 end

--- a/db/migrate/20220711210400_create_content_blocks.rb
+++ b/db/migrate/20220711210400_create_content_blocks.rb
@@ -1,0 +1,10 @@
+class CreateContentBlocks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :content_blocks do |t|
+      t.string :reference
+      t.string :value
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220714215552_add_homepage_banner_content_block.rb
+++ b/db/migrate/20220714215552_add_homepage_banner_content_block.rb
@@ -1,0 +1,9 @@
+class AddHomepageBannerContentBlock < ActiveRecord::Migration[5.1]
+  def up
+    ContentBlock.create(reference: 'homepage_banner', value: '')
+  end
+
+  def down
+    ContentBlock.find_by(reference: 'homepage_banner').destroy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220707190108) do
+ActiveRecord::Schema.define(version: 20220714215552) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
     t.integer "user_id", null: false
@@ -22,6 +22,13 @@ ActiveRecord::Schema.define(version: 20220707190108) do
     t.datetime "updated_at", null: false
     t.index ["document_id"], name: "index_bookmarks_on_document_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "content_blocks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|
+    t.string "reference"
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "flipflop_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci" do |t|

--- a/spec/controllers/admin/admin_controller_spec.rb
+++ b/spec/controllers/admin/admin_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe AdminController, type: :controller do
+RSpec.describe Admin::AdminController, type: :controller do
   describe '#index' do
     context 'when a user is logged in' do
       before do

--- a/spec/controllers/admin/content_blocks_controller_spec.rb
+++ b/spec/controllers/admin/content_blocks_controller_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Admin::ContentBlocksController, type: :controller do
+  describe '#index' do
+    context 'when a user is logged in' do
+      before do
+        sign_in(user)
+      end
+
+      context 'and is an admin' do
+        let(:user) { User.create(uid: 'test', role: :admin) }
+
+        it 'loads content blocks dashboard' do
+          get :index
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context 'and is a guest' do
+        let(:user) { User.create(uid: 'test', role: :guest) }
+
+        it 'denies access to the content blocks dashboard' do
+          expect { get :index }.to raise_error CanCan::AccessDenied
+        end
+      end
+    end
+
+    context 'when no user is logged in' do
+      it 'denies access to the content blocks dashboard' do
+        expect { get :index }.to raise_error CanCan::AccessDenied
+      end
+    end
+  end
+
+  describe '#show' do
+    let!(:content_block) { FactoryBot.create(:content_block) }
+
+    context 'when a user is logged in' do
+      before do
+        sign_in(user)
+      end
+
+      context 'and is an admin' do
+        let(:user) { User.create(uid: 'test', role: :admin) }
+
+        it 'loads the content block' do
+          get :show, params: { id: content_block.id }
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context 'and is a guest' do
+        let(:user) { User.create(uid: 'test', role: :guest) }
+
+        it 'denies access to the content block' do
+          expect { get :show, params: { id: content_block.id } }.to raise_error CanCan::AccessDenied
+        end
+      end
+    end
+
+    context 'when no user is logged in' do
+      it 'denies access to the content block' do
+        expect { get :show, params: { id: content_block.id } }.to raise_error CanCan::AccessDenied
+      end
+    end
+  end
+
+  describe '#update' do
+    let!(:content_block) { FactoryBot.create(:content_block) }
+
+    context 'when a user is logged in' do
+      before do
+        sign_in(user)
+      end
+
+      context 'and is an admin' do
+        let(:user) { User.create(uid: 'test', role: :admin) }
+
+        it 'enables user to update the content block' do
+          put :update, params: { "content_block" => { "value" => "new_value" }, "id" => content_block.id.to_s }
+          expect(response).to have_http_status(:found)
+          content_block.reload
+          expect(content_block.value).to eq('new_value')
+        end
+      end
+
+      context 'and is a guest' do
+        let(:user) { User.create(uid: 'test', role: :guest) }
+
+        it 'denies access to the content block' do
+          expect { put :update, params: { "content_block" => { "value" => "hello_world" }, "id" => content_block.id.to_s } }.to raise_error CanCan::AccessDenied
+        end
+      end
+    end
+
+    context 'when no user is logged in' do
+      it 'denies access to the content block' do
+        expect { put :update, params: { "content_block" => { "value" => "hello_world" }, "id" => content_block.id.to_s } }.to raise_error CanCan::AccessDenied
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let!(:content_block) { FactoryBot.create(:content_block) }
+
+    context 'when a user is logged in' do
+      before do
+        sign_in(user)
+      end
+
+      context 'and is an admin' do
+        let(:user) { User.create(uid: 'test', role: :admin) }
+
+        it 'is not permitted' do
+          expect { delete :destroy, params: { id: content_block.id } }.to raise_error CanCan::AccessDenied
+        end
+      end
+
+      context 'and is a guest' do
+        let(:user) { User.create(uid: 'test', role: :guest) }
+
+        it 'is not permitted' do
+          expect { delete :destroy, params: { id: content_block.id } }.to raise_error CanCan::AccessDenied
+        end
+      end
+    end
+
+    context 'when no user is logged in' do
+      it 'is not permitted' do
+        expect { delete :destroy, params: { id: content_block.id } }.to raise_error CanCan::AccessDenied
+      end
+    end
+  end
+end

--- a/spec/factories/content_blocks.rb
+++ b/spec/factories/content_blocks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :content_block do
+    reference { "reference" }
+    value { "value" }
+  end
+end

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Admin Dashboard', type: :feature do
       let(:user) { User.create(uid: 'test', role: :admin) }
 
       it 'loads admin dashboard' do
-        visit admin_path
+        visit admin_root_path
         expect(status_code).to eq(200)
         expect(page).to have_content('Admin Dashboard')
       end
@@ -22,7 +22,7 @@ RSpec.describe 'Admin Dashboard', type: :feature do
       let(:user) { User.create(uid: 'test', role: :guest) }
 
       it 'does not load the admin dashboard' do
-        visit admin_path
+        visit admin_root_path
         expect(status_code).to eq(500)
         expect(page).not_to have_content('Admin Dashboard')
       end
@@ -31,7 +31,7 @@ RSpec.describe 'Admin Dashboard', type: :feature do
 
   context 'when no user is logged in' do
     it 'does not load the admin dashboard' do
-      visit admin_path
+      visit admin_root_path
       expect(status_code).to eq(500)
       expect(page).not_to have_content('Admin Dashboard')
     end

--- a/spec/features/content_blocks_dashboard_spec.rb
+++ b/spec/features/content_blocks_dashboard_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Content Blocks Dashboard', type: :feature do
+  let!(:content_block) { FactoryBot.create(:content_block) }
+
+  context 'when a user is logged in' do
+    before do
+      sign_in(user)
+    end
+
+    context 'and is an admin' do
+      let(:user) { User.create(uid: 'test', role: :admin) }
+
+      it 'loads the content blocks dashboard' do
+        visit '/admin/content_blocks'
+        expect(status_code).to eq(200)
+        expect(page).to have_content('Content Blocks')
+      end
+
+      it 'enables user to edit a content block' do
+        visit '/admin/content_blocks'
+        click_link 'Edit'
+        fill_in 'content_block_value', with: 'new_value'
+        find('input[name="commit"]').click
+        expect(page).to have_content('Content block was successfully updated.')
+        content_block.reload
+        expect(content_block.value).to eq('new_value')
+      end
+    end
+
+    context 'and is a guest' do
+      let(:user) { User.create(uid: 'test', role: :guest) }
+
+      it 'does not load the content blocks dashboard' do
+        visit '/admin/content_blocks'
+        expect(status_code).to eq(500)
+        expect(page).not_to have_content('Content Blocks')
+      end
+    end
+  end
+
+  context 'when no user is logged in' do
+    it 'does not load the content blocks dashboard' do
+      visit '/admin/content_blocks'
+      expect(status_code).to eq(500)
+      expect(page).not_to have_content('Content Blocks')
+    end
+  end
+end

--- a/spec/models/content_block_spec.rb
+++ b/spec/models/content_block_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ContentBlock, type: :model do
+  it 'validates correctly formatted content blocks' do
+    content_block = described_class.new(reference: 'reference', value: 'value')
+    expect(content_block.valid?).to be true
+  end
+
+  it "validates the presence of reference" do
+    content_block = described_class.new(value: 'value')
+    expect(content_block.valid?).to be false
+  end
+end


### PR DESCRIPTION
This PR addresses the following requirement from #1275:

- Add admin ability to edit front page banner

This PR includes the following changes:
- Add gem `administrate ` to use customizable admin dashboards
- Add a dashboard to display and edit content blocks under route `/admin/content_blocks`
- Only allow logged in admins to read and update content blocks, no user is allowed to delete a content block
- Use value of `ContentBlock.homepage_banner` to populate the homepage banner, and remove deprecated view `_beta_banner.html.erb`

Please refer to the following screenshots:

![Screen Shot 2022-07-14 at 6 24 57 PM](https://user-images.githubusercontent.com/13107510/179098653-f65973ba-97df-4663-9121-b753857dde0f.png)

![Screen Shot 2022-07-14 at 6 25 17 PM](https://user-images.githubusercontent.com/13107510/179098692-82b50df4-2419-4d3e-ab3d-1e7dae6cd50e.png)

![Screen Shot 2022-07-14 at 6 25 40 PM](https://user-images.githubusercontent.com/13107510/179098720-25f35841-e1bf-409b-9551-0d4ee1e4b13b.png)

![Screen Shot 2022-07-14 at 6 32 22 PM](https://user-images.githubusercontent.com/13107510/179099458-e551bf92-15e2-4856-a674-976329cd92f7.png)

