### PR TITLE
Cache advanced search index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 ruby '~> 3.1.4'
 
+gem "actionpack-page_caching"
 gem 'administrate', '~> 0.17.0'
 gem 'blacklight', '~> 7.33'
 gem 'blacklight_advanced_search'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionpack-page_caching (1.2.4)
+      actionpack (>= 4.0.0)
     actiontext (6.1.7.6)
       actionpack (= 6.1.7.6)
       activerecord (= 6.1.7.6)
@@ -616,6 +618,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  actionpack-page_caching
   administrate (~> 0.17.0)
   bixby
   blacklight (~> 7.33)

--- a/config/initializers/advanced_controller.rb
+++ b/config/initializers/advanced_controller.rb
@@ -4,6 +4,8 @@
 # collection facet
 
 BlacklightAdvancedSearch::AdvancedController.class_eval do
+  caches_page :index
+
   def index
     @response = get_advanced_search_facets unless request.method == :post
     collection_auth = Qa::LocalAuthority.find_by(name: 'collections')

--- a/lib/tasks/marc_index_ingester.rake
+++ b/lib/tasks/marc_index_ingester.rake
@@ -41,5 +41,13 @@ task marc_index_ingest: [:environment] do
   # save to date for next time
   ingest_logger&.info("Storing 'to' time")
   PropertyBag.set('marc_ingest_time', to_time) unless single_record
+
+  # expire static page caches
+  static_pages = ['advanced.html']
+  static_pages.each do |page|
+    path = Rails.public_path.join(page)
+    File.delete(path) if File.exist?(path)
+  end
+
   ingest_logger&.info("Ingesting Complete!")
 end


### PR DESCRIPTION
Fix #1389 

In this PR, I use static page caching to cache the advanced search index page, which has Solr data that is only updated once we run a full or incremental reindex. The cache will be recreated every time:
- An incremental reindex is processed
- A full reindex is processed
- A new version is deployed, since the cache is stored in the public folder which gets reset upon deployment
