### PR TITLE
Disable advanced search page caching

### DIFF
--- a/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
+++ b/app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# blacklight_advanced_search (7.0.0) override
+# improve view rendering performance by only initializing one advanced query parser
+
+module BlacklightAdvancedSearch
+  # implementation for AdvancedHelper
+  module AdvancedHelperBehavior
+    # Fill in default from existing search, if present
+    # -- if you are using same search fields for basic
+    # search and advanced, will even fill in properly if existing
+    # search used basic search on same field present in advanced.
+    def label_tag_default_for(key)
+      if params[key].present?
+        params[key]
+      elsif params["search_field"] == key
+        params["q"]
+      end
+    end
+
+    def advanced_parser
+      @advanced_parser ||= BlacklightAdvancedSearch::QueryParser.new(params, blacklight_config)
+    end
+
+    # Is facet value in adv facet search results?
+    def facet_value_checked?(field, value)
+      advanced_parser.filters_include_value?(field, value)
+    end
+
+    def select_menu_for_field_operator
+      options = {
+        t('blacklight_advanced_search.all') => 'AND',
+        t('blacklight_advanced_search.any') => 'OR'
+      }.sort
+
+      select_tag(:op, options_for_select(options, params[:op]), class: 'input-small')
+    end
+
+    # Current params without fields that will be over-written by adv. search,
+    # or other fields we don't want.
+    def advanced_search_context
+      my_params = search_state.params_for_search.except :page, :f_inclusive, :q, :search_field, :op, :index, :sort
+
+      my_params.except!(*search_fields_for_advanced_search.map { |_key, field_def| field_def[:key] })
+    end
+
+    def search_fields_for_advanced_search
+      @search_fields_for_advanced_search ||= blacklight_config.search_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }
+    end
+
+    def facet_field_names_for_advanced_search
+      @facet_field_names_for_advanced_search ||= blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }.values.map(&:field)
+    end
+
+    # Use configured facet partial name for facet or fallback on 'catalog/facet_limit'
+    def advanced_search_facet_partial_name(display_facet)
+      facet_configuration_for_field(display_facet.name).try(:partial) || "catalog/facet_limit"
+    end
+  end
+end

--- a/app/views/advanced/_advanced_search_facets_as_select.html.erb
+++ b/app/views/advanced/_advanced_search_facets_as_select.html.erb
@@ -21,7 +21,7 @@
                         data: { 'live-search': 'true', placeholder: "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}", 'size': '6' }) do %>
           <% display_facet.items.each do |facet_item| %>
             <%= content_tag :option, value: facet_item.value, selected: facet_value_checked?(display_facet.name, facet_item.value) do %>
-              <%= facet_display_value(display_facet.name, facet_item.label) %>
+              <%= facet_item.label %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/advanced/_collection_select.html.erb
+++ b/app/views/advanced/_collection_select.html.erb
@@ -13,7 +13,7 @@
                       data: { 'live-search': 'true', placeholder: "Type or select #{facet_field_label("collection_ssim").downcase.pluralize}", 'size': '6' }) do %>
         <% @collection_ssim_facet&.each do |facet_item| %>
           <%= content_tag :option, value: facet_item, style: "white-space: normal;", selected: facet_value_checked?("collection_ssim", facet_item) do %>
-            <%= facet_display_value("collection_ssim", facet_item) %>
+            <%= facet_item %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/initializers/advanced_controller.rb
+++ b/config/initializers/advanced_controller.rb
@@ -4,8 +4,6 @@
 # collection facet
 
 BlacklightAdvancedSearch::AdvancedController.class_eval do
-  caches_page :index
-
   def index
     @response = get_advanced_search_facets unless request.method == :post
     collection_auth = Qa::LocalAuthority.find_by(name: 'collections')

--- a/lib/tasks/marc_index_ingester.rake
+++ b/lib/tasks/marc_index_ingester.rake
@@ -42,12 +42,5 @@ task marc_index_ingest: [:environment] do
   ingest_logger&.info("Storing 'to' time")
   PropertyBag.set('marc_ingest_time', to_time) unless single_record
 
-  # expire static page caches
-  static_pages = ['advanced.html']
-  static_pages.each do |page|
-    path = Rails.public_path.join(page)
-    File.delete(path) if File.exist?(path)
-  end
-
   ingest_logger&.info("Ingesting Complete!")
 end


### PR DESCRIPTION
- Disable caching the advanced search page
- Override `app/helpers/blacklight_advanced_search/advanced_helper_behavior.rb` to initialize and use one query parser to check if a facet value is checked,  refer to method `def facet_value_checked?`
- Change advanced search facet views to use facet label directly instead of using `#facet_display_value`. The use of `facet_display_value` leads to a massive number of allocations when the field rendered has a lot of values.
- Remove advanced search page caching related logic from indexing