### PR TITLE
notify slack directly when collections are backed up in prod

### DIFF
--- a/lib/solr/solr_backup.rb
+++ b/lib/solr/solr_backup.rb
@@ -15,6 +15,23 @@ class String
   end
 end
 
+def notify_slack(location,collection_name)
+  size = `du -s #{location}`
+  if size=="" or Integer(size.split("\t")[0]) < 300000
+      channel='dlp-backups-failed-jobs'
+      text = "#{collection_name} on solr prod had a problem backing up, please investigate"
+  else
+      channel='dlp-backups'
+      text = "#{collection_name} on solr prod backed up successfully"
+  end 
+  webhook_url='https://hooks.slack.com/services/'+ENV['SLACK_HOOK']
+  payload = {
+     :channel => channel,
+     :text    => text 
+     }.to_json
+  cmd = "curl -X POST --data-urlencode 'payload=#{payload}' #{webhook_url}"
+  system(cmd)    
+end
 
 def prepare_uri(endpoint)
   uri           = URI.parse(endpoint)
@@ -91,8 +108,12 @@ def perform_backup
     item        = ARGV[0]
     request_id  = "#{item}_backup_#{right_now}"
     url         = "http://localhost:8983/solr/admin/collections?action=BACKUP&collection=#{item}&location=/mnt/#{short_hostname}_efs/solr/backup/&name=#{item}_backup_#{right_now}&async=#{request_id}"
+    location = "/mnt/#{short_hostname}_efs/solr/backup/#{item}_backup_#{right_now}"
     prepare_uri(url)
     get_backup_status(request_id)
+  end
+  if short_hostname == 'prod'
+    notify_slack(location, item)
   end
 end
 

--- a/lib/solr/solr_backup.rb
+++ b/lib/solr/solr_backup.rb
@@ -16,7 +16,7 @@ class String
 end
 
 def notify_slack(location, collection_name)
-  size = "du -s #{location}"
+  size = `du -s #{location}`
   if size.empty? || size&.split("\t")&.first&.to_i < 300000
     channel = 'dlp-backups-failed-jobs'
     text = "#{collection_name} on solr prod had a problem backing up, please investigate"

--- a/lib/solr/solr_backup.rb
+++ b/lib/solr/solr_backup.rb
@@ -15,21 +15,19 @@ class String
   end
 end
 
-def notify_slack(location,collection_name)
-  size = `du -s #{location}`
-  if size=="" or Integer(size.split("\t")[0]) < 300000
-      channel='dlp-backups-failed-jobs'
-      text = "#{collection_name} on solr prod had a problem backing up, please investigate"
+def notify_slack(location, collection_name)
+  size = "du -s #{location}"
+  if size.empty? || size&.split("\t")&.first&.to_i < 300000
+    channel = 'dlp-backups-failed-jobs'
+    text = "#{collection_name} on solr prod had a problem backing up, please investigate"
   else
-      channel='dlp-backups'
-      text = "#{collection_name} on solr prod backed up successfully"
+    channel = 'dlp-backups'
+    text = "#{collection_name} on solr prod backed up successfully"
   end 
-  webhook_url='https://hooks.slack.com/services/'+ENV['SLACK_HOOK']
-  payload = {
-     :channel => channel,
-     :text    => text 
-     }.to_json
+  webhook_url = 'https://hooks.slack.com/services/' + ENV['SLACK_HOOK']
+  payload = { :channel => channel, :text => text }.to_json
   cmd = "curl -X POST --data-urlencode 'payload=#{payload}' #{webhook_url}"
+
   system(cmd)    
 end
 
@@ -108,12 +106,11 @@ def perform_backup
     item        = ARGV[0]
     request_id  = "#{item}_backup_#{right_now}"
     url         = "http://localhost:8983/solr/admin/collections?action=BACKUP&collection=#{item}&location=/mnt/#{short_hostname}_efs/solr/backup/&name=#{item}_backup_#{right_now}&async=#{request_id}"
-    location = "/mnt/#{short_hostname}_efs/solr/backup/#{item}_backup_#{right_now}"
+    location    = "/mnt/#{short_hostname}_efs/solr/backup/#{item}_backup_#{right_now}"
+
     prepare_uri(url)
     get_backup_status(request_id)
-  end
-  if short_hostname == 'prod'
-    notify_slack(location, item)
+    notify_slack(location, item) if short_hostname == 'prod'
   end
 end
 


### PR DESCRIPTION
notify slack directly rather than have a complicated system of logging and unclear cloudwatch alarms. 