### PR TITLE
Uses new EC2 lookup gem for automated IP pulling.

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -38,7 +38,6 @@ install_plugin Capistrano::SCM::Git
 # require "capistrano/chruby"
 require "capistrano/rails"
 require "capistrano/passenger"
-require "cap-ec2/capistrano"
 require 'capistrano/yarn'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'bootstrap-select-rails', '>= 1.13'
 gem 'cancancan'
 gem 'citeproc-ruby'
 gem 'coffee-rails', '~> 4.2'
+gem 'concurrent-ruby', '1.3.4'
 gem 'csl-styles'
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
@@ -67,11 +68,13 @@ group :development, :test do
 end
 
 group :development do
-  gem 'cap-ec2-emory', github: 'curationexperts/cap-ec2'
-  gem 'capistrano', '= 3.14.1', require: false
+  gem 'bcrypt_pbkdf'
+  gem 'capistrano', require: false
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', '~> 1.6', require: false
   gem 'capistrano-yarn'
+  gem 'ec2_ipv4_retriever', git: 'https://github.com/emory-libraries/ec2_ipv4_retriever', branch: 'main'
+  gem 'ed25519'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'rack-mini-profiler'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,12 @@ GIT
       rails (>= 3.1.0)
 
 GIT
-  remote: https://github.com/curationexperts/cap-ec2.git
-  revision: 0c8e355aa8984eb5969704921b9dcc3a35bd410b
+  remote: https://github.com/emory-libraries/ec2_ipv4_retriever
+  revision: c0e0f90a94baedcd712f35cfb6b6644cdffc9612
+  branch: main
   specs:
-    cap-ec2-emory (1.2.2)
-      aws-sdk-ec2 (~> 1.204)
-      capistrano (~> 3.0)
-      colorize
-      terminal-table
+    ec2_ipv4_retriever (0.1.0)
+      aws-sdk-ec2
 
 GEM
   remote: https://rubygems.org/
@@ -94,25 +92,30 @@ GEM
       momentjs-rails (~> 2.8)
       sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
-    airbrussh (1.4.2)
+    airbrussh (1.5.3)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
-    aws-eventstream (1.2.0)
-    aws-partitions (1.813.0)
-    aws-sdk-core (3.181.0)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.5)
+    aws-eventstream (1.3.2)
+    aws-partitions (1.1087.0)
+    aws-sdk-core (3.222.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-ec2 (1.402.0)
-      aws-sdk-core (~> 3, >= 3.177.0)
-      aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.6.0)
+      logger
+    aws-sdk-ec2 (1.515.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.19)
+    bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-arm64-darwin)
+    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     bindex (0.8.1)
     bixby (5.0.2)
       rubocop (= 1.28.2)
@@ -150,7 +153,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     cancancan (3.5.0)
-    capistrano (3.14.1)
+    capistrano (3.19.2)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -187,8 +190,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    colorize (1.1.0)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.4)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -226,6 +228,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    ed25519 (1.3.0)
     erubi (1.12.0)
     execjs (2.8.1)
     factory_bot (4.11.1)
@@ -282,7 +285,7 @@ GEM
     http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
     httpclient (2.8.3)
-    i18n (1.14.4)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     inline_svg (1.9.0)
       activesupport (>= 3.0)
@@ -319,6 +322,7 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    logger (1.7.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -354,11 +358,13 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-scp (4.0.0)
+    net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.0)
       net-protocol
-    net-ssh (7.2.0)
+    net-ssh (7.3.0)
     netrc (0.11.0)
     nio4r (2.7.1)
     nokogiri (1.16.4-aarch64-linux)
@@ -565,9 +571,13 @@ GEM
     sqlite3 (1.6.4-arm64-darwin)
     sqlite3 (1.6.4-x86_64-darwin)
     sqlite3 (1.6.4-x86_64-linux)
-    sshkit (1.21.5)
+    sshkit (1.24.0)
+      base64
+      logger
       net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
+      ostruct
     stackprof (0.2.25)
     sync (0.5.0)
     term-ansicolor (1.7.1)
@@ -639,6 +649,7 @@ PLATFORMS
 DEPENDENCIES
   actionpack-page_caching
   administrate (~> 0.17.0)
+  bcrypt_pbkdf
   bixby
   blacklight (~> 7.33)
   blacklight-marc (~> 7.2)
@@ -648,19 +659,21 @@ DEPENDENCIES
   bootstrap-select-rails (>= 1.13)
   byebug
   cancancan
-  cap-ec2-emory!
-  capistrano (= 3.14.1)
+  capistrano
   capistrano-passenger
   capistrano-rails (~> 1.6)
   capistrano-yarn
   capybara (~> 3.0)
   citeproc-ruby
   coffee-rails (~> 4.2)
+  concurrent-ruby (= 1.3.4)
   coveralls
   csl-styles
   devise
   devise-guests (~> 0.6)
   dotenv-rails
+  ec2_ipv4_retriever!
+  ed25519
   factory_bot_rails (~> 4.11.1)
   faraday (~> 1.10.3)
   ffaker

--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ document.deep_symbolize_keys!
 1. Remove `:score` and `:_version_` lines (will not re-save to solr if these are included)
 1. Assign to a global variable and add `.freeze` to the end of the hash
 
+
+#### Deployment
+
+1. Connect to `vpn.emory.edu`
+2. Pull the latest version of `main`
+3. Stub AWS' environment variables for `Emory Account 70` within the same terminal window. These can be found in the page loaded after logging into [Emory's AWS](https://aws.emory.edu). Directions below:
+  a. After logging in, the page should be the `AWS access portal`. A table of multiple accounts should be presesnt (typically three). Expand the `Emory Account 70` option.
+  b. Clicking on `Access keys` will open a modal with multiple credential options. Option 1 (`Set AWS environment variables`) is necessary for successful deployment.
+  c. Copy the variables in Option 1, paste them into the terminal window that the deployment script will be processed, and press enter.
+5. To deploy, run `BRANCH={BRANCH_NAME_OR_TAG} bundle exec cap {ENVIRONMENT} deploy`. To deploy main to the arch environment, for instance, you run `BRANCH=main bundle exec cap arch deploy`.
+
+##### Deployment Troubleshooting
+
+If errors occur when running the deployment script, there could be a couple of factors causing them:
+- Ensure you are authorized to access the server you are deploying to. You can verify your access by trying to ssh into the server e.g. `ssh deploy@SERVER_IP_ADDRESS`.
+- The server IP lookup processing may not be working. In this case, stub the backup environment variables for the desired server in the local `.env.development` file. The list of backup environment variables are below:
+
+```
+ARCH_SERVER_IP=
+TEST_SERVER_IP=
+PROD_SERVER_IP=
+```
+
 #### Using Docker (Experimental)
 
 1. Install Docker using these [instructions](https://docs.docker.com/engine/install/)

--- a/config/deploy/arch.rb
+++ b/config/deploy/arch.rb
@@ -1,67 +1,7 @@
 # frozen_string_literal: true
+require 'ec2_ipv4_retriever'
+include Ec2Ipv4Retriever
 
-# server-based syntax
-# ======================
-# Defines a single server with a list of roles and multiple properties.
-# You can define all roles on a single server, or split them:
-
-# server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
-# server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
-# server "db.example.com", user: "deploy", roles: %w{db}
-
-# role-based syntax
-# ==================
-# Defines a role with one or multiple servers. The primary server in each
-# group is considered to be the first unless any hosts have the primary
-# property set. Specify the username and a domain or IP for the server.
-# Don't use `:all`, it's a meta role.
-
-# role :app, %w{deploy@example.com}, my_property: :my_value
-# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
-# role :db,  %w{deploy@example.com}
-
-# Configuration
-# =============
-# You can set any configuration variable like in config/deploy.rb
-# These variables are then only loaded and set in this stage.
-# For available Capistrano configuration variables see the documentation page.
-# http://capistranorb.com/documentation/getting-started/configuration/
-# Feel free to add new variables to customise your setup.
-
-# Custom SSH Options
-# ==================
-# You may pass any option but keep in mind that net/ssh understands a
-# limited set of options, consult the Net::SSH documentation.
-# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
-#
-# Global options
-# --------------
-#  set :ssh_options, {
-#    keys: %w(/home/user_name/.ssh/id_rsa),
-#    forward_agent: false,
-#    auth_methods: %w(password)
-#  }
-#
-# The server-based syntax can be used to override options:
-# ------------------------------------
-# server "example.com",
-#   user: "user_name",
-#   roles: %w{web app},
-#   ssh_options: {
-#     user: "user_name", # overrides user setting above
-#     keys: %w(/home/user_name/.ssh/id_rsa),
-#     forward_agent: false,
-#     auth_methods: %w(publickey password)
-#     # password: "please use keys"
-#   }
 set :stage, :ARCH
 set :honeybadger_env, "Catalog-Arch"
-
-set :ec2_region, %w[us-east-1]
-ec2_role %i[web app db],
-  user: 'deploy',
-  ssh_options: {
-    keys: ENV['SSH_EC2_KEY_FILE'],
-    forward_agent: true,
-    verify_host_key: :never
-  }
+server find_ip_by_ec2_name(ec2_name: 'blackcat-arch-web') || ENV['ARCH_SERVER_IP'], user: 'deploy', roles: %i[web app db]

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,68 +1,7 @@
 # frozen_string_literal: true
-
-# server-based syntax
-# ======================
-# Defines a single server with a list of roles and multiple properties.
-# You can define all roles on a single server, or split them:
-
-# server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
-# server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
-# server "db.example.com", user: "deploy", roles: %w{db}
-
-# role-based syntax
-# ==================
-# Defines a role with one or multiple servers. The primary server in each
-# group is considered to be the first unless any hosts have the primary
-# property set. Specify the username and a domain or IP for the server.
-# Don't use `:all`, it's a meta role.
-
-# role :app, %w{deploy@example.com}, my_property: :my_value
-# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
-# role :db,  %w{deploy@example.com}
-
-# Configuration
-# =============
-# You can set any configuration variable like in config/deploy.rb
-# These variables are then only loaded and set in this stage.
-# For available Capistrano configuration variables see the documentation page.
-# http://capistranorb.com/documentation/getting-started/configuration/
-# Feel free to add new variables to customise your setup.
-
-# Custom SSH Options
-# ==================
-# You may pass any option but keep in mind that net/ssh understands a
-# limited set of options, consult the Net::SSH documentation.
-# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
-#
-# Global options
-# --------------
-#  set :ssh_options, {
-#    keys: %w(/home/user_name/.ssh/id_rsa),
-#    forward_agent: false,
-#    auth_methods: %w(password)
-#  }
-#
-# The server-based syntax can be used to override options:
-# ------------------------------------
-# server "example.com",
-#   user: "user_name",
-#   roles: %w{web app},
-#   ssh_options: {
-#     user: "user_name", # overrides user setting above
-#     keys: %w(/home/user_name/.ssh/id_rsa),
-#     forward_agent: false,
-#     auth_methods: %w(publickey password)
-#     # password: "please use keys"
-#   }
+require 'ec2_ipv4_retriever'
+include Ec2Ipv4Retriever
 
 set :stage, :PROD
 set :honeybadger_env, "Catalog-Prod"
-
-set :ec2_region, %w[us-east-1]
-ec2_role %i[web app db],
-  user: 'deploy',
-  ssh_options: {
-    keys: ENV['SSH_EC2_KEY_FILE'],
-    forward_agent: true,
-    verify_host_key: :never
-  }
+server find_ip_by_ec2_name(ec2_name: 'blackcat-prod-web') || ENV['PROD_SERVER_IP'], user: 'deploy', roles: %i[web app db]

--- a/config/deploy/test.rb
+++ b/config/deploy/test.rb
@@ -1,68 +1,7 @@
 # frozen_string_literal: true
-
-# server-based syntax
-# ======================
-# Defines a single server with a list of roles and multiple properties.
-# You can define all roles on a single server, or split them:
-
-# server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
-# server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
-# server "db.example.com", user: "deploy", roles: %w{db}
-
-# role-based syntax
-# ==================
-# Defines a role with one or multiple servers. The primary server in each
-# group is considered to be the first unless any hosts have the primary
-# property set. Specify the username and a domain or IP for the server.
-# Don't use `:all`, it's a meta role.
-
-# role :app, %w{deploy@example.com}, my_property: :my_value
-# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
-# role :db,  %w{deploy@example.com}
-
-# Configuration
-# =============
-# You can set any configuration variable like in config/deploy.rb
-# These variables are then only loaded and set in this stage.
-# For available Capistrano configuration variables see the documentation page.
-# http://capistranorb.com/documentation/getting-started/configuration/
-# Feel free to add new variables to customise your setup.
-
-# Custom SSH Options
-# ==================
-# You may pass any option but keep in mind that net/ssh understands a
-# limited set of options, consult the Net::SSH documentation.
-# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
-#
-# Global options
-# --------------
-#  set :ssh_options, {
-#    keys: %w(/home/user_name/.ssh/id_rsa),
-#    forward_agent: false,
-#    auth_methods: %w(password)
-#  }
-#
-# The server-based syntax can be used to override options:
-# ------------------------------------
-# server "example.com",
-#   user: "user_name",
-#   roles: %w{web app},
-#   ssh_options: {
-#     user: "user_name", # overrides user setting above
-#     keys: %w(/home/user_name/.ssh/id_rsa),
-#     forward_agent: false,
-#     auth_methods: %w(publickey password)
-#     # password: "please use keys"
-#   }
+require 'ec2_ipv4_retriever'
+include Ec2Ipv4Retriever
 
 set :stage, :TEST
 set :honeybadger_env, "Catalog-Test"
-
-set :ec2_region, %w[us-east-1]
-ec2_role %i[web app db],
-  user: 'deploy',
-  ssh_options: {
-    keys: ENV['SSH_EC2_KEY_FILE'],
-    forward_agent: true,
-    verify_host_key: :never
-  }
+server find_ip_by_ec2_name(ec2_name: 'blackcat-test-web') || ENV['TEST_SERVER_IP'], user: 'deploy', roles: %i[web app db]

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -37,3 +37,8 @@ HONEYBADGER_ENV=
 
 # Honeybadger blacklight:reindex check-in ID. You can find this ID in the Honeybadger portal, under Blacklight Catalog > Check-Ins
 HONEYBADGER_BLACKLIGHT_REINDEX_CHECK_IN_ID=
+
+# IPs needed for deployment
+ARCH_SERVER_IP=
+TEST_SERVER_IP=
+PROD_SERVER_IP=


### PR DESCRIPTION
- Capfile: removes deprecated gem from operation.
- Gemfile*: installs new gem that handles ip lookup.
- README.md: details the new instructions for deployment.
- config/deploy.rb: adds ENV loading for the IPs, extracts the ec2 gem variables, and locks config to new version.
- config/deploy/arch.rb, config/deploy/test.rb, and config/deploy/production.rb: swaps out server identifiers to the new gem process, with a default to variables.
- dotenv.sample: announces the necessary variables that should be set in the developer's `.env.development` file.