### PR TITLE
AS023: Updates the link url for Finding Aids to archives.libraries.

### DIFF
--- a/app/views/catalog/other_resources/_accordions.html.erb
+++ b/app/views/catalog/other_resources/_accordions.html.erb
@@ -54,7 +54,7 @@
             data_target: 'finding-aids',
             panel_header: 'Finding Aids',
             body_text: "The EmoryFindingAids database provides centralized access to detailed descriptions of archival and manuscript collections held in various repositories at Emory.",
-            body_link: 'https://findingaids.library.emory.edu/') %>
+            body_link: 'https://archives.libraries.emory.edu/') %>
     </div>
   </section>
 </div>


### PR DESCRIPTION
per https://app.zenhub.com/workspaces/archivesspace-63122393d517dc001c3ceb07/issues/gh/emory-libraries/aspace/23