### PR TITLE
Automates current year testing

### DIFF
--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe 'Indexing fields with custom logic' do
     context 'when it is journal with end year 9999' do
       it 'has end date as current year' do
         # 750727c20109999nyuqr p 0 a0eng c - 008 value with start year 2010 and end year 9999
-        expect(solr_doc4['pub_date_isim']).to eq([2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024])
+        expect(solr_doc4['pub_date_isim']).to eq((2010..Time.now.getlocal.year).to_a)
       end
     end
 


### PR DESCRIPTION
Rather than needing to update tests each January as the year changes, use the Date module to get the current year programmatically.