### PR TITLE
Blacklight 7.33 Upgrade: Fix facet search from links on show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -134,6 +134,11 @@ class CatalogController < ApplicationController
     config.add_facet_field 'genre_ssim', label: 'Genre', limit: 5, index_range: true
     config.add_facet_field 'author_display_ssim', label: 'Author', limit: 5
 
+    config.add_facet_field 'author_addl_ssim', show: false
+    config.add_facet_field 'author_vern_ssim', show: false
+    config.add_facet_field 'subject_display_ssim', show: false
+    config.add_facet_field 'title_uniform_ssim', show: false
+
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
     # handler defaults, or have no facets.

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -59,7 +59,9 @@ RSpec.describe CatalogController, type: :controller do
     let(:expected_facet_fields) do
       ["author_ssim", "format_ssim", "language_ssim", "marc_resource_ssim",
        "subject_era_ssim", "subject_geo_ssim", "subject_ssim", "library_ssim",
-       "collection_ssim", "genre_ssim", "pub_date_isim", "lc_1letter_ssim", "title_main_first_char_ssim", "author_display_ssim"]
+       "collection_ssim", "genre_ssim", "pub_date_isim", "lc_1letter_ssim",
+       "title_main_first_char_ssim", "author_display_ssim", "author_addl_ssim",
+       "author_vern_ssim", "subject_display_ssim", "title_uniform_ssim"]
     end
     let(:homepage_facet_fields) { controller.blacklight_config.homepage_facet_fields }
     let(:suppressed_facet_fields) { controller.blacklight_config.suppressed_facet_fields }


### PR DESCRIPTION
Fix #1387

The show page has links for fields such as "Additional Author/Creators" that lead users to running a facet search (e.g. using field `author_add_ssim`) without the field being explicitly set as a facet field in the Blacklight configuration.

In this PR, I added all fields that are used as facet fields on links on the show page to the Blacklight configuration as facet fields. This resolves the issue reported in #1387.