### PR TITLE
Fixes the bug preventing temporarily located items from appearing in a record's XML.

### DIFF
--- a/app/views/catalog/show.xml.builder
+++ b/app/views/catalog/show.xml.builder
@@ -18,7 +18,7 @@ xml.document do
     end
   end
   xml.physical_holdings do
-    @document.physical_holdings&.each do |ph|
+    @document.physical_holdings_for_xml&.each do |ph|
       xml << render(partial: 'physical_holding', locals: { ph: ph })
     end
   end

--- a/spec/fixtures/alma_availability_test_file_a.xml
+++ b/spec/fixtures/alma_availability_test_file_a.xml
@@ -147,6 +147,20 @@
       <subfield code="p">1</subfield>
       <subfield code="q">Robert W. Woodruff Library</subfield>
     </datafield>
+    <datafield ind1=" " ind2=" " tag="AVA">
+      <subfield code="0">990005988630302486</subfield>
+      <subfield code="a">01GALI_EMORY</subfield>
+      <subfield code="b">OXFD</subfield>
+      <subfield code="c">New York Times Bestsellers</subfield>
+      <subfield code="d">973.933 B1682D</subfield>
+      <subfield code="e">available</subfield>
+      <subfield code="f">1</subfield>
+      <subfield code="g">0</subfield>
+      <subfield code="j">NEWNYT</subfield>
+      <subfield code="k">1</subfield>
+      <subfield code="p">1</subfield>
+      <subfield code="q">Oxford College Library</subfield>
+    </datafield>
   </record>
   <requests>0</requests>
 </bib>

--- a/spec/fixtures/alma_item_records/990005988630302486.xml
+++ b/spec/fixtures/alma_item_records/990005988630302486.xml
@@ -91,4 +91,108 @@
       <physical_condition/>
     </item_data>
   </item>
+  <item link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9937608859902486/holdings/22488030790002486/items/23488030780002486">
+    <bib_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9937608859902486">
+      <mms_id>990005988630302486</mms_id>
+      <bib_suppress_from_publishing>false</bib_suppress_from_publishing>
+      <title>The divider : Trump in the White House, 2017-2021 /</title>
+      <author>Baker, Peter,</author>
+      <isbn>038554653X</isbn>
+      <complete_edition>First edition.</complete_edition>
+      <network_numbers>
+        <network_number>(OCoLC)1344297863</network_number>
+        <network_number>on1344297863</network_number>
+        <network_number>(OCoLC)1338026340</network_number>
+        <network_number>(OCoLC)1337585125</network_number>
+        <network_number>(OCoLC)1334494675</network_number>
+        <network_number>(OCoLC)1333914724</network_number>
+        <network_number>(OCoLC)1333868351</network_number>
+        <network_number>(OCoLC)1333811274</network_number>
+        <network_number>(OCoLC)1290431471</network_number>
+        <network_number>(OCoLC)1290415537</network_number>
+        <network_number>(OCoLC)1290377887</network_number>
+        <network_number>(OCoLC)1290338193</network_number>
+        <network_number>(OCoLC)1290309671</network_number>
+      </network_numbers>
+      <place_of_publication>New York :</place_of_publication>
+      <date_of_publication>[2022]</date_of_publication>
+      <publisher_const>Doubleday</publisher_const>
+    </bib_data>
+    <holding_data link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/9937608859902486/holdings/22488030790002486">
+      <holding_id>22488030790002486</holding_id>
+      <holding_suppress_from_publishing>false</holding_suppress_from_publishing>
+      <calculated_suppress_from_publishing>false</calculated_suppress_from_publishing>
+      <permanent_call_number_type desc="Dewey Decimal classification">1</permanent_call_number_type>
+      <permanent_call_number>973.933 B1682D</permanent_call_number>
+      <call_number_type desc="Dewey Decimal classification">1</call_number_type>
+      <call_number>973.933 B1682D</call_number>
+      <accession_number/>
+      <copy_id/>
+      <in_temp_location>true</in_temp_location>
+      <temp_library desc="Oxford College Library">OXFD</temp_library>
+      <temp_location desc="New York Times Bestsellers">NEWNYT</temp_location>
+      <temp_call_number_type/>
+      <temp_call_number/>
+      <temp_call_number_source/>
+      <temp_policy desc="2 Week Loan (Popular Reading)">21</temp_policy>
+    </holding_data>
+    <item_data>
+      <pid>23488030780002486</pid>
+      <barcode>050000104980</barcode>
+      <creation_date>2022-10-31Z</creation_date>
+      <modification_date>2022-12-15Z</modification_date>
+      <base_status desc="Item in place">1</base_status>
+      <awaiting_reshelving>false</awaiting_reshelving>
+      <physical_material_type desc="Book">BOOK</physical_material_type>
+      <policy/>
+      <provenance/>
+      <po_line>POL-107666</po_line>
+      <arrival_date>2022-11-30Z</arrival_date>
+      <expected_arrival_date>2022-11-01Z</expected_arrival_date>
+      <year_of_issue/>
+      <enumeration_a/>
+      <enumeration_b/>
+      <enumeration_c/>
+      <enumeration_d/>
+      <enumeration_e/>
+      <enumeration_f/>
+      <enumeration_g/>
+      <enumeration_h/>
+      <chronology_i/>
+      <chronology_j/>
+      <chronology_k/>
+      <chronology_l/>
+      <chronology_m/>
+      <break_indicator/>
+      <pattern_type/>
+      <linking_number/>
+      <type_of_unit/>
+      <description/>
+      <receiving_operator>System</receiving_operator>
+      <process_type/>
+      <inventory_number/>
+      <inventory_price/>
+      <library desc="Oxford College Library">OXFD</library>
+      <location desc="Oxford Book Stacks">STACK</location>
+      <alternative_call_number/>
+      <alternative_call_number_type/>
+      <storage_location_id/>
+      <pages/>
+      <pieces/>
+      <public_note/>
+      <fulfillment_note/>
+      <due_date_policy>14 Days Loan</due_date_policy>
+      <internal_note_1/>
+      <internal_note_2/>
+      <internal_note_3/>
+      <statistics_note_1/>
+      <statistics_note_2/>
+      <statistics_note_3/>
+      <requested>false</requested>
+      <physical_condition/>
+      <committed_to_retain/>
+      <retention_reason/>
+      <retention_note/>
+    </item_data>
+  </item>
 </items>

--- a/spec/system/view_show_page_spec.rb
+++ b/spec/system/view_show_page_spec.rb
@@ -377,6 +377,8 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
     end
 
     context 'viewing xml version of document' do
+      let(:first_phys_holding_item) { "//physical_holdings//physical_holding//call_number[text()='PT2613 .M45 Z92 2006']/following-sibling::items//item" }
+      let(:second_phys_holding_item) { "//physical_holdings//physical_holding//call_number[text()='973.933 B1682D']/following-sibling::items//item" }
       let(:expected_values_arr) do
         [['//title', 'The Title of my Work'], ['//author', 'George Jenkins'], ['//edition', 'A sample edition'],
          ['//is_physical_holding', 'false'], ['//is_electronic_holding', 'false'],
@@ -384,11 +386,11 @@ RSpec.describe "View a item's show page", type: :system, js: true, alma: true do
          ['//publication_date', '2015'], ['//isbn', 'SOME MAGICAL NUM .66G'], ['//issn', 'SOME OTHER MAGICAL NUMBER .12Q'],
          ['//supplemental_links//supplemental_link//link', 'http://www.example.com'],
          ['//supplemental_links//supplemental_link//label', 'http://www.example.com'],
-         ['//physical_holdings//physical_holding//call_number', 'PT2613 .M45 Z92 2006'],
-         ['//physical_holdings//physical_holding//library', 'UNIV'],
-         ['//physical_holdings//physical_holding//location', 'STACK'], ['//physical_holdings//physical_holding//items//item//barcode', '010001233671'],
-         ['//physical_holdings//physical_holding//items/item//volume_or_issue', ''],
-         ['//physical_holdings//physical_holding//items/item//status', 'Item in place']]
+         ["#{first_phys_holding_item}//library", 'UNIV'], ["#{first_phys_holding_item}//location", 'STACK'],
+         ["#{first_phys_holding_item}//barcode", '010001233671'], ["#{first_phys_holding_item}//volume_or_issue", ''],
+         ["#{first_phys_holding_item}//status", 'Item in place'], ["#{second_phys_holding_item}//library", 'OXFD'],
+         ["#{second_phys_holding_item}//location", 'NEWNYT'], ["#{second_phys_holding_item}//barcode", '050000104980'],
+         ["#{second_phys_holding_item}//volume_or_issue", ''], ["#{second_phys_holding_item}//status", 'Item in place']]
       end
 
       it 'displays correct tag/values' do


### PR DESCRIPTION
- app/models/concerns/statusable.rb: 
  - creates a customized method especially for the XML physical holdings
  - wires the pulling of holding items to accommodate missing holding ids.
- app/views/catalog/show.xml.builder: uses the new modified method instead.
- spec/*: tests presence of the new temp located item.