### PR TITLE
Limit end dates

### DIFF
--- a/lib/traject/extract_publication_date.rb
+++ b/lib/traject/extract_publication_date.rb
@@ -6,7 +6,8 @@ module ExtractPublicationDate
       if rec['008']
         date_type = rec['008'].value[0o6]
         start_year = rec['008'].value[0o7, 4]
-        end_year = rec['008'].value[11, 4].to_i >= (Date.current.year + 100) ? (Date.current.year + 100).to_s : rec['008'].value[11, 4]
+        # If the end year is more than 100 years in the future, then treat it as if the end year is this year.
+        end_year = rec['008'].value[11, 4].to_i >= (Date.current.year + 100) ? Date.current.year.to_s : rec['008'].value[11, 4]
         if range_processing?(date_type, start_year, end_year)
           possible_range_processing(start_year, end_year, rec, acc)
         elsif include_zeroes?(start_year, end_year) && not_include_alpha_characters?(start_year, end_year)

--- a/spec/models/marc_indexing_spec.rb
+++ b/spec/models/marc_indexing_spec.rb
@@ -283,10 +283,9 @@ RSpec.describe 'Indexing fields with custom logic' do
     end
 
     context 'when it is journal with end year 9999' do
-      it 'has end date as current year plus 100' do
+      it 'has end date as current year' do
         # 750727c20109999nyuqr p 0 a0eng c - 008 value with start year 2010 and end year 9999
-        current_year = Time.now.getlocal.year
-        expect(solr_doc4['pub_date_isim']).to eq((2010..(current_year + 100)).to_a)
+        expect(solr_doc4['pub_date_isim']).to eq((2010..Time.now.getlocal.year).to_a)
       end
     end
 


### PR DESCRIPTION
Rather than using 9999 as the ultimate far future end date that we truncate to this year, narrow that scope down so that any end year more than 100 years in the future is reduced to this year.