### PR TITLE
Fixes the font size of the front page tagline.

### DIFF
--- a/app/assets/stylesheets/blacklight_catalog/_search_form.scss
+++ b/app/assets/stylesheets/blacklight_catalog/_search_form.scss
@@ -26,7 +26,7 @@ form.search-query-form {
   color: #091c44;
   margin-top: 1.25rem;
   font-family: Cardo;
-  font-size: 1.75rem;
+  font-size: 1.7rem;
   margin-bottom: map-get($spacers, 2);
   line-height: 1.88;
 }


### PR DESCRIPTION
![Screenshot 2024-05-20 at 7 07 19 PM](https://github.com/emory-libraries/blacklight-catalog/assets/43180845/03b6f365-5ed7-4e50-a8d8-378b16d838c6)
