### PR TITLE
Makes show page's availability async.

### DIFF
--- a/app/controllers/availability_indicators_controller.rb
+++ b/app/controllers/availability_indicators_controller.rb
@@ -14,6 +14,12 @@ class AvailabilityIndicatorsController < ApplicationController
     render json: availability_indicators
   end
 
+  def single
+    _deprecated_response, @document = search_service.fetch(params['document_id'])
+    @documents_availability = AlmaAvailabilityService.new([params['document_id']]).availability_of_documents
+    render partial: 'catalog/show_request_options', layout: false
+  end
+
   private
 
   def document_ids

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,7 +1,7 @@
 <% # [Blacklight-overwrite v7.4.1] Overwrites the way fields get displayed on item show page %>
 <%= render 'catalog/show_tools/metadata_block', document: document, presenter: MainMetadataPresenter, title: '' %>
 <% # New partial for request options %>
-<%= render 'show_request_options', document: document %>
+<div id="show-request-options-container"></div>
 <%= tag.h2 t('catalog.show.more_details_header'), class: "section-title more-details-header" %>
 <%= render 'catalog/show_tools/metadata_block_collapsible', 
     document: document, 
@@ -25,5 +25,17 @@
   gtag('event', '<%= document['format_ssim']&.first %>', {
     'event_category': 'format_view',
     'event_label': '<%= document['title_main_display_ssim'].first %>'
+  });
+
+  $.ajax({
+    type: "GET",
+    data: {
+      document_id: "<%= document.id %>"
+    },
+    url: "/availability_indicator",
+    cache: false,
+    success: function(html){
+      $("#show-request-options-container").append(html);
+    }
   });
 </script>

--- a/app/views/catalog/_show_request_options.html.erb
+++ b/app/views/catalog/_show_request_options.html.erb
@@ -1,5 +1,6 @@
-<% doc_avail_values = @documents_availability[document.id] if @documents_availability.present? %>
-<% service_page_link = service_page_url(document.id) %>
+<% doc_avail_values = @documents_availability[@document.id] if @documents_availability.present? %>
+<% service_page_link = service_page_url(@document.id) %>
+<% physical_holdings = @document.physical_holdings(current_or_guest_user) if Flipflop.enable_requesting_using_api? %>
 
 <div class="where-to-find-table">
   <div class="row justify-content-between align-items-center">
@@ -9,11 +10,11 @@
     <% if !Flipflop.enable_requesting_using_api? && doc_avail_values.present? %>
       <div class="col-12">
         <%= render 'catalog/availability/badges', 
-              document: document, 
+              document: @document, 
               doc_avail_values: doc_avail_values, 
               service_page_link: service_page_link %>
         <%= render 'catalog/availability/table', 
-              document: document, 
+              document: @document, 
               doc_avail_values: doc_avail_values, 
               service_page_link: service_page_link %>
       </div>
@@ -26,17 +27,17 @@
             <span class="sr-only">Toggle Dropdown</span>
           </button>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-            <% if document.hold_requestable?(current_or_guest_user) %>
-            <%= link_to "Hold request", new_hold_request_path(hold_request: {mms_id: document.id, title: document['title_citation_ssi']}), class: "dropdown-item" %>
+            <% if @document.hold_requestable?(current_or_guest_user) %>
+            <%= link_to "Hold request", new_hold_request_path(hold_request: {mms_id: @document.id, title: @document['title_citation_ssi']}), class: "dropdown-item" %>
             <% end %>
-            <% if document.one_step_doc_delivery?(@physical_holdings, current_or_guest_user) %>
-            <%= link_to "Request Article or Chapter", document.one_step_link, class: "dropdown-item" %>
+            <% if @document.one_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
+            <%= link_to "Request Article or Chapter", @document.one_step_link, class: "dropdown-item" %>
             <% end %>
-            <% if document.two_step_doc_delivery?(@physical_holdings, current_or_guest_user) %>
+            <% if @document.two_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
             <%= link_to "Request Article or Chapter", "#", class: "dropdown-item", data: {toggle: "modal", target: "#two-step-illiad"} %>
             <% end %>
-            <% if document.special_collections_requestable?(current_or_guest_user) %>
-            <%= link_to "Request from Special Collections", document.special_collections_url, class: "dropdown-item" %>
+            <% if @document.special_collections_requestable?(current_or_guest_user) %>
+            <%= link_to "Request from Special Collections", @document.special_collections_url, class: "dropdown-item" %>
             <% end %>
           </div>
         </div>
@@ -44,7 +45,7 @@
     <% end %>
   </div>
   <% if Flipflop.enable_requesting_using_api? %>
-    <% if @physical_holdings&.any? %>
+    <% if physical_holdings&.any? %>
       <div class="table-responsive">
         <table class="table">
           <thead>
@@ -54,7 +55,7 @@
             </tr>
           </thead>
           <tbody>
-            <% @physical_holdings.each.with_index(1) do |holding, index| %>
+            <% physical_holdings.each.with_index(1) do |holding, index| %>
               <tr id="physical-holding-<%= index.to_s %>" class="d-flex">
                 <td class="col-sm-4">
                   <%= holding[:library][:label] %>
@@ -106,11 +107,11 @@
           </tbody>
         </table>
       </div>
-      <% if document.two_step_doc_delivery?(@physical_holdings, current_or_guest_user) %>
-        <%= render 'two_step_illiad_modal', document: document, physical_holdings: @physical_holdings %>
+      <% if @document.two_step_doc_delivery?(physical_holdings, current_or_guest_user) %>
+        <%= render 'two_step_illiad_modal', document: @document, physical_holdings: physical_holdings %>
       <% end %>
     <% end %>
-    <% if document.online_holdings&.any? %>
+    <% if @document.online_holdings&.any? %>
       <table class="table">
         <thead>
           <tr>
@@ -119,7 +120,7 @@
           </tr>
         </thead>
         <tbody>
-          <% document.online_holdings.each do |holding| %>
+          <% @document.online_holdings.each do |holding| %>
             <tr>
               <td><%= t('blacklight.availability.access_online') %></td>
               <td><%= link_to(holding[:label], holding[:url]) %></td>
@@ -132,3 +133,7 @@
     <%= link_to("Services page", service_page_link, target: "_blank") %>
   <% end %>
 </div>
+
+<script type="text/javascript">
+  $('#avail-<%= @document.id %>-toggle').collapse('show')
+</script>

--- a/app/views/catalog/show_tools/_metadata_block.html.erb
+++ b/app/views/catalog/show_tools/_metadata_block.html.erb
@@ -14,7 +14,3 @@
     <% end %>
   </dl>
 <% end %>
-
-<script type="text/javascript">
-  $('#avail-<%= @document.id %>-toggle').collapse('show')
-</script>

--- a/config/initializers/catalog_show_override.rb
+++ b/config/initializers/catalog_show_override.rb
@@ -7,8 +7,6 @@ CatalogController.class_eval do
   def show
     deprecated_response, @document = search_service.fetch(params[:id])
     @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_response, 'The @response instance variable is deprecated; use @document.response instead.')
-    @documents_availability = AlmaAvailabilityService.new([@document.id]).availability_of_documents
-    @physical_holdings = @document.physical_holdings(current_or_guest_user) if Flipflop.enable_requesting_using_api?
     respond_to do |format|
       format.html { @search_context = setup_next_and_previous_documents }
       format.json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,8 @@ Rails.application.routes.draw do
   end
 
   resources :hold_requests
-  resources :availability_indicators, only: [:index], constraints: ->(request) { request.format == :json }
+  get '/availability_indicators', to: 'availability_indicators#index', constraints: ->(request) { request.format == :json }
+  get '/availability_indicator', to: 'availability_indicators#single'
 
   devise_for :users, controllers: { omniauth_callbacks: "omniauth_callbacks" }, skip: "sessions"
 


### PR DESCRIPTION
- app/controllers/availability_indicators_controller.rb: adds a controller action to pull just a single document's availability and deliver it via partial.
- app/views/catalog/_show.html.erb: provides a container for the partial instead of directly loading it, and adds AJAX to call the partial GET path.
- app/views/catalog/_show_request_options.html.erb: reworks this partial to utilize the new variables coming from the just created action. Also adds script to open the show pages availability immediately.
- app/views/catalog/show_tools/_metadata_block.html.erb: removes the exand command that wasn't working in this position anymore.
- config/initializers/catalog_show_override.rb: Strips API reliant pulls from the Controller function.
- config/routes.rb: adds another route to the AvailabilityIndicatorsController.