### PR TITLE
Fix duplicate constraints

### DIFF
--- a/app/helpers/constraints_helper.rb
+++ b/app/helpers/constraints_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module ConstraintsHelper
+  # Blacklight v7.4.2
+  # app/helpers/blacklight/render_constraints_helper_behavior.rb
+  # Render the facet constraints
+  # @param [Hash] localized_params query parameters
+  # @return [String]
+  def render_constraints_filters(localized_params = params)
+    return "".html_safe unless localized_params[:f]
+
+    path = controller.search_state_class.new(localized_params, blacklight_config, controller)
+    content = []
+    localized_params[:f].each_pair do |facet, values|
+      content << render_filter_element(facet, values, path)
+    end
+
+    safe_join(content.flatten, "\n")
+  end
+end


### PR DESCRIPTION
Ticket #1339 

#### Context

The changes to `app/helpers/blacklight/render_constraints_helper_behavior.rb` in Blacklight `v7.33` introduced a new issue where the filter constraints are duplicated in display, as shown below:

![image](https://user-images.githubusercontent.com/13107510/227633055-c2cf26f2-3d69-47e3-aae3-89474940ae54.png)

#### Solution

To resolve the failing specs tied to this issue, and ensure the search constraints are working properly, I am reverting the filter constraint rendering logic to Blacklight `v7.4.2`. Once we switch the search constraints to using components, we will be able to remove this override.

#### Screenshot

<img width="1198" alt="Screenshot 2023-03-24 at 3 35 35 PM" src="https://user-images.githubusercontent.com/13107510/227633445-ced053a8-e2a2-4666-b470-455e5c53fa42.png">


