### PR TITLE
Revert omniauth upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'jquery-rails'
 gem 'jwt'
 gem 'mysql2', '~> 0.5'
 gem 'nokogiri'
-gem "omniauth", ">= 2.0.0"
+gem 'omniauth', '~> 1.9'
 gem 'omniauth-shibboleth', '~> 1.3'
 gem 'openurl'
 gem 'puma', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,10 +290,9 @@ GEM
     nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    omniauth (2.1.0)
+    omniauth (1.9.2)
       hashie (>= 3.4.6)
-      rack (>= 2.2.3)
-      rack-protection
+      rack (>= 1.6.2, < 3)
     omniauth-shibboleth (1.3.0)
       omniauth (>= 1.0.0)
     openurl (1.0.0)
@@ -327,8 +326,6 @@ GEM
     rack (2.2.4)
     rack-mini-profiler (2.3.3)
       rack (>= 1.2.0)
-    rack-protection (3.0.2)
-      rack
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (5.1.7)
@@ -585,7 +582,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mysql2 (~> 0.5)
   nokogiri
-  omniauth (>= 2.0.0)
+  omniauth (~> 1.9)
   omniauth-shibboleth (~> 1.3)
   openurl
   pry


### PR DESCRIPTION
Fixes `Not found. Authentication passthru.` error in the authentication worflow.

Refer to https://github.com/emory-libraries/dlp-curate/pull/2034 and https://github.com/emory-libraries/dlp-curate/pull/2038 for details on the fix we implemented in `dlp-curate`