### PR TITLE
Delete guest users and searches once a day

### DIFF
--- a/app/services/delete_old_guests_service.rb
+++ b/app/services/delete_old_guests_service.rb
@@ -3,7 +3,9 @@ class DeleteOldGuestsService
   def self.destroy_users
     log_file = Rails.env.production? ? "log/production.log" : "log/development.log"
     Rails.logger = Logger.new(log_file)
+    start = DateTime.now
     Rails.logger.info "Deleting all Guest users along with their bookmarks"
-    User.where(["created_at < ? AND uid LIKE 'guest_%'", 30.minutes.ago]).destroy_all
+    User.where(["created_at < ? AND uid LIKE 'guest_%'", 1.day.ago]).destroy_all
+    Rails.logger.info "Guest deletion started at #{start} and finished at #{DateTime.now}."
   end
 end

--- a/app/services/delete_old_guests_service.rb
+++ b/app/services/delete_old_guests_service.rb
@@ -3,9 +3,13 @@ class DeleteOldGuestsService
   def self.destroy_users
     log_file = Rails.env.production? ? "log/production.log" : "log/development.log"
     Rails.logger = Logger.new(log_file)
+    # Whenever we upgrade Blacklight, we need to ensure all data associated to guests is deleted properly
+    # whenever guest users are deleted. For now, only bookmarks and searches are deleted.
     start = DateTime.now
     Rails.logger.info "Deleting all Guest users along with their bookmarks"
-    User.where(["created_at < ? AND uid LIKE 'guest_%'", 1.day.ago]).destroy_all
+    Bookmark.where(["user_id IN (SELECT id FROM `users` WHERE (created_at < ? AND uid LIKE 'guest_%') )", 1.day.ago]).delete_all
+    Search.where(["user_id IN (SELECT id FROM `users` WHERE (created_at < ? AND uid LIKE 'guest_%') )", 1.day.ago]).delete_all
+    User.where(["created_at < ? AND uid LIKE 'guest_%'", 1.day.ago]).delete_all
     Rails.logger.info "Guest deletion started at #{start} and finished at #{DateTime.now}."
   end
 end

--- a/app/services/delete_old_searches_service.rb
+++ b/app/services/delete_old_searches_service.rb
@@ -5,7 +5,7 @@ class DeleteOldSearchesService
     Rails.logger = Logger.new(log_file)
     start = DateTime.now
     Rails.logger.info "Deleting all Searches where User is NULL"
-    Search.where(["created_at < ? AND user_id IS NULL", 1.day.ago]).destroy_all
+    Search.delete_old_searches(1)
     Rails.logger.info "Search deletion started at #{start} and finished at #{DateTime.now}."
   end
 end

--- a/app/services/delete_old_searches_service.rb
+++ b/app/services/delete_old_searches_service.rb
@@ -3,7 +3,9 @@ class DeleteOldSearchesService
   def self.destroy_searches
     log_file = Rails.env.production? ? "log/production.log" : "log/development.log"
     Rails.logger = Logger.new(log_file)
+    start = DateTime.now
     Rails.logger.info "Deleting all Searches where User is NULL"
-    Search.where(["created_at < ? AND user_id IS NULL", 30.minutes.ago]).destroy_all
+    Search.where(["created_at < ? AND user_id IS NULL", 1.day.ago]).destroy_all
+    Rails.logger.info "Search deletion started at #{start} and finished at #{DateTime.now}."
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -24,7 +24,7 @@
 set :output, "log/cron_log.log"
 env :PATH, ENV['PATH']
 
-every 30.minutes do
+every 1.day, at: '4am' do
   rake "delete_old_guests_and_associations"
 end
 

--- a/spec/services/delete_old_guests_service_spec.rb
+++ b/spec/services/delete_old_guests_service_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe DeleteOldGuestsService, :clean do
     Bookmark.destroy_all
   end
 
-  it 'deletes guest user created 30 mins ago along with their bookmarks' do
-    User.update(id: 123, created_at: Time.current - 31.minutes)
+  it 'deletes guest user created one day ago or more along with their bookmarks' do
+    User.update(id: 123, created_at: Time.current - 1.day)
     described_class.destroy_users
     expect(User.find_by_id(123).nil?).to eq true
     expect(Bookmark.find_by_id(123).nil?).to eq true
   end
 
-  it 'does not delete guest user created 30 mins ago' do
-    User.update(id: 123, created_at: Time.current - 29.minutes)
+  it 'does not delete guest user created less than a day ago' do
+    User.update(id: 123, created_at: Time.current - 30.minutes)
     described_class.destroy_users
     expect(User.find_by_id(123).nil?).to eq false
     expect(Bookmark.find_by_id(123).nil?).to eq false

--- a/spec/services/delete_old_searches_service_spec.rb
+++ b/spec/services/delete_old_searches_service_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe DeleteOldSearchesService, :clean do
     Search.destroy_all
   end
 
-  it 'deletes all searches without user which are more than 30 mins old' do
-    Search.update(id: 123, created_at: Time.current - 31.minutes)
+  it 'deletes all searches without user which are a day old or more' do
+    Search.update(id: 123, created_at: Time.zone.today - 1 - 1.minute)
     described_class.destroy_searches
     expect(Search.find_by_id(123)).to eq nil
   end
 
-  it 'does not delete searches without user which are less than 30 mins old' do
-    Search.update(id: 123, created_at: Time.current - 29.minutes)
+  it 'does not delete searches without user which are less than a day old' do
+    Search.update(id: 123, created_at: Time.current - 30.minutes)
     described_class.destroy_searches
     expect(Search.find_by_id(123).nil?).to eq false
   end


### PR DESCRIPTION
Previously, this ran every 30 minutes, and did not seem to complete in a reliable way. This should attempt to run less frequently, and report start and end times when it finishes.