### PR TITLE
Add CAB acknowledgment to production deployment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,14 @@ Lint/PercentStringArray:
     Exclude:
         - 'config/initializers/secure_headers.rb'
 
+Rails/Exit:
+    Exclude:
+        - 'config/deploy.rb'
+
+Rails/Output:
+    Exclude:
+        - 'config/deploy.rb'
+
 Rails/OutputSafety:
     Exclude:
         - 'app/helpers/citation_modal_helper.rb'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+namespace :deploy do
+  desc 'Ask user for CAB approval before deployment if stage is PROD'
+  task :confirm_cab_approval do
+    if fetch(:stage) == :PROD
+      ask(:cab_acknowledged, 'Have you submitted and received CAB approval? (Yes/No): ')
+      unless /^y(es)?$/i.match?(fetch(:cab_acknowledged))
+        puts 'Please submit a CAB request and get it approved before proceeding with deployment.'
+        exit
+      end
+    end
+  end
+end
+
+before 'deploy:starting', 'deploy:confirm_cab_approval'
+
 # config valid for current version and patch releases of Capistrano
 lock "~> 3.14.1"
 


### PR DESCRIPTION
The new changes will help remind users to submit a CAB request before proceeding with a production deployment.

I tested the changes with the Arch environment as the target and the following screenshots show how users will have to acknowledge CAB submission and approval before proceeding:

![Screenshot 2024-02-06 at 3 59 34 PM](https://github.com/emory-libraries/blacklight-catalog/assets/13107510/adefa426-6723-45b4-aac1-8ae9ae213c29)

![Screenshot 2024-02-06 at 4 00 05 PM](https://github.com/emory-libraries/blacklight-catalog/assets/13107510/6d7cdea2-1ea0-4160-b637-55c75ed96b79)
