### PR TITLE
Fix pagination UI

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_sort_widgets.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_sort_widgets.scss
@@ -23,7 +23,7 @@ div#sortAndPerPage {
       min-width: $results-drop-menu-min-w;
     }
   }
-  > .page-links {
+  > .pagination {
     padding: 0 $pagination-padding-left-right;
     max-width: fit-content;
     align-items: center;


### PR DESCRIPTION
Restore alignment between pagination elements and "Show Locations"

Before:

<img width="887" alt="Screenshot 2023-09-18 at 10 27 11 AM" src="https://github.com/emory-libraries/blacklight-catalog/assets/13107510/acfe0200-e0f9-4d13-bb9e-542db7b50d9f">

After:

<img width="884" alt="Screenshot 2023-09-18 at 10 29 31 AM" src="https://github.com/emory-libraries/blacklight-catalog/assets/13107510/a1f0149a-d6c4-4ce2-895f-7f1ae5eb5e58">

