### PR TITLE
Revise 856 mapping

### DIFF
--- a/app/views/catalog/availability/_table.html.erb
+++ b/app/views/catalog/availability/_table.html.erb
@@ -1,4 +1,4 @@
-<% if doc_avail_values[:physical_holdings].present? %>
+<% if doc_avail_values.present? && doc_avail_values[:physical_holdings].present? %>
   <span id="avail-<%= document.id %>-toggle" class="collapse">
     <div class="table-responsive-sm">
       <table class="table availability-table">

--- a/lib/traject/extract_url_fulltext.rb
+++ b/lib/traject/extract_url_fulltext.rb
@@ -12,7 +12,7 @@ module ExtractUrlFulltext
           next unless base_url
 
           url = parse_url(base_url)
-          exclude_links_to = ["table of contents", "table of contents only", "publisher description", "cover image", "contributor biographical information"]
+          exclude_links_to = ["table of contents", "table of contents only", "publisher description", "cover image", "contributor biographical information", "sample text"]
           label = [f['y'], f['3'], f['z']].compact.first
           next if label.present? && exclude_links_to.include?(label.downcase)
 

--- a/lib/traject/extract_url_suppl.rb
+++ b/lib/traject/extract_url_suppl.rb
@@ -12,7 +12,7 @@ module ExtractUrlSuppl
         pulled_text = [uf['y'], uf['3'], uf['z']].compact.first
 
         if ['0', '1'].include?(uf.indicator2)
-          include_links_to = ["table of contents", "table of contents only", "publisher description", "cover image", "contributor biographical information"]
+          include_links_to = ["table of contents", "table of contents only", "publisher description", "cover image", "contributor biographical information", "sample text"]
           next if pulled_text.nil? || include_links_to.exclude?(pulled_text.downcase)
         end
 


### PR DESCRIPTION
Fixes #1319 

- Search results no longer show sample text
<img width="895" alt="Screenshot 2023-03-08 at 11 12 13 AM" src="https://user-images.githubusercontent.com/13107510/223783306-534cd486-5585-43e4-b731-41a6ef698a25.png">

- Item page shows sample text under "Related Resources Link"

<img width="873" alt="Screenshot 2023-03-08 at 11 12 22 AM" src="https://user-images.githubusercontent.com/13107510/223783302-7ef075c2-b287-44c3-9d12-e81bfc61e5a4.png">

<img width="510" alt="Screenshot 2023-03-08 at 11 12 34 AM" src="https://user-images.githubusercontent.com/13107510/223783292-bffa3f95-1699-4811-afaa-8b7d015ccd7d.png">

