### PR TITLE
Address Lighthouse report warnings

### DIFF
--- a/app/helpers/alternate_catalog_helper.rb
+++ b/app/helpers/alternate_catalog_helper.rb
@@ -11,7 +11,7 @@ module AlternateCatalogHelper
 
   def rounded_lightbulb
     tag.div(
-      tag.span(image_tag("lightbulb.svg", height: "32", width: "32"), class: "rounded-lightbulb"),
+      tag.span(image_tag("lightbulb.svg", height: "32", width: "32", alt: ""), class: "rounded-lightbulb"),
       class: "lightbulb"
     )
   end

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -13,7 +13,7 @@
       <div class="row justify-content-between branding-row header-main">
         <div class="branding-header">
           <div class="branding-header logo">
-            <%= link_to root_path, class: "branding-header-badge" do %>
+            <%= link_to root_path, class: "branding-header-badge", 'aria-label' => 'Emory Library Catalog' do %>
               <div class="logo"><%= inline_svg_tag("shield.svg", alt: 'Emory Library') %></div> 
           <% end %>
         </div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -13,7 +13,7 @@
       <div class="row justify-content-between branding-row header-main">
         <div class="branding-header">
           <div class="branding-header logo">
-            <%= link_to root_path, class: "branding-header-badge", 'aria-label' => 'Emory Library Catalog' do %>
+            <%= link_to root_path, class: "branding-header-badge", 'aria-label' => 'Homepage' do %>
               <div class="logo"><%= inline_svg_tag("shield.svg", alt: 'Emory Library') %></div> 
           <% end %>
         </div>


### PR DESCRIPTION
- Add empty `alt` to lightbulb picture in the homepage since it is decorative
- Add `aria-label` to homepage Emory Library logo/link that takes the user back to the catalog homepage