### PR TITLE
Add enhancements to Chicago citation formatter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/AbcSize:
         - 'app/models/concerns/blacklight/solr/document/marc_export.rb'
         - 'app/services/oai_processing_service.rb'
         - 'app/services/oai_processing_single_service.rb'
-        - 'lib/citation_formatter.rb'
+        - 'lib/chicago_citation_formatter.rb'
         - 'app/helpers/citation_modal_helper.rb'
 
 Metrics/BlockLength:
@@ -53,7 +53,7 @@ Metrics/MethodLength:
         - 'app/helpers/citation_modal_helper.rb'
         - 'lib/traject/extract_publication_date.rb'
         - 'lib/traject/extract_url_fulltext.rb'
-        - 'lib/citation_formatter.rb'
+        - 'lib/chicago_citation_formatter.rb'
         - 'app/controllers/sessions/social_login.rb'
         - 'config/initializers/bookmarks_index_override.rb'
         - 'config/initializers/catalog_index_override.rb'

--- a/app/models/concerns/blacklight/solr/document/marc_export.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'openurl'
-require './lib/citation_formatter'
+require './lib/chicago_citation_formatter'
 
 # Overwrites the apa_citation and mla_citation methods from module of same name
 #   v7.0.0, as well as adds new methods to assist the new logic.
@@ -41,12 +41,9 @@ module Blacklight::Solr::Document::MarcExport
   end
 
   def export_as_chicago_citation_txt
-    generator = CitationFormatter.new(self)
-    begin
-      generator.citation_for('chicago-fullnote-bibliography')
-    rescue
-      chicago_citation(to_marc)
-    end
+    ChicagoCitationFormatter.new(self).cite!
+  rescue
+    chicago_citation(to_marc)
   end
 
   # Exports as an OpenURL KEV (key-encoded value) query string.

--- a/lib/chicago_citation_formatter.rb
+++ b/lib/chicago_citation_formatter.rb
@@ -23,7 +23,7 @@ class ChicagoCitationFormatter
                          "author": chicago_author(obj),
                          "issued": obj[:pub_date_isim].first,
                          "publisher": chicago_publisher(obj),
-                         "publisher-place": obj[:publisher_location_ssim].first,
+                         "publisher-place": obj[:publisher_location_ssim]&.first,
                          "title": obj[:title_citation_ssi],
                          "type": obj[:format_ssim]&.first&.downcase,
                          "DOI": chicago_doi(obj)

--- a/lib/chicago_citation_formatter.rb
+++ b/lib/chicago_citation_formatter.rb
@@ -3,7 +3,7 @@ require 'citeproc'
 require 'csl/styles'
 require './lib/citation_string_processor'
 
-class CitationFormatter
+class ChicagoCitationFormatter
   include CitationStringProcessor
   attr_accessor :obj, :default_citations
 
@@ -11,8 +11,8 @@ class CitationFormatter
     @obj = obj
   end
 
-  def citation_for(style)
-    CiteProc::Processor.new(style: style, format: 'html').import(item).render(:bibliography, id: :item).first
+  def cite!
+    CiteProc::Processor.new(style: 'chicago-fullnote-bibliography', format: 'html').import(item).render(:bibliography, id: :item).first
   end
 
   private
@@ -23,7 +23,7 @@ class CitationFormatter
                          "author": chicago_author(obj),
                          "issued": obj[:pub_date_isim].first,
                          "publisher": chicago_publisher(obj),
-                         "publisher-place": obj[:publisher_location_ssim]&.join(', '),
+                         "publisher-place": obj[:publisher_location_ssim].first,
                          "title": obj[:title_citation_ssi],
                          "type": obj[:format_ssim]&.first&.downcase,
                          "DOI": chicago_doi(obj)

--- a/lib/citation_string_processor.rb
+++ b/lib/citation_string_processor.rb
@@ -3,7 +3,8 @@
 module CitationStringProcessor
   # Chicago Citation
   def chicago_author(obj)
-    clean_end_punctuation(obj[:author_tesim]&.join(', '))
+    author = obj.to_marc['100'] ? obj.to_marc['100']['a'] : nil
+    author.present? ? clean_end_punctuation(author) : nil
   end
 
   def chicago_publisher(obj)
@@ -11,12 +12,13 @@ module CitationStringProcessor
     return nil if publisher.blank?
 
     publisher = publisher.gsub(/\[|\]/, '')
-    clean_end_punctuation(publisher) if publisher.present?
+    publisher.present? ? clean_end_punctuation(publisher) : nil
   end
 
   def chicago_doi(obj)
-    doi = obj['other_standard_ids_tesim']&.first&.strip
-    clean_end_punctuation(doi) if doi.present?
+    standard_ids = obj['other_standard_ids_tesim']
+    doi = standard_ids&.find { |v| v.match?(/doi:/) }
+    doi.present? ? clean_end_punctuation(doi).partition('doi: ').last : nil
   end
 
   # Helper Methods


### PR DESCRIPTION
Fixes #961

The following are the issues raised by @eporter23 and a screenshot that corresponds to the fix for each error:

### Case I

**Record**

> This record shows DOI but actually is another type of identifier (we only want a DOI entry, which is one of several types of standard identifiers). The author entry also shows ", and author". https://blackcat-test.library.emory.edu/catalog/9937313645402486

**Fix**
![Screen Shot 2022-09-26 at 4 53 29 PM](https://user-images.githubusercontent.com/13107510/192387619-46f47a19-79b8-49d5-8316-94f7351fa8ca.png)

### Case II

**Record**

Here is another example of the ", and author" being added. It looks like the $e relator term is getting included, which we don't want. https://blackcat-test.library.emory.edu/catalog/990035853090302486

**Fix**

![Screen Shot 2022-09-26 at 4 55 52 PM](https://user-images.githubusercontent.com/13107510/192387844-dc061b1f-d735-4987-9c2f-1a9210deda89.png)

### Case III

**Record**

> This record is missing the publication information: https://blackcat-test.library.emory.edu/catalog/990018128730302486

**Fix**

![Screen Shot 2022-09-26 at 4 57 14 PM](https://user-images.githubusercontent.com/13107510/192388013-32cdd22d-1d80-4611-b43e-25fa7bde9a84.png)

### Case IV

**Record**

This record omits the publication year. It's populated in SOLR and the other two styles are including it. https://blackcat-test.library.emory.edu/catalog/9937307669402486

**Fix**

![Screen Shot 2022-09-26 at 4 58 13 PM](https://user-images.githubusercontent.com/13107510/192388138-85622bdc-6ff6-409a-a41d-4fba0a3725c8.png)

